### PR TITLE
Fix lint warnings

### DIFF
--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -270,16 +270,12 @@ class ItemCategoryAdapter extends TypeAdapter<ItemCategory> {
     switch (obj) {
       case ItemCategory.furniture:
         writer.writeByte(0);
-        break;
       case ItemCategory.books:
         writer.writeByte(1);
-        break;
       case ItemCategory.electronics:
         writer.writeByte(2);
-        break;
       case ItemCategory.other:
         writer.writeByte(3);
-        break;
     }
   }
 

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -74,6 +74,7 @@ class _LoginPageState extends State<LoginPage> {
 
       widget.onLoginSuccess();
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Login failed: $e')),
       );

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -150,8 +150,7 @@ class DashboardPage extends StatelessWidget {
   }
 
   void _navigate(BuildContext context, int index) {
-    final state = context.findAncestorStateOfType<_MainPageState>();
-    state?.setState(() => state._currentIndex = index);
+    setState(() => _currentIndex = index);
   }
 }
 

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -88,16 +88,17 @@ class _MaintenancePageState extends State<MaintenancePage> {
               final subject = _subjectController.text.trim();
               final desc = _descriptionController.text.trim();
               if (subject.isEmpty || desc.isEmpty) return;
-              await _service.createRequest(
-                MaintenanceRequest(
-                  userId: 1,
-                  subject: subject,
-                  description: desc,
-                ),
-              );
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Request submitted!')),
-              );
+                await _service.createRequest(
+                  MaintenanceRequest(
+                    userId: 1,
+                    subject: subject,
+                    description: desc,
+                  ),
+                );
+                if (!mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Request submitted!')),
+                );
               _subjectController.clear();
               _descriptionController.clear();
               _loadTickets();

--- a/lib/pages/post_item_page.dart
+++ b/lib/pages/post_item_page.dart
@@ -50,6 +50,7 @@ class _PostItemPageState extends State<PostItemPage> {
         Navigator.pop(context, true);
       }
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text('Failed to post: $e')));
     } finally {
@@ -84,19 +85,16 @@ class _PostItemPageState extends State<PostItemPage> {
                 decoration: const InputDecoration(labelText: 'Category'),
                 items: ItemCategory.values.map((cat) {
                   String label;
-                  switch (cat) {
-                    case ItemCategory.furniture:
-                      label = 'Furniture';
-                      break;
-                    case ItemCategory.books:
-                      label = 'Books';
-                      break;
-                    case ItemCategory.electronics:
-                      label = 'Electronics';
-                      break;
-                    default:
-                      label = 'Other';
-                  }
+                    switch (cat) {
+                      case ItemCategory.furniture:
+                        label = 'Furniture';
+                      case ItemCategory.books:
+                        label = 'Books';
+                      case ItemCategory.electronics:
+                        label = 'Electronics';
+                      default:
+                        label = 'Other';
+                    }
                   return DropdownMenuItem(value: cat, child: Text(label));
                 }).toList(),
                 onChanged: (val) => setState(() => _category = val ?? ItemCategory.other),


### PR DESCRIPTION
## Summary
- ensure context is only used when mounted
- simplify navigation call
- remove `break` statements flagged by analyzer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d71e4ac832bba3a6b837882789e