### PR TITLE
Add item request action

### DIFF
--- a/lib/pages/item_detail_page.dart
+++ b/lib/pages/item_detail_page.dart
@@ -9,6 +9,19 @@ class ItemDetailPage extends StatelessWidget {
 
   const ItemDetailPage({super.key, required this.item, this.service});
 
+  Future<void> _requestItem(BuildContext context) async {
+    if (item.id == null) return;
+    final svc = service ?? ItemService();
+    try {
+      await svc.requestItem(item.id!);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Request sent!')));
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed: $e')));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -116,7 +129,7 @@ class ItemDetailPage extends StatelessWidget {
                             foregroundColor: colorScheme.onPrimary,
                           ),
                           onPressed: () {
-                            // TODO: send request action
+                            _requestItem(context);
                           },
                         ),
                       ),

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -42,4 +42,9 @@ class ItemService extends ApiService {
       (json) => Message.fromJson(json as Map<String, dynamic>),
     );
   }
+
+  /// Sends a request to claim or purchase the item with [itemId].
+  Future<void> requestItem(int itemId) async {
+    await post('/items/$itemId/request', {}, (_) => null);
+  }
 }

--- a/test/item_request_test.dart
+++ b/test/item_request_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/item_detail_page.dart';
+import 'package:oly_app/services/item_service.dart';
+
+class FakeItemService extends ItemService {
+  bool called = false;
+  FakeItemService();
+  @override
+  Future<void> requestItem(int itemId) async {
+    called = true;
+  }
+}
+
+void main() {
+  testWidgets('Request button triggers service and shows snackbar', (tester) async {
+    final service = FakeItemService();
+    final item = Item(id: 1, ownerId: 1, title: 'Chair');
+    await tester.pumpWidget(MaterialApp(home: ItemDetailPage(item: item, service: service)));
+
+    await tester.tap(find.text('Request'));
+    await tester.pump();
+
+    expect(service.called, isTrue);
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- hook up request button in `ItemDetailPage`
- add `requestItem` API method
- show confirmation snackbar when requesting an item
- test that request calls service and shows a snackbar

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6840a6cd3f84832ba23372b527740d5c