### PR TITLE
Add user profile page

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -1,16 +1,23 @@
 import 'package:flutter/material.dart';
 import 'calendar_page.dart';
 import 'item_exchange_page.dart';
-import 'maintenance_page.dart'; 
-import 'admin/admin_home_page.dart'; 
-import 'map_page.dart'; 
+import 'maintenance_page.dart';
+import 'admin/admin_home_page.dart';
+import 'map_page.dart';
+import 'profile_page.dart';
 
 class MainPage extends StatefulWidget {
   final CalendarPage? calendarPage;
   final MaintenancePage? maintenancePage;
   final bool isAdmin;
   final VoidCallback? onLogout;
-  const MainPage({super.key, this.calendarPage, this.maintenancePage, this.isAdmin = false, this.onLogout});
+  const MainPage({
+    super.key,
+    this.calendarPage,
+    this.maintenancePage,
+    this.isAdmin = false,
+    this.onLogout,
+  });
 
   @override
   State<MainPage> createState() => _MainPageState();
@@ -33,10 +40,7 @@ class _MainPageState extends State<MainPage> {
   void initState() {
     super.initState();
     _pages = [
-      DashboardPage(
-        onNavigate: _onDashboardNavigate,
-        isAdmin: widget.isAdmin,
-      ),
+      DashboardPage(onNavigate: _onDashboardNavigate, isAdmin: widget.isAdmin),
       const MapPage(),
       widget.calendarPage ?? const CalendarPage(),
       const ItemExchangePage(),
@@ -54,27 +58,35 @@ class _MainPageState extends State<MainPage> {
         foregroundColor: colorScheme.onPrimaryContainer,
         elevation: 2,
         actions: [
-          if (widget.onLogout != null)
-            PopupMenuButton<String>(
-              onSelected: (val) {
-                if (val == 'logout') widget.onLogout!();
-              },
-              itemBuilder: (context) => const [
-                PopupMenuItem(value: 'logout', child: Text('Logout')),
-              ],
-            ),
+          PopupMenuButton<String>(
+            onSelected: (val) async {
+              if (val == 'profile') {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const ProfilePage()),
+                );
+              } else if (val == 'logout' && widget.onLogout != null) {
+                widget.onLogout!();
+              }
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(value: 'profile', child: Text('Profile')),
+              if (widget.onLogout != null)
+                const PopupMenuItem(value: 'logout', child: Text('Logout')),
+            ],
+          ),
         ],
       ),
       body: _pages[_currentIndex],
       floatingActionButton: _currentIndex != 4
           ? FloatingActionButton(
-        onPressed: () {
-          // TODO: implement quick actions per tab
-        },
-        backgroundColor: colorScheme.secondary,
-        foregroundColor: colorScheme.onSecondary,
-        child: Icon(_fabIcon()),
-      )
+              onPressed: () {
+                // TODO: implement quick actions per tab
+              },
+              backgroundColor: colorScheme.secondary,
+              foregroundColor: colorScheme.onSecondary,
+              child: Icon(_fabIcon()),
+            )
           : null,
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
@@ -83,8 +95,14 @@ class _MainPageState extends State<MainPage> {
         destinations: const [
           NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
           NavigationDestination(icon: Icon(Icons.map), label: 'Map'),
-          NavigationDestination(icon: Icon(Icons.calendar_today), label: 'Calendar'),
-          NavigationDestination(icon: Icon(Icons.swap_horiz), label: 'Exchange'),
+          NavigationDestination(
+            icon: Icon(Icons.calendar_today),
+            label: 'Calendar',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.swap_horiz),
+            label: 'Exchange',
+          ),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
         ],
       ),
