### PR TITLE
Fix BuildContext lint in item detail

### DIFF
--- a/lib/pages/item_detail_page.dart
+++ b/lib/pages/item_detail_page.dart
@@ -12,13 +12,14 @@ class ItemDetailPage extends StatelessWidget {
   Future<void> _requestItem(BuildContext context) async {
     if (item.id == null) return;
     final svc = service ?? ItemService();
+    final messenger = ScaffoldMessenger.of(context);
     try {
       await svc.requestItem(item.id!);
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Request sent!')));
+      messenger.showSnackBar(
+          const SnackBar(content: Text('Request sent!')));
     } catch (e) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Failed: $e')));
+      messenger.showSnackBar(
+          SnackBar(content: Text('Failed: $e')));
     }
   }
 


### PR DESCRIPTION
## Summary
- fix BuildContext usage across async gap in item detail page

## Testing
- `flutter analyze`
- `flutter test` *(fails: Auto login test did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab5c91e8832b9262229b597f817b