### PR TITLE
Add backend service layer and integrate pages

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// Base class for API services.
+class ApiService {
+  ApiService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+  static const String baseUrl = 'https://example.com/api';
+
+  Uri buildUri(String path, [Map<String, dynamic>? query]) {
+    return Uri.parse(baseUrl).replace(path: '/api$path', queryParameters: query);
+  }
+
+  Future<T> get<T>(String path, T Function(dynamic json) parser) async {
+    final response = await _client.get(buildUri(path));
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      return parser(data);
+    } else {
+      throw Exception('Request failed: ${response.statusCode}');
+    }
+  }
+
+  Future<T> post<T>(String path, dynamic body, T Function(dynamic json) parser) async {
+    final response = await _client.post(
+      buildUri(path),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final data = jsonDecode(response.body);
+      return parser(data);
+    } else {
+      throw Exception('Request failed: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -1,0 +1,18 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class EventService extends ApiService {
+  EventService({super.client});
+
+  Future<List<CalendarEvent>> fetchEvents() async {
+    return get('/events', (json) {
+      final list = json as List<dynamic>;
+      return list.map((e) => CalendarEvent.fromJson(e as Map<String, dynamic>)).toList();
+    });
+  }
+
+  Future<CalendarEvent> createEvent(CalendarEvent event) async {
+    return post('/events', event.toJson(),
+        (json) => CalendarEvent.fromJson(json as Map<String, dynamic>));
+  }
+}

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -1,0 +1,18 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class ItemService extends ApiService {
+  ItemService({super.client});
+
+  Future<List<Item>> fetchItems() async {
+    return get('/items', (json) {
+      final list = json as List<dynamic>;
+      return list.map((e) => Item.fromJson(e as Map<String, dynamic>)).toList();
+    });
+  }
+
+  Future<Item> createItem(Item item) async {
+    return post('/items', item.toJson(),
+        (json) => Item.fromJson(json as Map<String, dynamic>));
+  }
+}

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -1,0 +1,21 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class MaintenanceService extends ApiService {
+  MaintenanceService({super.client});
+
+  Future<List<MaintenanceRequest>> fetchRequests() async {
+    return get('/maintenance', (json) {
+      final list = json as List<dynamic>;
+      return list
+          .map((e) => MaintenanceRequest.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<MaintenanceRequest> createRequest(MaintenanceRequest request) async {
+    return post('/maintenance', request.toJson(), (json) {
+      return MaintenanceRequest.fromJson(json as Map<String, dynamic>);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- implement HTTP-based API service layer
- fetch and create events through `EventService`
- load items using `ItemService`
- submit and list maintenance tickets via `MaintenanceService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407aae64b4832bbeead1477f203b5f