### PR TITLE
Support auto login via Hive boxes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,12 +40,34 @@ class _OlyAppState extends State<OlyApp> {
   bool _loggedIn = false;
   bool _isAdmin = false;
 
+  @override
+  void initState() {
+    super.initState();
+    final authBox = Hive.box('authBox');
+    final token = authBox.get('token');
+    final userBox = Hive.box<User>('userBox');
+    final user = userBox.get('currentUser');
+    if (token != null && user != null) {
+      _loggedIn = true;
+      _isAdmin = user.isAdmin;
+    }
+  }
+
   void _handleLogin() {
     final userBox = Hive.box<User>('userBox');
     final user = userBox.get('currentUser');
     setState(() {
       _loggedIn = true;
       _isAdmin = user?.isAdmin ?? false;
+    });
+  }
+
+  Future<void> _logout() async {
+    await Hive.box('authBox').clear();
+    await Hive.box<User>('userBox').clear();
+    setState(() {
+      _loggedIn = false;
+      _isAdmin = false;
     });
   }
 
@@ -58,7 +80,7 @@ class _OlyAppState extends State<OlyApp> {
         useMaterial3: true,
       ),
       home: _loggedIn
-          ? MainPage(isAdmin: _isAdmin)
+          ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
           : LoginPage(onLoginSuccess: _handleLogin),
     );
   }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -9,7 +9,8 @@ class MainPage extends StatefulWidget {
   final CalendarPage? calendarPage;
   final MaintenancePage? maintenancePage;
   final bool isAdmin;
-  const MainPage({super.key, this.calendarPage, this.maintenancePage, this.isAdmin = false});
+  final VoidCallback? onLogout;
+  const MainPage({super.key, this.calendarPage, this.maintenancePage, this.isAdmin = false, this.onLogout});
 
   @override
   State<MainPage> createState() => _MainPageState();
@@ -52,6 +53,17 @@ class _MainPageState extends State<MainPage> {
         backgroundColor: colorScheme.primaryContainer,
         foregroundColor: colorScheme.onPrimaryContainer,
         elevation: 2,
+        actions: [
+          if (widget.onLogout != null)
+            PopupMenuButton<String>(
+              onSelected: (val) {
+                if (val == 'logout') widget.onLogout!();
+              },
+              itemBuilder: (context) => const [
+                PopupMenuItem(value: 'logout', child: Text('Logout')),
+              ],
+            ),
+        ],
       ),
       body: _pages[_currentIndex],
       floatingActionButton: _currentIndex != 4

--- a/test/auto_login_test.dart
+++ b/test/auto_login_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:oly_app/main.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/main_page.dart';
+import 'package:oly_app/pages/login_page.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserAdapter());
+    await Hive.openBox('authBox');
+    await Hive.openBox<User>('userBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('Loads MainPage when credentials exist', (tester) async {
+    final authBox = Hive.box('authBox');
+    await authBox.put('token', 'token');
+    final userBox = Hive.box<User>('userBox');
+    await userBox.put('currentUser', User(name: 'Test', email: 't@test.com'));
+
+    await tester.pumpWidget(const OlyApp());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MainPage), findsOneWidget);
+    expect(find.byType(LoginPage), findsNothing);
+  });
+}

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -34,6 +34,7 @@ void main() {
       home: MainPage(
         calendarPage: CalendarPage(service: fakeEventService),
         maintenancePage: MaintenancePage(service: fakeMaintenanceService),
+        onLogout: () {},
       ),
     ));
 
@@ -60,14 +61,14 @@ void main() {
   });
 
   testWidgets('Admin card visible for admins', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: MainPage(isAdmin: true)));
+    await tester.pumpWidget(const MaterialApp(home: MainPage(isAdmin: true, onLogout: null)));
     await tester.pumpAndSettle();
 
     expect(find.text('Admin'), findsOneWidget);
   });
 
   testWidgets('Admin card hidden for regular user', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: MainPage()));
+    await tester.pumpWidget(const MaterialApp(home: MainPage(onLogout: null)));
     await tester.pumpAndSettle();
     expect(find.text('Admin'), findsNothing);
   });


### PR DESCRIPTION
## Summary
- check Hive boxes for saved token and user during initialization
- expose logout action from OlyApp and hook it up in MainPage
- add widget test for loading credentials
- adjust existing tests for new MainPage callback

## Testing
- `flutter test` *(fails: Loads MainPage when credentials exist - did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_6840a707adc8832b80f712fc6945d742