### PR TITLE
Update services for Node backend

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -3,6 +3,12 @@ import 'package:hive/hive.dart';
 
 part 'models.g.dart';
 
+DateTime _parseDate(dynamic value) {
+  if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);
+  if (value is String) return DateTime.parse(value);
+  throw ArgumentError('Unsupported date format: $value');
+}
+
 @HiveType(typeId: 0)
 class User {
   @HiveField(0)
@@ -71,7 +77,7 @@ class MaintenanceRequest {
       userId: map['userId'] as int,
       subject: map['subject'] as String,
       description: map['description'] as String,
-      createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+      createdAt: _parseDate(map['createdAt']),
       status: map['status'] as String,
     );
   }
@@ -81,7 +87,7 @@ class MaintenanceRequest {
     'userId': userId,
     'subject': subject,
     'description': description,
-    'createdAt': createdAt.millisecondsSinceEpoch,
+    'createdAt': createdAt.toIso8601String(),
     'status': status,
   };
 
@@ -117,7 +123,7 @@ class Message {
     requestId: map['requestId'] as int,
     senderId: map['senderId'] as int,
     content: map['content'] as String,
-    timestamp: DateTime.fromMillisecondsSinceEpoch(map['timestamp'] as int),
+    timestamp: _parseDate(map['timestamp']),
   );
 
   Map<String, dynamic> toMap() => {
@@ -125,7 +131,7 @@ class Message {
     'requestId': requestId,
     'senderId': senderId,
     'content': content,
-    'timestamp': timestamp.millisecondsSinceEpoch,
+    'timestamp': timestamp.toIso8601String(),
   };
 
   factory Message.fromJson(Map<String, dynamic> json) => Message.fromMap(json);
@@ -155,14 +161,14 @@ class CalendarEvent {
   factory CalendarEvent.fromMap(Map<String, dynamic> map) => CalendarEvent(
     id: map['id'] as int?,
     title: map['title'] as String,
-    date: DateTime.fromMillisecondsSinceEpoch(map['date'] as int),
+    date: _parseDate(map['date']),
     description: map['description'] as String?,
   );
 
   Map<String, dynamic> toMap() => {
     if (id != null) 'id': id,
     'title': title,
-    'date': date.millisecondsSinceEpoch,
+    'date': date.toIso8601String(),
     'description': description,
   };
 
@@ -224,9 +230,14 @@ class Item {
     description: map['description'] as String?,
     imageUrl: map['imageUrl'] as String?,
     price: map['price'] != null ? (map['price'] as num).toDouble() : null,
-    isFree: (map['isFree'] as int) == 1,
-    category: ItemCategory.values[map['category'] as int],
-    createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+    isFree: map['isFree'] is bool
+        ? map['isFree'] as bool
+        : (map['isFree'] as int) == 1,
+    category: map['category'] is int
+        ? ItemCategory.values[map['category'] as int]
+        : ItemCategory.values
+            .firstWhere((e) => e.name == map['category'] as String),
+    createdAt: _parseDate(map['createdAt']),
   );
 
   Map<String, dynamic> toMap() => {
@@ -236,9 +247,9 @@ class Item {
     'description': description,
     'imageUrl': imageUrl,
     'price': price,
-    'isFree': isFree ? 1 : 0,
-    'category': category.index,
-    'createdAt': createdAt.millisecondsSinceEpoch,
+    'isFree': isFree,
+    'category': category.name,
+    'createdAt': createdAt.toIso8601String(),
   };
 
   factory Item.fromJson(Map<String, dynamic> json) => Item.fromMap(json);

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart' as http;
 import '../models/models.dart';
 import '../utils/validators.dart';
+import '../services/api_service.dart';
 
 /// A simple login page with email/password and placeholder Google/Apple login buttons.
 class LoginPage extends StatefulWidget {
@@ -16,7 +17,7 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  static const bool useMock = true; // Toggle between mock and real API
+  static const bool useMock = false; // Toggle between mock and real API
   final _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
@@ -40,8 +41,7 @@ class _LoginPageState extends State<LoginPage> {
       };
     }
 
-    // TODO: Replace with real api call
-    final uri = Uri.parse('https://example.com/api/login');
+    final uri = ApiService().buildUri('/auth/login');
     final response = await http.post(
       uri,
       headers: {'Content-Type': 'application/json'},

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -6,7 +6,8 @@ class ApiService {
   ApiService({http.Client? client}) : _client = client ?? http.Client();
 
   final http.Client _client;
-  static const String baseUrl = 'https://example.com/api';
+  // Base URL of the Node.js/Express backend
+  static const String baseUrl = 'http://localhost:3000';
 
   Uri buildUri(String path, [Map<String, dynamic>? query]) {
     return Uri.parse(baseUrl).replace(path: '/api$path', queryParameters: query);

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -6,13 +6,16 @@ class EventService extends ApiService {
 
   Future<List<CalendarEvent>> fetchEvents() async {
     return get('/events', (json) {
-      final list = json as List<dynamic>;
-      return list.map((e) => CalendarEvent.fromJson(e as Map<String, dynamic>)).toList();
+      final list = (json['data'] as List<dynamic>);
+      return list
+          .map((e) => CalendarEvent.fromJson(e as Map<String, dynamic>))
+          .toList();
     });
   }
 
   Future<CalendarEvent> createEvent(CalendarEvent event) async {
-    return post('/events', event.toJson(),
-        (json) => CalendarEvent.fromJson(json as Map<String, dynamic>));
+    return post('/events', event.toJson(), (json) {
+      return CalendarEvent.fromJson(json['data'] as Map<String, dynamic>);
+    });
   }
 }

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -6,13 +6,16 @@ class ItemService extends ApiService {
 
   Future<List<Item>> fetchItems() async {
     return get('/items', (json) {
-      final list = json as List<dynamic>;
-      return list.map((e) => Item.fromJson(e as Map<String, dynamic>)).toList();
+      final list = (json['data'] as List<dynamic>);
+      return list
+          .map((e) => Item.fromJson(e as Map<String, dynamic>))
+          .toList();
     });
   }
 
   Future<Item> createItem(Item item) async {
-    return post('/items', item.toJson(),
-        (json) => Item.fromJson(json as Map<String, dynamic>));
+    return post('/items', item.toJson(), (json) {
+      return Item.fromJson(json['data'] as Map<String, dynamic>);
+    });
   }
 }

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -6,7 +6,7 @@ class MaintenanceService extends ApiService {
 
   Future<List<MaintenanceRequest>> fetchRequests() async {
     return get('/maintenance', (json) {
-      final list = json as List<dynamic>;
+      final list = (json['data'] as List<dynamic>);
       return list
           .map((e) => MaintenanceRequest.fromJson(e as Map<String, dynamic>))
           .toList();
@@ -15,13 +15,13 @@ class MaintenanceService extends ApiService {
 
   Future<MaintenanceRequest> createRequest(MaintenanceRequest request) async {
     return post('/maintenance', request.toJson(), (json) {
-      return MaintenanceRequest.fromJson(json as Map<String, dynamic>);
+      return MaintenanceRequest.fromJson(json['data'] as Map<String, dynamic>);
     });
   }
 
   Future<List<Message>> fetchMessages(int requestId) async {
     return get('/maintenance/$requestId/messages', (json) {
-      final list = json as List<dynamic>;
+      final list = (json['data'] as List<dynamic>);
       return list
           .map((e) => Message.fromJson(e as Map<String, dynamic>))
           .toList();
@@ -30,6 +30,7 @@ class MaintenanceService extends ApiService {
 
   Future<Message> sendMessage(Message message) async {
     return post('/maintenance/${message.requestId}/messages', message.toJson(),
-        (json) => Message.fromJson(json as Map<String, dynamic>));
+        (json) =>
+            Message.fromJson(json['data'] as Map<String, dynamic>));
   }
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -48,7 +48,7 @@ void main() {
       'userId': 3,
       'subject': 'Leaky faucet',
       'description': 'Kitchen sink leaks',
-      'createdAt': created.millisecondsSinceEpoch,
+      'createdAt': created.toIso8601String(),
       'status': 'open',
     };
 
@@ -81,7 +81,7 @@ void main() {
       'requestId': 10,
       'senderId': 4,
       'content': 'Hello world',
-      'timestamp': timestamp.millisecondsSinceEpoch,
+      'timestamp': timestamp.toIso8601String(),
     };
 
     test('toMap/fromMap round trip', () {
@@ -110,7 +110,7 @@ void main() {
     final eventMap = {
       'id': 4,
       'title': 'Meeting',
-      'date': eventDate.millisecondsSinceEpoch,
+      'date': eventDate.toIso8601String(),
       'description': 'Project discussion',
     };
 
@@ -149,9 +149,9 @@ void main() {
       'description': 'Comfy chair',
       'imageUrl': 'https://example.com/chair.png',
       'price': 20.5,
-      'isFree': 0,
-      'category': ItemCategory.furniture.index,
-      'createdAt': created.millisecondsSinceEpoch,
+      'isFree': false,
+      'category': ItemCategory.furniture.name,
+      'createdAt': created.toIso8601String(),
     };
 
     test('toMap/fromMap round trip', () {

--- a/test/services/event_service_test.dart
+++ b/test/services/event_service_test.dart
@@ -12,14 +12,19 @@ void main() {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
         expect(request.url.path, '/api/events');
-        return http.Response(jsonEncode([
-          {
-            'id': 1,
-            'title': 'Party',
-            'date': 0,
-            'description': 'fun'
-          }
-        ]), 200);
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': 1,
+                'title': 'Party',
+                'date': '1970-01-01T00:00:00.000Z',
+                'description': 'fun'
+              }
+            ]
+          }),
+          200,
+        );
       });
 
       final service = EventService(client: mockClient);
@@ -29,7 +34,10 @@ void main() {
     });
 
     test('createEvent sends POST and parses event', () async {
-      final input = CalendarEvent(title: 'Meet', date: DateTime.fromMillisecondsSinceEpoch(0));
+      final input = CalendarEvent(
+        title: 'Meet',
+        date: DateTime.fromMillisecondsSinceEpoch(0),
+      );
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
         expect(request.url.path, '/api/events');
@@ -37,8 +45,10 @@ void main() {
         expect(body['title'], input.title);
         return http.Response(
           jsonEncode({
-            'id': 2,
-            ...input.toJson(),
+            'data': {
+              'id': 2,
+              ...input.toJson(),
+            }
           }),
           201,
         );

--- a/test/services/item_service_test.dart
+++ b/test/services/item_service_test.dart
@@ -12,19 +12,24 @@ void main() {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
         expect(request.url.path, '/api/items');
-        return http.Response(jsonEncode([
-          {
-            'id': 1,
-            'ownerId': 1,
-            'title': 'Chair',
-            'description': null,
-            'imageUrl': null,
-            'price': null,
-            'isFree': 0,
-            'category': 0,
-            'createdAt': 0
-          }
-        ]), 200);
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': 1,
+                'ownerId': 1,
+                'title': 'Chair',
+                'description': null,
+                'imageUrl': null,
+                'price': null,
+                'isFree': false,
+                'category': 'furniture',
+                'createdAt': '1970-01-01T00:00:00.000Z'
+              }
+            ]
+          }),
+          200,
+        );
       });
 
       final service = ItemService(client: mockClient);
@@ -43,11 +48,10 @@ void main() {
         expect(body['title'], itemInput.title);
         return http.Response(
           jsonEncode({
-            'id': 2,
-            ...itemInput.toJson(),
-            'createdAt': 0,
-            'isFree': itemInput.isFree ? 1 : 0,
-            'category': itemInput.category.index
+            'data': {
+              'id': 2,
+              ...itemInput.toJson(),
+            }
           }),
           201,
         );

--- a/test/services/maintenance_service_test.dart
+++ b/test/services/maintenance_service_test.dart
@@ -12,16 +12,21 @@ void main() {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
         expect(request.url.path, '/api/maintenance');
-        return http.Response(jsonEncode([
-          {
-            'id': 1,
-            'userId': 1,
-            'subject': 'Leak',
-            'description': 'Water',
-            'createdAt': 0,
-            'status': 'open'
-          }
-        ]), 200);
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': 1,
+                'userId': 1,
+                'subject': 'Leak',
+                'description': 'Water',
+                'createdAt': '1970-01-01T00:00:00.000Z',
+                'status': 'open'
+              }
+            ]
+          }),
+          200,
+        );
       });
 
       final service = MaintenanceService(client: mockClient);
@@ -39,8 +44,10 @@ void main() {
         expect(body['subject'], input.subject);
         return http.Response(
           jsonEncode({
-            'id': 2,
-            ...input.toJson(),
+            'data': {
+              'id': 2,
+              ...input.toJson(),
+            }
           }),
           201,
         );
@@ -55,15 +62,20 @@ void main() {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
         expect(request.url.path, '/api/maintenance/1/messages');
-        return http.Response(jsonEncode([
-          {
-            'id': 1,
-            'requestId': 1,
-            'senderId': 2,
-            'content': 'Hi',
-            'timestamp': 0
-          }
-        ]), 200);
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': 1,
+                'requestId': 1,
+                'senderId': 2,
+                'content': 'Hi',
+                'timestamp': '1970-01-01T00:00:00.000Z'
+              }
+            ]
+          }),
+          200,
+        );
       });
 
       final service = MaintenanceService(client: mockClient);
@@ -81,8 +93,10 @@ void main() {
         expect(body['content'], input.content);
         return http.Response(
           jsonEncode({
-            'id': 3,
-            ...input.toJson(),
+            'data': {
+              'id': 3,
+              ...input.toJson(),
+            }
           }),
           201,
         );


### PR DESCRIPTION
## Summary
- switch API base URL to localhost Node backend
- parse new response format for events, items and maintenance
- generate ISO date strings and bool fields in models
- update login page to use real authentication endpoint
- adjust service tests to expect new format and updated models

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684084e689ec832ba3ad09622bff8345