### PR TITLE
Fix auth storage initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ void main() async {
   await Hive.openBox('calendarBox');
   await Hive.openBox('itemsBox');
   await Hive.openBox('userBox');
+  await Hive.openBox('authBox');
 
   runApp(const OlyApp());
 }


### PR DESCRIPTION
## Summary
- open Hive box for auth tokens on startup

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684078530034832b87029116ffcc487e