### PR TITLE
Fix dashboard navigation and linter warning

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -20,12 +20,18 @@ class _MainPageState extends State<MainPage> {
     'Maintenance',
   ];
 
-  late final List<Widget> _pages = [
-    DashboardPage(),
-    const CalendarPage(),
-    const ItemExchangePage(),
-    const MaintenancePage(),
-  ];
+  late final List<Widget> _pages;
+
+  @override
+  void initState() {
+    super.initState();
+    _pages = [
+      DashboardPage(onNavigate: _onDashboardNavigate),
+      const CalendarPage(),
+      const ItemExchangePage(),
+      const MaintenancePage(),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -74,10 +80,15 @@ class _MainPageState extends State<MainPage> {
         return Icons.add;
     }
   }
+
+  void _onDashboardNavigate(int index) {
+    setState(() => _currentIndex = index);
+  }
 }
 
 class DashboardPage extends StatelessWidget {
-  const DashboardPage({super.key});
+  final ValueChanged<int> onNavigate;
+  const DashboardPage({super.key, required this.onNavigate});
 
   @override
   Widget build(BuildContext context) {
@@ -126,19 +137,19 @@ class DashboardPage extends StatelessWidget {
                   icon: Icons.calendar_today,
                   label: 'Calendar',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(context, 1),
+                  onTap: () => _navigate(1),
                 ),
                 DashboardCard(
                   icon: Icons.swap_horiz,
                   label: 'Exchange',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(context, 2),
+                  onTap: () => _navigate(2),
                 ),
                 DashboardCard(
                   icon: Icons.build,
                   label: 'Maintenance',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(context, 3),
+                  onTap: () => _navigate(3),
                 ),
                 // add more cards here
               ],
@@ -149,8 +160,8 @@ class DashboardPage extends StatelessWidget {
     );
   }
 
-  void _navigate(BuildContext context, int index) {
-    setState(() => _currentIndex = index);
+  void _navigate(int index) {
+    onNavigate(index);
   }
 }
 

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -95,7 +95,7 @@ class _MaintenancePageState extends State<MaintenancePage> {
                     description: desc,
                   ),
                 );
-                if (!mounted) return;
+                if (!context.mounted) return;
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Request submitted!')),
                 );


### PR DESCRIPTION
## Summary
- pass callback to `DashboardPage` so dashboard navigation works
- initialize `_pages` in `initState`
- use `context.mounted` check in maintenance page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407e81e7e4832bba201beb3bb4f2d7