### PR TITLE
Add FAB actions and tests

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -47,9 +47,9 @@ class _CalendarPageState extends State<CalendarPage> {
       });
     } catch (_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to load events')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to load events')));
     }
   }
 
@@ -74,11 +74,15 @@ class _CalendarPageState extends State<CalendarPage> {
   }
 
   void _addEvent() async {
-    await _showAddEventDialog(context, (title, date) async {
+    await showAddEventDialog(context, (title, date) async {
       final event = await _service.createEvent(
         CalendarEvent(title: title, date: date),
       );
-      final dayKey = DateTime(event.date.year, event.date.month, event.date.day);
+      final dayKey = DateTime(
+        event.date.year,
+        event.date.month,
+        event.date.day,
+      );
       if (_events.containsKey(dayKey)) {
         _events[dayKey]!.add(event);
       } else {
@@ -92,7 +96,6 @@ class _CalendarPageState extends State<CalendarPage> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return Scaffold(
-
       body: Column(
         children: [
           TableCalendar<CalendarEvent>(
@@ -117,11 +120,17 @@ class _CalendarPageState extends State<CalendarPage> {
             ),
             calendarStyle: CalendarStyle(
               todayDecoration: BoxDecoration(
-                  color: cs.primaryContainer, shape: BoxShape.circle),
+                color: cs.primaryContainer,
+                shape: BoxShape.circle,
+              ),
               selectedDecoration: BoxDecoration(
-                  color: cs.secondary, shape: BoxShape.circle),
+                color: cs.secondary,
+                shape: BoxShape.circle,
+              ),
               markerDecoration: BoxDecoration(
-                  color: cs.secondaryContainer, shape: BoxShape.circle),
+                color: cs.secondaryContainer,
+                shape: BoxShape.circle,
+              ),
             ),
           ),
           const SizedBox(height: 8),
@@ -157,11 +166,10 @@ class _CalendarPageState extends State<CalendarPage> {
   }
 }
 
-
-Future<void> _showAddEventDialog(
-    BuildContext context,
-    void Function(String title, DateTime date) onConfirm,
-    ) async {
+Future<void> showAddEventDialog(
+  BuildContext context,
+  void Function(String title, DateTime date) onConfirm,
+) async {
   final textCtrl = TextEditingController();
   DateTime selectedDate = DateTime.now();
   await showDialog(
@@ -179,7 +187,8 @@ Future<void> _showAddEventDialog(
           TextButton.icon(
             icon: const Icon(Icons.calendar_today),
             label: Text(
-                '${selectedDate.day}/${selectedDate.month}/${selectedDate.year}'),
+              '${selectedDate.day}/${selectedDate.month}/${selectedDate.year}',
+            ),
             onPressed: () async {
               final picked = await showDatePicker(
                 context: ctx,
@@ -194,8 +203,9 @@ Future<void> _showAddEventDialog(
       ),
       actions: [
         TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Cancel')),
+          onPressed: () => Navigator.pop(ctx),
+          child: const Text('Cancel'),
+        ),
         ElevatedButton(
           onPressed: () {
             if (textCtrl.text.isNotEmpty) {

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/material.dart';
 import 'calendar_page.dart';
 import 'item_exchange_page.dart';
-import 'maintenance_page.dart'; 
-import 'admin/admin_home_page.dart'; 
-import 'map_page.dart'; 
+import 'maintenance_page.dart';
+import 'admin/admin_home_page.dart';
+import 'map_page.dart';
+import 'post_item_page.dart';
+import '../models/models.dart';
+import '../services/event_service.dart';
 
 class MainPage extends StatefulWidget {
   final CalendarPage? calendarPage;
   final MaintenancePage? maintenancePage;
   final bool isAdmin;
   final VoidCallback? onLogout;
-  const MainPage({super.key, this.calendarPage, this.maintenancePage, this.isAdmin = false, this.onLogout});
+  const MainPage({
+    super.key,
+    this.calendarPage,
+    this.maintenancePage,
+    this.isAdmin = false,
+    this.onLogout,
+  });
 
   @override
   State<MainPage> createState() => _MainPageState();
@@ -33,10 +42,7 @@ class _MainPageState extends State<MainPage> {
   void initState() {
     super.initState();
     _pages = [
-      DashboardPage(
-        onNavigate: _onDashboardNavigate,
-        isAdmin: widget.isAdmin,
-      ),
+      DashboardPage(onNavigate: _onDashboardNavigate, isAdmin: widget.isAdmin),
       const MapPage(),
       widget.calendarPage ?? const CalendarPage(),
       const ItemExchangePage(),
@@ -66,15 +72,13 @@ class _MainPageState extends State<MainPage> {
         ],
       ),
       body: _pages[_currentIndex],
-      floatingActionButton: _currentIndex != 4
+      floatingActionButton: _fabCallback() != null
           ? FloatingActionButton(
-        onPressed: () {
-          // TODO: implement quick actions per tab
-        },
-        backgroundColor: colorScheme.secondary,
-        foregroundColor: colorScheme.onSecondary,
-        child: Icon(_fabIcon()),
-      )
+              onPressed: _fabCallback(),
+              backgroundColor: colorScheme.secondary,
+              foregroundColor: colorScheme.onSecondary,
+              child: Icon(_fabIcon()),
+            )
           : null,
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
@@ -83,8 +87,14 @@ class _MainPageState extends State<MainPage> {
         destinations: const [
           NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
           NavigationDestination(icon: Icon(Icons.map), label: 'Map'),
-          NavigationDestination(icon: Icon(Icons.calendar_today), label: 'Calendar'),
-          NavigationDestination(icon: Icon(Icons.swap_horiz), label: 'Exchange'),
+          NavigationDestination(
+            icon: Icon(Icons.calendar_today),
+            label: 'Calendar',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.swap_horiz),
+            label: 'Exchange',
+          ),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
         ],
       ),
@@ -106,6 +116,39 @@ class _MainPageState extends State<MainPage> {
     }
   }
 
+  VoidCallback? _fabCallback() {
+    switch (_currentIndex) {
+      case 0:
+        return () {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('No notifications')));
+        };
+      case 1:
+        return () {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('No map action')));
+        };
+      case 2:
+        return () async {
+          await showAddEventDialog(context, (title, date) async {
+            final service = EventService();
+            await service.createEvent(CalendarEvent(title: title, date: date));
+          });
+        };
+      case 3:
+        return () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const PostItemPage()),
+          );
+        };
+      default:
+        return null;
+    }
+  }
+
   void _onDashboardNavigate(int index) {
     setState(() => _currentIndex = index);
   }
@@ -114,7 +157,11 @@ class _MainPageState extends State<MainPage> {
 class DashboardPage extends StatelessWidget {
   final ValueChanged<int> onNavigate;
   final bool isAdmin;
-  const DashboardPage({super.key, required this.onNavigate, this.isAdmin = false});
+  const DashboardPage({
+    super.key,
+    required this.onNavigate,
+    this.isAdmin = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -190,9 +237,7 @@ class DashboardPage extends StatelessWidget {
                     colorScheme: colorScheme,
                     onTap: () => Navigator.push(
                       context,
-                      MaterialPageRoute(
-                        builder: (_) => const AdminHomePage(),
-                      ),
+                      MaterialPageRoute(builder: (_) => const AdminHomePage()),
                     ),
                   ),
               ],
@@ -238,10 +283,9 @@ class StatusCard extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: textColor),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: textColor),
               ),
             ),
           ],
@@ -281,10 +325,9 @@ class DashboardCard extends StatelessWidget {
               const SizedBox(height: 12),
               Text(
                 label,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyLarge
-                    ?.copyWith(color: colorScheme.onSurfaceVariant),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -6,6 +6,7 @@ import 'package:oly_app/pages/maintenance_page.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/services/event_service.dart';
 import 'package:oly_app/services/maintenance_service.dart';
+import 'package:oly_app/pages/post_item_page.dart';
 
 class FakeEventService extends EventService {
   final List<CalendarEvent> events = [];
@@ -26,42 +27,54 @@ class FakeMaintenanceService extends MaintenanceService {
 }
 
 void main() {
-  testWidgets('Bottom navigation changes pages and FAB visibility', (tester) async {
+  testWidgets('Bottom navigation changes pages and FAB visibility', (
+    tester,
+  ) async {
     final fakeEventService = FakeEventService();
     final fakeMaintenanceService = FakeMaintenanceService();
 
-    await tester.pumpWidget(MaterialApp(
-      home: MainPage(
-        calendarPage: CalendarPage(service: fakeEventService),
-        maintenancePage: MaintenancePage(service: fakeMaintenanceService),
-        onLogout: () {},
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MainPage(
+          calendarPage: CalendarPage(service: fakeEventService),
+          maintenancePage: MaintenancePage(service: fakeMaintenanceService),
+          onLogout: () {},
+        ),
       ),
-    ));
+    );
 
     // Starts on Dashboard
     expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
 
     // Navigate to Calendar tab
-    await tester.tap(find.descendant(
+    await tester.tap(
+      find.descendant(
         of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.calendar_today)));
+        matching: find.byIcon(Icons.calendar_today),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.widgetWithText(AppBar, 'Calendar'), findsOneWidget);
     // Calendar page includes its own FAB so at least one is present.
     expect(find.byType(FloatingActionButton), findsWidgets);
 
     // Navigate to Maintenance tab
-    await tester.tap(find.descendant(
+    await tester.tap(
+      find.descendant(
         of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.build)));
+        matching: find.byIcon(Icons.build),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.widgetWithText(AppBar, 'Maintenance'), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
   testWidgets('Admin card visible for admins', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: MainPage(isAdmin: true, onLogout: null)));
+    await tester.pumpWidget(
+      const MaterialApp(home: MainPage(isAdmin: true, onLogout: null)),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Admin'), findsOneWidget);
@@ -71,5 +84,58 @@ void main() {
     await tester.pumpWidget(const MaterialApp(home: MainPage(onLogout: null)));
     await tester.pumpAndSettle();
     expect(find.text('Admin'), findsNothing);
+  });
+
+  testWidgets('FAB on calendar tab opens add event dialog', (tester) async {
+    final fakeEventService = FakeEventService();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MainPage(
+          calendarPage: CalendarPage(service: fakeEventService),
+          onLogout: () {},
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.byIcon(Icons.calendar_today),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final fab = find.widgetWithIcon(FloatingActionButton, Icons.event);
+    expect(fab, findsOneWidget);
+
+    await tester.tap(fab);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add Event'), findsOneWidget);
+  });
+
+  testWidgets('FAB on exchange tab opens PostItemPage', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: MainPage(onLogout: null)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(NavigationBar),
+        matching: find.byIcon(Icons.swap_horiz),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final fab = find.widgetWithIcon(
+      FloatingActionButton,
+      Icons.add_shopping_cart,
+    );
+    expect(fab, findsOneWidget);
+
+    await tester.tap(fab);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PostItemPage), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- enable `showAddEventDialog` for reuse
- implement per-tab FAB callbacks in `MainPage`
- add widget tests verifying FAB behaviour

## Testing
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840b0fd7b90832b8f48727af36172fd