### PR TITLE
Add widget tests for navigation and pages

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -4,14 +4,15 @@ import '../models/models.dart';
 import '../services/event_service.dart';
 
 class CalendarPage extends StatefulWidget {
-  const CalendarPage({super.key});
+  final EventService? service;
+  const CalendarPage({super.key, this.service});
 
   @override
   State<CalendarPage> createState() => _CalendarPageState();
 }
 
 class _CalendarPageState extends State<CalendarPage> {
-  final EventService _service = EventService();
+  late final EventService _service;
   final Map<DateTime, List<CalendarEvent>> _events = {};
   late final ValueNotifier<List<CalendarEvent>> _selectedEvents;
   CalendarFormat _calendarFormat = CalendarFormat.month;
@@ -21,6 +22,7 @@ class _CalendarPageState extends State<CalendarPage> {
   @override
   void initState() {
     super.initState();
+    _service = widget.service ?? EventService();
     _selectedEvents = ValueNotifier(_getEventsForDay(_selectedDay));
     _loadEvents();
   }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -4,7 +4,9 @@ import 'item_exchange_page.dart';
 import 'maintenance_page.dart';
 
 class MainPage extends StatefulWidget {
-  const MainPage({super.key});
+  final CalendarPage? calendarPage;
+  final MaintenancePage? maintenancePage;
+  const MainPage({super.key, this.calendarPage, this.maintenancePage});
 
   @override
   State<MainPage> createState() => _MainPageState();
@@ -27,9 +29,9 @@ class _MainPageState extends State<MainPage> {
     super.initState();
     _pages = [
       DashboardPage(onNavigate: _onDashboardNavigate),
-      const CalendarPage(),
+      widget.calendarPage ?? const CalendarPage(),
       const ItemExchangePage(),
-      const MaintenancePage(),
+      widget.maintenancePage ?? const MaintenancePage(),
     ];
   }
 

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -4,14 +4,15 @@ import '../services/maintenance_service.dart';
 import 'maintenance_chat_page.dart';
 
 class MaintenancePage extends StatefulWidget {
-  const MaintenancePage({super.key});
+  final MaintenanceService? service;
+  const MaintenancePage({super.key, this.service});
 
   @override
   State<MaintenancePage> createState() => _MaintenancePageState();
 }
 
 class _MaintenancePageState extends State<MaintenancePage> {
-  final MaintenanceService _service = MaintenanceService();
+  late final MaintenanceService _service;
   int _selectedTab = 0;
   final _subjectController = TextEditingController();
   final _descriptionController = TextEditingController();
@@ -21,6 +22,7 @@ class _MaintenancePageState extends State<MaintenancePage> {
   @override
   void initState() {
     super.initState();
+    _service = widget.service ?? MaintenanceService();
     _loadTickets();
   }
 

--- a/test/calendar_page_test.dart
+++ b/test/calendar_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/calendar_page.dart';
+import 'package:oly_app/services/event_service.dart';
+
+class FakeEventService extends EventService {
+  final List<CalendarEvent> events = [];
+  FakeEventService();
+  @override
+  Future<List<CalendarEvent>> fetchEvents() async => events;
+  @override
+  Future<CalendarEvent> createEvent(CalendarEvent event) async {
+    events.add(event);
+    return event;
+  }
+}
+
+void main() {
+  testWidgets('Add event displays in list', (tester) async {
+    final service = FakeEventService();
+    await tester.pumpWidget(MaterialApp(home: CalendarPage(service: service)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No events for this day.'), findsOneWidget);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Meeting');
+    await tester.tap(find.text('Add'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Meeting'), findsOneWidget);
+  });
+}

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -38,7 +38,7 @@ void main() {
     ));
 
     // Starts on Dashboard
-    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
 
     // Navigate to Calendar tab
@@ -46,7 +46,7 @@ void main() {
         of: find.byType(NavigationBar),
         matching: find.byIcon(Icons.calendar_today)));
     await tester.pumpAndSettle();
-    expect(find.text('Calendar'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Calendar'), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
 
     // Navigate to Maintenance tab
@@ -54,7 +54,7 @@ void main() {
         of: find.byType(NavigationBar),
         matching: find.byIcon(Icons.build)));
     await tester.pumpAndSettle();
-    expect(find.text('Maintenance'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Maintenance'), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 }

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/pages/calendar_page.dart';
+import 'package:oly_app/pages/main_page.dart';
+import 'package:oly_app/pages/maintenance_page.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/services/event_service.dart';
+import 'package:oly_app/services/maintenance_service.dart';
+
+class FakeEventService extends EventService {
+  final List<CalendarEvent> events = [];
+  FakeEventService();
+  @override
+  Future<List<CalendarEvent>> fetchEvents() async => events;
+  @override
+  Future<CalendarEvent> createEvent(CalendarEvent event) async {
+    events.add(event);
+    return event;
+  }
+}
+
+class FakeMaintenanceService extends MaintenanceService {
+  FakeMaintenanceService();
+  @override
+  Future<List<MaintenanceRequest>> fetchRequests() async => [];
+}
+
+void main() {
+  testWidgets('Bottom navigation changes pages and FAB visibility', (tester) async {
+    final fakeEventService = FakeEventService();
+    final fakeMaintenanceService = FakeMaintenanceService();
+
+    await tester.pumpWidget(MaterialApp(
+      home: MainPage(
+        calendarPage: CalendarPage(service: fakeEventService),
+        maintenancePage: MaintenancePage(service: fakeMaintenanceService),
+      ),
+    ));
+
+    // Starts on Dashboard
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+
+    // Navigate to Calendar tab
+    await tester.tap(find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.byIcon(Icons.calendar_today)));
+    await tester.pumpAndSettle();
+    expect(find.text('Calendar'), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+
+    // Navigate to Maintenance tab
+    await tester.tap(find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.byIcon(Icons.build)));
+    await tester.pumpAndSettle();
+    expect(find.text('Maintenance'), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsNothing);
+  });
+}

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -47,7 +47,8 @@ void main() {
         matching: find.byIcon(Icons.calendar_today)));
     await tester.pumpAndSettle();
     expect(find.widgetWithText(AppBar, 'Calendar'), findsOneWidget);
-    expect(find.byType(FloatingActionButton), findsOneWidget);
+    // Calendar page includes its own FAB so at least one is present.
+    expect(find.byType(FloatingActionButton), findsWidgets);
 
     // Navigate to Maintenance tab
     await tester.tap(find.descendant(

--- a/test/maintenance_page_test.dart
+++ b/test/maintenance_page_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/maintenance_page.dart';
+import 'package:oly_app/services/maintenance_service.dart';
+
+class FakeMaintenanceService extends MaintenanceService {
+  FakeMaintenanceService();
+  @override
+  Future<List<MaintenanceRequest>> fetchRequests() async => [];
+}
+
+void main() {
+  testWidgets('Switches between request and conversations tabs', (tester) async {
+    final service = FakeMaintenanceService();
+    await tester.pumpWidget(MaterialApp(home: MaintenancePage(service: service)));
+    await tester.pumpAndSettle();
+
+    // Form visible on start
+    expect(find.byType(TextField), findsNWidgets(2));
+
+    // Switch to conversations
+    await tester.tap(find.text('Conversations'));
+    await tester.pumpAndSettle();
+    expect(find.text('No conversations yet.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- allow dependency injection for `CalendarPage` and `MaintenancePage`
- expose optional pages to `MainPage` for testing
- test bottom navigation and floating action button visibility
- test calendar event creation
- test maintenance page tab switching

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684080666008832bafa21985aa1fe90c