### PR TITLE
Add validation and item filter tests

### DIFF
--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -4,6 +4,7 @@ import 'item_detail_page.dart';
 import 'post_item_page.dart';
 import '../models/models.dart';
 import '../services/item_service.dart';
+import '../utils/item_filter.dart';
 
 class ItemExchangePage extends StatefulWidget {
   const ItemExchangePage({super.key});
@@ -37,28 +38,10 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
   }
 
   void _filter() {
-    final query = _searchCtrl.text.toLowerCase();
+    final query = _searchCtrl.text;
     setState(() {
-      _filteredItems = _allItems.where((item) {
-        final matchesSearch = item.title.toLowerCase().contains(query);
-        final matchesCat = _selectedCategory == 'All'
-            || (itemCategory(item) == _selectedCategory);
-        return matchesSearch && matchesCat;
-      }).toList();
+      _filteredItems = filterItems(_allItems, query, _selectedCategory);
     });
-  }
-
-  String itemCategory(Item item) {
-    switch (item.category) {
-      case ItemCategory.furniture:
-        return 'Furniture';
-      case ItemCategory.books:
-        return 'Books';
-      case ItemCategory.electronics:
-        return 'Electronics';
-      default:
-        return 'Other';
-    }
   }
 
   @override

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
 import '../models/models.dart';
+import '../utils/validators.dart';
 
 /// A simple login page with email/password and placeholder Google/Apple login buttons.
 class LoginPage extends StatefulWidget {
@@ -90,18 +91,9 @@ class _LoginPageState extends State<LoginPage> {
     super.dispose();
   }
 
-  String? _validateEmail(String? value) {
-    if (value == null || value.isEmpty) return 'Email is required';
-    final emailRegex = RegExp(r"^[^@]+@[^@]+\.[^@]+$");
-    if (!emailRegex.hasMatch(value)) return 'Enter a valid email';
-    return null;
-  }
+  String? _validateEmail(String? value) => validateEmail(value);
 
-  String? _validatePassword(String? value) {
-    if (value == null || value.isEmpty) return 'Password is required';
-    if (value.length < 6) return 'Password must be at least 6 characters';
-    return null;
-  }
+  String? _validatePassword(String? value) => validatePassword(value);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/utils/item_filter.dart
+++ b/lib/utils/item_filter.dart
@@ -1,0 +1,24 @@
+import '../models/models.dart';
+
+String itemCategory(Item item) {
+  switch (item.category) {
+    case ItemCategory.furniture:
+      return 'Furniture';
+    case ItemCategory.books:
+      return 'Books';
+    case ItemCategory.electronics:
+      return 'Electronics';
+    default:
+      return 'Other';
+  }
+}
+
+List<Item> filterItems(List<Item> items, String query, String selectedCategory) {
+  final lower = query.toLowerCase();
+  return items.where((item) {
+    final matchesSearch = item.title.toLowerCase().contains(lower);
+    final matchesCat = selectedCategory == 'All' ||
+        itemCategory(item) == selectedCategory;
+    return matchesSearch && matchesCat;
+  }).toList();
+}

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -1,0 +1,12 @@
+String? validateEmail(String? value) {
+  if (value == null || value.isEmpty) return 'Email is required';
+  final emailRegex = RegExp(r"^[^@]+@[^@]+\.[^@]+$");
+  if (!emailRegex.hasMatch(value)) return 'Enter a valid email';
+  return null;
+}
+
+String? validatePassword(String? value) {
+  if (value == null || value.isEmpty) return 'Password is required';
+  if (value.length < 6) return 'Password must be at least 6 characters';
+  return null;
+}

--- a/test/item_filter_test.dart
+++ b/test/item_filter_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/utils/item_filter.dart';
+
+void main() {
+  final items = [
+    Item(ownerId: 1, title: 'Wooden Chair', category: ItemCategory.furniture),
+    Item(ownerId: 1, title: 'Dart Book', category: ItemCategory.books),
+    Item(ownerId: 1, title: 'Laptop', category: ItemCategory.electronics),
+  ];
+
+  test('search query filters items', () {
+    final result = filterItems(items, 'book', 'All');
+    expect(result.map((e) => e.title).toList(), ['Dart Book']);
+  });
+
+  test('category filters items', () {
+    final result = filterItems(items, '', 'Furniture');
+    expect(result.map((e) => e.title).toList(), ['Wooden Chair']);
+  });
+
+  test('combined search and category filters items', () {
+    final result = filterItems(items, 'laptop', 'Electronics');
+    expect(result.map((e) => e.title).toList(), ['Laptop']);
+  });
+
+  test('no match returns empty list', () {
+    final result = filterItems(items, 'chair', 'Books');
+    expect(result, isEmpty);
+  });
+}

--- a/test/login_validation_test.dart
+++ b/test/login_validation_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/utils/validators.dart';
+
+void main() {
+  group('validateEmail', () {
+    test('empty email', () {
+      expect(validateEmail(''), 'Email is required');
+    });
+
+    test('invalid email', () {
+      expect(validateEmail('invalid'), 'Enter a valid email');
+    });
+
+    test('valid email', () {
+      expect(validateEmail('test@example.com'), isNull);
+    });
+  });
+
+  group('validatePassword', () {
+    test('empty password', () {
+      expect(validatePassword(''), 'Password is required');
+    });
+
+    test('too short password', () {
+      expect(validatePassword('123'), 'Password must be at least 6 characters');
+    });
+
+    test('valid password', () {
+      expect(validatePassword('123456'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- move login validators to new utils file so they can be tested
- expose item filtering logic via helper
- update page code to use helpers
- add tests for login validation
- add tests for item filtering

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684080645028832b903267d4761210f0