### PR TITLE
Add service unit tests using MockClient

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
 
   http: any
 dev_dependencies:
+  test: any
   flutter_test:
     sdk: flutter
 

--- a/test/services/event_service_test.dart
+++ b/test/services/event_service_test.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:oly_app/services/event_service.dart';
+import 'package:oly_app/models/models.dart';
+
+void main() {
+  group('EventService', () {
+    test('fetchEvents parses list correctly', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.path, '/api/events');
+        return http.Response(jsonEncode([
+          {
+            'id': 1,
+            'title': 'Party',
+            'date': 0,
+            'description': 'fun'
+          }
+        ]), 200);
+      });
+
+      final service = EventService(client: mockClient);
+      final events = await service.fetchEvents();
+      expect(events, hasLength(1));
+      expect(events.first.title, 'Party');
+    });
+
+    test('createEvent sends POST and parses event', () async {
+      final input = CalendarEvent(title: 'Meet', date: DateTime.fromMillisecondsSinceEpoch(0));
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.path, '/api/events');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['title'], input.title);
+        return http.Response(
+          jsonEncode({
+            'id': 2,
+            ...input.toJson(),
+          }),
+          201,
+        );
+      });
+
+      final service = EventService(client: mockClient);
+      final event = await service.createEvent(input);
+      expect(event.id, 2);
+      expect(event.title, 'Meet');
+    });
+
+    test('fetchEvents throws on error', () async {
+      final mockClient = MockClient((_) async => http.Response('err', 404));
+      final service = EventService(client: mockClient);
+      expect(service.fetchEvents(), throwsException);
+    });
+  });
+}

--- a/test/services/item_service_test.dart
+++ b/test/services/item_service_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:oly_app/services/item_service.dart';
+import 'package:oly_app/models/models.dart';
+
+void main() {
+  group('ItemService', () {
+    test('fetchItems parses list correctly', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.path, '/api/items');
+        return http.Response(jsonEncode([
+          {
+            'id': 1,
+            'ownerId': 1,
+            'title': 'Chair',
+            'description': null,
+            'imageUrl': null,
+            'price': null,
+            'isFree': 0,
+            'category': 0,
+            'createdAt': 0
+          }
+        ]), 200);
+      });
+
+      final service = ItemService(client: mockClient);
+      final items = await service.fetchItems();
+      expect(items, hasLength(1));
+      expect(items.first.id, 1);
+      expect(items.first.title, 'Chair');
+    });
+
+    test('createItem sends POST and parses item', () async {
+      final itemInput = Item(ownerId: 1, title: 'Table');
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.path, '/api/items');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['title'], itemInput.title);
+        return http.Response(
+          jsonEncode({
+            'id': 2,
+            ...itemInput.toJson(),
+            'createdAt': 0,
+            'isFree': itemInput.isFree ? 1 : 0,
+            'category': itemInput.category.index
+          }),
+          201,
+        );
+      });
+
+      final service = ItemService(client: mockClient);
+      final item = await service.createItem(itemInput);
+      expect(item.id, 2);
+      expect(item.title, 'Table');
+    });
+
+    test('throws on non-success status', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('error', 500);
+      });
+
+      final service = ItemService(client: mockClient);
+      expect(service.fetchItems(), throwsException);
+    });
+  });
+}

--- a/test/services/maintenance_service_test.dart
+++ b/test/services/maintenance_service_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:oly_app/services/maintenance_service.dart';
+import 'package:oly_app/models/models.dart';
+
+void main() {
+  group('MaintenanceService', () {
+    test('fetchRequests parses list correctly', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.path, '/api/maintenance');
+        return http.Response(jsonEncode([
+          {
+            'id': 1,
+            'userId': 1,
+            'subject': 'Leak',
+            'description': 'Water',
+            'createdAt': 0,
+            'status': 'open'
+          }
+        ]), 200);
+      });
+
+      final service = MaintenanceService(client: mockClient);
+      final requests = await service.fetchRequests();
+      expect(requests, hasLength(1));
+      expect(requests.first.subject, 'Leak');
+    });
+
+    test('createRequest uses POST', () async {
+      final input = MaintenanceRequest(userId: 1, subject: 'Leak', description: 'Water');
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.path, '/api/maintenance');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['subject'], input.subject);
+        return http.Response(
+          jsonEncode({
+            'id': 2,
+            ...input.toJson(),
+          }),
+          201,
+        );
+      });
+
+      final service = MaintenanceService(client: mockClient);
+      final result = await service.createRequest(input);
+      expect(result.id, 2);
+    });
+
+    test('fetchMessages parses list correctly', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.path, '/api/maintenance/1/messages');
+        return http.Response(jsonEncode([
+          {
+            'id': 1,
+            'requestId': 1,
+            'senderId': 2,
+            'content': 'Hi',
+            'timestamp': 0
+          }
+        ]), 200);
+      });
+
+      final service = MaintenanceService(client: mockClient);
+      final messages = await service.fetchMessages(1);
+      expect(messages, hasLength(1));
+      expect(messages.first.content, 'Hi');
+    });
+
+    test('sendMessage posts message', () async {
+      final input = Message(requestId: 1, senderId: 2, content: 'Hi');
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.path, '/api/maintenance/1/messages');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['content'], input.content);
+        return http.Response(
+          jsonEncode({
+            'id': 3,
+            ...input.toJson(),
+          }),
+          201,
+        );
+      });
+
+      final service = MaintenanceService(client: mockClient);
+      final message = await service.sendMessage(input);
+      expect(message.id, 3);
+    });
+
+    test('throws on error status', () async {
+      final mockClient = MockClient((_) async => http.Response('err', 500));
+      final service = MaintenanceService(client: mockClient);
+      expect(service.fetchRequests(), throwsException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `test` dev dependency to run dart tests
- create tests for item, event, and maintenance services using `http/testing.dart`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684080588488832bb29d005c5ab21e0d