@@ -114,7 +132,11 @@ class _MainPageState extends State<MainPage> {
 class DashboardPage extends StatelessWidget {
   final ValueChanged<int> onNavigate;
   final bool isAdmin;
-  const DashboardPage({super.key, required this.onNavigate, this.isAdmin = false});
+  const DashboardPage({
+    super.key,
+    required this.onNavigate,
+    this.isAdmin = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -190,9 +212,7 @@ class DashboardPage extends StatelessWidget {
                     colorScheme: colorScheme,
                     onTap: () => Navigator.push(
                       context,
-                      MaterialPageRoute(
-                        builder: (_) => const AdminHomePage(),
-                      ),
+                      MaterialPageRoute(builder: (_) => const AdminHomePage()),
                     ),
                   ),
               ],
@@ -238,10 +258,9 @@ class StatusCard extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: textColor),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(color: textColor),
               ),
             ),
           ],
@@ -281,10 +300,9 @@ class DashboardCard extends StatelessWidget {
               const SizedBox(height: 12),
               Text(
                 label,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodyLarge
-                    ?.copyWith(color: colorScheme.onSurfaceVariant),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/models.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  late final Box<User> _userBox;
+  late User _user;
+
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameCtrl;
+  late final TextEditingController _emailCtrl;
+  late final TextEditingController _avatarCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _userBox = Hive.box<User>('userBox');
+    _user = _userBox.get('currentUser')!;
+    _nameCtrl = TextEditingController(text: _user.name);
+    _emailCtrl = TextEditingController(text: _user.email);
+    _avatarCtrl = TextEditingController(text: _user.avatarUrl ?? '');
+    _avatarCtrl.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _emailCtrl.dispose();
+    _avatarCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    final updated = User(
+      id: _user.id,
+      name: _nameCtrl.text.trim(),
+      email: _emailCtrl.text.trim(),
+      avatarUrl: _avatarCtrl.text.trim().isEmpty
+          ? null
+          : _avatarCtrl.text.trim(),
+      isAdmin: _user.isAdmin,
+    );
+    await _userBox.put('currentUser', updated);
+    if (mounted) {
+      setState(() => _user = updated);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Profile updated')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = _avatarCtrl.text.trim();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                radius: 40,
+                backgroundImage: avatarUrl.isNotEmpty
+                    ? NetworkImage(avatarUrl)
+                    : null,
+                child: avatarUrl.isEmpty
+                    ? const Icon(Icons.person, size: 40)
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _emailCtrl,
+                decoration: const InputDecoration(labelText: 'Email'),
+                keyboardType: TextInputType.emailAddress,
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _avatarCtrl,
+                decoration: const InputDecoration(labelText: 'Avatar URL'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(onPressed: _save, child: const Text('Save')),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/profile_page.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserAdapter());
+    await Hive.openBox<User>('userBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('Edits persist and reload', (tester) async {
+    final box = Hive.box<User>('userBox');
+    await box.put('currentUser', User(name: 'Old', email: 'old@test.com'));
+
+    await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+    await tester.pumpAndSettle();
+
+    Finder nameField() => find.bySemanticsLabel('Name');
+    Finder emailField() => find.bySemanticsLabel('Email');
+    Finder avatarField() => find.bySemanticsLabel('Avatar URL');
+
+    expect(tester.widget<TextFormField>(nameField()).controller!.text, 'Old');
+    expect(
+      tester.widget<TextFormField>(emailField()).controller!.text,
+      'old@test.com',
+    );
+
+    await tester.enterText(nameField(), 'New Name');
+    await tester.enterText(emailField(), 'new@example.com');
+    await tester.enterText(avatarField(), 'http://example.com/avatar.png');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final saved = box.get('currentUser')!;
+    expect(saved.name, 'New Name');
+    expect(saved.email, 'new@example.com');
+    expect(saved.avatarUrl, 'http://example.com/avatar.png');
+
+    await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<TextFormField>(nameField()).controller!.text,
+      'New Name',
+    );
+    expect(
+      tester.widget<TextFormField>(emailField()).controller!.text,
+      'new@example.com',
+    );
+    expect(
+      tester.widget<TextFormField>(avatarField()).controller!.text,
+      'http://example.com/avatar.png',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a `ProfilePage` to edit user details stored in Hive
- show the profile page from MainPage menu
- test profile editing persistence

## Testing
- `flutter test` *(fails: TimeoutException)*

------
https://chatgpt.com/codex/tasks/task_e_6840b1058430832b85d4250ed354a1b6