### PR TITLE
Add ItemExchangePage widget tests

### DIFF
--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -7,14 +7,15 @@ import '../services/item_service.dart';
 import '../utils/item_filter.dart';
 
 class ItemExchangePage extends StatefulWidget {
-  const ItemExchangePage({super.key});
+  final ItemService? service;
+  const ItemExchangePage({super.key, this.service});
 
   @override
   State<ItemExchangePage> createState() => _ItemExchangePageState();
 }
 
 class _ItemExchangePageState extends State<ItemExchangePage> {
-  final ItemService _service = ItemService();
+  late final ItemService _service;
   final _searchCtrl = TextEditingController();
   String _selectedCategory = 'All';
 
@@ -26,6 +27,7 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
   @override
   void initState() {
     super.initState();
+    _service = widget.service ?? ItemService();
     _loadItems();
   }
 

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/item_exchange_page.dart';
+import 'package:oly_app/pages/item_detail_page.dart';
+import 'package:oly_app/services/item_service.dart';
+import 'package:oly_app/widgets/item_card.dart';
+
+class FakeItemService extends ItemService {
+  final List<Item> items;
+  FakeItemService(this.items);
+  @override
+  Future<List<Item>> fetchItems() async => items;
+}
+
+void main() {
+  testWidgets('Search text or category filters items', (tester) async {
+    final service = FakeItemService([
+      Item(ownerId: 1, title: 'Dart Book', category: ItemCategory.books),
+      Item(ownerId: 1, title: 'Laptop', category: ItemCategory.electronics),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ItemExchangePage(service: service)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dart Book'), findsOneWidget);
+    expect(find.text('Laptop'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'laptop');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Laptop'), findsOneWidget);
+    expect(find.text('Dart Book'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Books'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dart Book'), findsOneWidget);
+    expect(find.text('Laptop'), findsNothing);
+  });
+
+  testWidgets('Tapping item opens detail page', (tester) async {
+    final item = Item(
+      ownerId: 1,
+      title: 'Chair',
+      category: ItemCategory.furniture,
+    );
+    final service = FakeItemService([item]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ItemExchangePage(service: service)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(ItemCard, 'Chair'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ItemDetailPage), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting ItemService into `ItemExchangePage`
- test search and category filters update the grid
- test tapping an item navigates to detail page

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6840a6c493d4832ba76a35ffef1feaba