### PR TITLE
Add maintenance chat page

### DIFF
--- a/lib/pages/maintenance_chat_page.dart
+++ b/lib/pages/maintenance_chat_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../models/models.dart';
+import '../services/maintenance_service.dart';
+
+class MaintenanceChatPage extends StatefulWidget {
+  final MaintenanceRequest request;
+  const MaintenanceChatPage({super.key, required this.request});
+
+  @override
+  State<MaintenanceChatPage> createState() => _MaintenanceChatPageState();
+}
+
+class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
+  final MaintenanceService _service = MaintenanceService();
+  final TextEditingController _messageCtrl = TextEditingController();
+
+  List<Message> _messages = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMessages();
+  }
+
+  Future<void> _loadMessages() async {
+    if (widget.request.id == null) return;
+    final msgs = await _service.fetchMessages(widget.request.id!);
+    setState(() => _messages = msgs);
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _messageCtrl.text.trim();
+    if (text.isEmpty || widget.request.id == null) return;
+    final message = Message(
+      requestId: widget.request.id!,
+      senderId: 1,
+      content: text,
+    );
+    final saved = await _service.sendMessage(message);
+    setState(() => _messages.add(saved));
+    _messageCtrl.clear();
+  }
+
+  @override
+  void dispose() {
+    _messageCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.request.subject),
+        backgroundColor: colorScheme.primaryContainer,
+        foregroundColor: colorScheme.onPrimaryContainer,
+        elevation: 1,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                final isMe = msg.senderId == 1;
+                return Align(
+                  alignment:
+                      isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: isMe
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(msg.content),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _messageCtrl,
+                    decoration: const InputDecoration(hintText: 'Type a message'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _sendMessage,
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/models.dart';
 import '../services/maintenance_service.dart';
+import 'maintenance_chat_page.dart';
 
 class MaintenancePage extends StatefulWidget {
   const MaintenancePage({super.key});
@@ -122,8 +123,11 @@ class _MaintenancePageState extends State<MaintenancePage> {
           subtitle: Text('Status: ${ticket.status}'),
           trailing: const Icon(Icons.chevron_right),
           onTap: () {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Open ticket ${ticket.id}')),
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => MaintenanceChatPage(request: ticket),
+              ),
             );
           },
         );

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -18,4 +18,18 @@ class MaintenanceService extends ApiService {
       return MaintenanceRequest.fromJson(json as Map<String, dynamic>);
     });
   }
+
+  Future<List<Message>> fetchMessages(int requestId) async {
+    return get('/maintenance/$requestId/messages', (json) {
+      final list = json as List<dynamic>;
+      return list
+          .map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<Message> sendMessage(Message message) async {
+    return post('/maintenance/${message.requestId}/messages', message.toJson(),
+        (json) => Message.fromJson(json as Map<String, dynamic>));
+  }
 }


### PR DESCRIPTION
## Summary
- show message history and input in new `MaintenanceChatPage`
- support fetching and sending messages through `MaintenanceService`
- open chat page from ticket tap in `MaintenancePage`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407bc15740832b9a043e155f635507