### PR TITLE
Add Map Page with markers and tests

### DIFF
--- a/lib/models/map_pin.dart
+++ b/lib/models/map_pin.dart
@@ -1,0 +1,31 @@
+class MapPin {
+  final String id;
+  final String title;
+  final double lat;
+  final double lon;
+  final String type;
+
+  MapPin({
+    required this.id,
+    required this.title,
+    required this.lat,
+    required this.lon,
+    required this.type,
+  });
+
+  factory MapPin.fromMap(Map<String, dynamic> map) => MapPin(
+        id: map['id'] as String,
+        title: map['title'] as String,
+        lat: (map['lat'] as num).toDouble(),
+        lon: (map['lon'] as num).toDouble(),
+        type: map['type'] as String,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'title': title,
+        'lat': lat,
+        'lon': lon,
+        'type': type,
+      };
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'calendar_page.dart';
 import 'item_exchange_page.dart';
 import 'maintenance_page.dart';
+import 'map_page.dart';
 
 class MainPage extends StatefulWidget {
   final CalendarPage? calendarPage;
@@ -17,6 +18,7 @@ class _MainPageState extends State<MainPage> {
 
   static const List<String> _titles = [
     'Dashboard',
+    'Map',
     'Calendar',
     'Item Exchange',
     'Maintenance',
@@ -29,6 +31,7 @@ class _MainPageState extends State<MainPage> {
     super.initState();
     _pages = [
       DashboardPage(onNavigate: _onDashboardNavigate),
+      const MapPage(),
       widget.calendarPage ?? const CalendarPage(),
       const ItemExchangePage(),
       widget.maintenancePage ?? const MaintenancePage(),
@@ -46,7 +49,7 @@ class _MainPageState extends State<MainPage> {
         elevation: 2,
       ),
       body: _pages[_currentIndex],
-      floatingActionButton: _currentIndex != 3
+      floatingActionButton: _currentIndex != 4
           ? FloatingActionButton(
         onPressed: () {
           // TODO: implement quick actions per tab
@@ -62,6 +65,7 @@ class _MainPageState extends State<MainPage> {
         height: 60,
         destinations: const [
           NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+          NavigationDestination(icon: Icon(Icons.map), label: 'Map'),
           NavigationDestination(icon: Icon(Icons.calendar_today), label: 'Calendar'),
           NavigationDestination(icon: Icon(Icons.swap_horiz), label: 'Exchange'),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
@@ -75,8 +79,10 @@ class _MainPageState extends State<MainPage> {
       case 0:
         return Icons.notifications;
       case 1:
-        return Icons.event;
+        return Icons.place;
       case 2:
+        return Icons.event;
+      case 3:
         return Icons.add_shopping_cart;
       default:
         return Icons.add;
@@ -136,22 +142,28 @@ class DashboardPage extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               children: [
                 DashboardCard(
+                  icon: Icons.map,
+                  label: 'Map',
+                  colorScheme: colorScheme,
+                  onTap: () => _navigate(1),
+                ),
+                DashboardCard(
                   icon: Icons.calendar_today,
                   label: 'Calendar',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(1),
+                  onTap: () => _navigate(2),
                 ),
                 DashboardCard(
                   icon: Icons.swap_horiz,
                   label: 'Exchange',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(2),
+                  onTap: () => _navigate(3),
                 ),
                 DashboardCard(
                   icon: Icons.build,
                   label: 'Maintenance',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(3),
+                  onTap: () => _navigate(4),
                 ),
                 // add more cards here
               ],

--- a/lib/pages/map_page.dart
+++ b/lib/pages/map_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../models/map_pin.dart';
+import '../services/map_service.dart';
+
+class MapPage extends StatefulWidget {
+  final MapService? service;
+  final bool loadTiles;
+  const MapPage({super.key, this.service, this.loadTiles = true});
+
+  @override
+  State<MapPage> createState() => _MapPageState();
+}
+
+class _MapPageState extends State<MapPage> {
+  late final MapService _service;
+  List<MapPin> _pins = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? MapService();
+    _loadPins();
+  }
+
+  Future<void> _loadPins() async {
+    final pins = await _service.fetchPins();
+    setState(() => _pins = pins);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: FlutterMap(
+        options: MapOptions(
+          initialCenter: const LatLng(48.1740, 11.5475),
+          initialZoom: 16,
+        ),
+        children: [
+          if (widget.loadTiles)
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.example.olyapp',
+            ),
+          MarkerLayer(
+            markers: _pins
+                .map(
+                  (p) => Marker(
+                    width: 40,
+                    height: 40,
+                    point: LatLng(p.lat, p.lon),
+                    child: Icon(
+                      Icons.location_pin,
+                      color: _colorFor(p.type),
+                      size: 32,
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _colorFor(String type) {
+    switch (type) {
+      case 'building':
+        return Colors.blue;
+      case 'venue':
+        return Colors.red;
+      case 'amenity':
+        return Colors.green;
+      default:
+        return Colors.purple;
+    }
+  }
+}

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -1,0 +1,31 @@
+import '../models/map_pin.dart';
+
+class MapService {
+  Future<List<MapPin>> fetchPins() async {
+    // In real implementation, fetch from API
+    await Future.delayed(const Duration(milliseconds: 100));
+    return [
+      MapPin(
+        id: 'building1',
+        title: 'Dormitory',
+        lat: 48.1745,
+        lon: 11.548,
+        type: 'building',
+      ),
+      MapPin(
+        id: 'venue1',
+        title: 'Event Hall',
+        lat: 48.1740,
+        lon: 11.547,
+        type: 'venue',
+      ),
+      MapPin(
+        id: 'amenity1',
+        title: 'Laundry',
+        lat: 48.1735,
+        lon: 11.549,
+        type: 'amenity',
+      ),
+    ];
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,10 +34,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -126,6 +126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -158,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "4b8701e48a58f7712492c9b1f7ba0bb9d525644dd66d023b62e1fc8cdb560c8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.14.0"
   crypto:
     dependency: transitive
     description:
@@ -174,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_earcut:
+    dependency: transitive
+    description:
+      name: dart_earcut
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   dart_style:
     dependency: transitive
     description:
@@ -186,10 +210,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -227,6 +251,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_map:
+    dependency: "direct main"
+    description:
+      name: flutter_map
+      sha256: f7d0379477274f323c3f3bc12d369a2b42eb86d1e7bd2970ae1ea3cff782449a
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -336,14 +368,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  latlong2:
+    dependency: "direct main"
+    description:
+      name: latlong2
+      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -368,6 +408,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  lists:
+    dependency: transitive
+    description:
+      name: lists
+      sha256: "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.0"
   logging:
     dependency: transitive
     description:
@@ -408,6 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mgrs_dart:
+    dependency: transitive
+    description:
+      name: mgrs_dart
+      sha256: fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   mime:
     dependency: transitive
     description:
@@ -416,6 +480,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -496,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  polylabel:
+    dependency: transitive
+    description:
+      name: polylabel
+      sha256: "41b9099afb2aa6c1730bdd8a0fab1400d287694ec7615dd8516935fa3144214b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   pool:
     dependency: transitive
     description:
@@ -504,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  proj4dart:
+    dependency: transitive
+    description:
+      name: proj4dart
+      sha256: c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
@@ -528,6 +616,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -565,6 +669,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -621,6 +741,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: "direct dev"
+    description:
+      name: test
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
@@ -629,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.8"
   timing:
     dependency: transitive
     description:
@@ -645,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      sha256: "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -657,10 +801,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -693,6 +837,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  wkt_parser:
+    dependency: transitive
+    description:
+      name: wkt_parser
+      sha256: "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
 
+  flutter_map: ^8.1.1
+  latlong2: ^0.9.1
+
   http: any
 dev_dependencies:
   test: any

--- a/test/map_page_test.dart
+++ b/test/map_page_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/map_pin.dart';
+import 'package:oly_app/pages/map_page.dart';
+import 'package:oly_app/services/map_service.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+class FakeMapService extends MapService {
+  final List<MapPin> pins;
+  FakeMapService(this.pins);
+  @override
+  Future<List<MapPin>> fetchPins() async => pins;
+}
+
+void main() {
+  testWidgets('Map loads and displays pins', (tester) async {
+    final service = FakeMapService([
+      MapPin(id: '1', title: 'Test', lat: 0, lon: 0, type: 'building'),
+      MapPin(id: '2', title: 'Another', lat: 1, lon: 1, type: 'venue'),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: MapPage(service: service, loadTiles: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byType(MarkerLayer), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `flutter_map` dependency and generate lockfile
- implement `MapPage` with optional tile loading and colored markers
- add `Map` card and navigation destination
- provide static pin data via `MapService`
- test map page using a fake service

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6840850435d4832ba1f0c691a6007d9c