### PR TITLE
Handle load errors gracefully

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -34,15 +34,23 @@ class _CalendarPageState extends State<CalendarPage> {
   }
 
   Future<void> _loadEvents() async {
-    final events = await _service.fetchEvents();
-    setState(() {
-      _events.clear();
-      for (final e in events) {
-        final key = DateTime(e.date.year, e.date.month, e.date.day);
-        _events.putIfAbsent(key, () => []).add(e);
-      }
-      _selectedEvents.value = _getEventsForDay(_selectedDay);
-    });
+    try {
+      final events = await _service.fetchEvents();
+      if (!mounted) return;
+      setState(() {
+        _events.clear();
+        for (final e in events) {
+          final key = DateTime(e.date.year, e.date.month, e.date.day);
+          _events.putIfAbsent(key, () => []).add(e);
+        }
+        _selectedEvents.value = _getEventsForDay(_selectedDay);
+      });
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to load events')),
+      );
+    }
   }
 
   List<CalendarEvent> _getEventsForDay(DateTime day) {

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -27,8 +27,16 @@ class _MaintenancePageState extends State<MaintenancePage> {
   }
 
   Future<void> _loadTickets() async {
-    final tickets = await _service.fetchRequests();
-    setState(() => _tickets = tickets);
+    try {
+      final tickets = await _service.fetchRequests();
+      if (!mounted) return;
+      setState(() => _tickets = tickets);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to load tickets')),
+      );
+    }
   }
 
   @override

--- a/test/calendar_page_test.dart
+++ b/test/calendar_page_test.dart
@@ -16,6 +16,12 @@ class FakeEventService extends EventService {
   }
 }
 
+class ErrorEventService extends EventService {
+  @override
+  Future<List<CalendarEvent>> fetchEvents() async =>
+      throw Exception('fail');
+}
+
 void main() {
   testWidgets('Add event displays in list', (tester) async {
     final service = FakeEventService();
@@ -32,5 +38,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Meeting'), findsOneWidget);
+  });
+
+  testWidgets('Shows snackbar on load error', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: CalendarPage(service: ErrorEventService())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load events'), findsOneWidget);
   });
 }

--- a/test/maintenance_page_test.dart
+++ b/test/maintenance_page_test.dart
@@ -10,6 +10,12 @@ class FakeMaintenanceService extends MaintenanceService {
   Future<List<MaintenanceRequest>> fetchRequests() async => [];
 }
 
+class ErrorMaintenanceService extends MaintenanceService {
+  @override
+  Future<List<MaintenanceRequest>> fetchRequests() async =>
+      throw Exception('fail');
+}
+
 void main() {
   testWidgets('Switches between request and conversations tabs', (tester) async {
     final service = FakeMaintenanceService();
@@ -23,5 +29,14 @@ void main() {
     await tester.tap(find.text('Conversations'));
     await tester.pumpAndSettle();
     expect(find.text('No conversations yet.'), findsOneWidget);
+  });
+
+  testWidgets('Shows snackbar on ticket load error', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: MaintenancePage(service: ErrorMaintenanceService())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load tickets'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- show SnackBar if event or ticket loading fails
- keep state unchanged when errors occur
- test CalendarPage and MaintenancePage error handling with failing services

## Testing
- `flutter test --update-goldens`

------
https://chatgpt.com/codex/tasks/task_e_6840a7567c10832b9c43177d7a84e173