### PR TITLE
Make API URL configurable via dart-define

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ OlyApp is a mobile app built by and for residents of the Olympiadorf (Olydorf) i
    flutter run
    ```
 
+   To point the app at a different backend, pass a custom API URL:
+   ```bash
+   flutter run --dart-define=API_URL=https://prod.example.com
+   ```
+
 ## 🧪 Running Tests
 
 Install dependencies and run the unit tests:

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -7,7 +7,8 @@ class ApiService {
 
   final http.Client _client;
   // Base URL of the Node.js/Express backend
-  static const String baseUrl = 'http://localhost:3000';
+  static const String baseUrl =
+      String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
 
   Uri buildUri(String path, [Map<String, dynamic>? query]) {
     return Uri.parse(baseUrl).replace(path: '/api$path', queryParameters: query);

--- a/test/services/event_service_test.dart
+++ b/test/services/event_service_test.dart
@@ -6,11 +6,15 @@ import 'package:http/testing.dart';
 import 'package:oly_app/services/event_service.dart';
 import 'package:oly_app/models/models.dart';
 
+const apiUrl =
+    String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+
 void main() {
   group('EventService', () {
     test('fetchEvents parses list correctly', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/events');
         return http.Response(
           jsonEncode({
@@ -40,6 +44,7 @@ void main() {
       );
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/events');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['title'], input.title);
@@ -64,6 +69,7 @@ void main() {
       final input = CalendarEvent(id: 1, title: 'Edit', date: DateTime.fromMillisecondsSinceEpoch(0));
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/events/1');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['title'], input.title);

--- a/test/services/item_service_test.dart
+++ b/test/services/item_service_test.dart
@@ -6,11 +6,15 @@ import 'package:http/testing.dart';
 import 'package:oly_app/services/item_service.dart';
 import 'package:oly_app/models/models.dart';
 
+const apiUrl =
+    String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+
 void main() {
   group('ItemService', () {
     test('fetchItems parses list correctly', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/items');
         return http.Response(
           jsonEncode({
@@ -43,6 +47,7 @@ void main() {
       final itemInput = Item(ownerId: 1, title: 'Table');
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/items');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['title'], itemInput.title);
@@ -66,6 +71,7 @@ void main() {
     test('fetchMessages parses list correctly', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/items/1/messages');
         return http.Response(
           jsonEncode([
@@ -91,6 +97,7 @@ void main() {
       final input = Message(requestId: 1, senderId: 1, content: 'Hello');
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/items/1/messages');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['content'], input.content);

--- a/test/services/maintenance_service_test.dart
+++ b/test/services/maintenance_service_test.dart
@@ -6,11 +6,15 @@ import 'package:http/testing.dart';
 import 'package:oly_app/services/maintenance_service.dart';
 import 'package:oly_app/models/models.dart';
 
+const apiUrl =
+    String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+
 void main() {
   group('MaintenanceService', () {
     test('fetchRequests parses list correctly', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance');
         return http.Response(
           jsonEncode({
@@ -39,6 +43,7 @@ void main() {
       final input = MaintenanceRequest(userId: 1, subject: 'Leak', description: 'Water');
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['subject'], input.subject);
@@ -61,6 +66,7 @@ void main() {
     test('fetchMessages parses list correctly', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance/1/messages');
         return http.Response(
           jsonEncode({
@@ -88,6 +94,7 @@ void main() {
       final input = Message(requestId: 1, senderId: 2, content: 'Hi');
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance/1/messages');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['content'], input.content);
@@ -110,6 +117,7 @@ void main() {
     test('updateStatus posts update', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance/1');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['status'], 'closed');


### PR DESCRIPTION
## Summary
- allow overriding `ApiService.baseUrl` with `API_URL` dart define
- document passing `--dart-define` in README
- check request origins in service tests so they honor the env var

## Testing
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840b054894c832b810d7f5b864929eb