### PR TITLE
Fix hanging profile page test

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -557,6 +557,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mockito:
+    dependency: transitive
+    description:
+      name: mockito
+      sha256: f99d8d072e249f719a5531735d146d8cf04c580d93920b04de75bef6dfb2daf6
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.4.5"
+  network_image_mock:
+    dependency: "direct dev"
+    description:
+      name: network_image_mock
+      sha256: "855cdd01d42440e0cffee0d6c2370909fc31b3bcba308a59829f24f64be42db7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   google_sign_in_mocks: ^0.3.0
+  network_image_mock: ^2.1.1
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
 import 'package:hive/hive.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/profile_page.dart';
@@ -9,6 +10,7 @@ void main() {
   late Directory dir;
 
   setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
     Hive.registerAdapter(UserAdapter());
@@ -21,47 +23,49 @@ void main() {
   });
 
   testWidgets('Edits persist and reload', (tester) async {
-    final box = Hive.box<User>('userBox');
-    await box.put('currentUser', User(name: 'Old', email: 'old@test.com'));
+    await mockNetworkImagesFor(() async {
+      final box = Hive.box<User>('userBox');
+      await box.put('currentUser', User(name: 'Old', email: 'old@test.com'));
 
-    await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+      await tester.pump();
 
-    Finder nameField() => find.bySemanticsLabel('Name');
-    Finder emailField() => find.bySemanticsLabel('Email');
-    Finder avatarField() => find.bySemanticsLabel('Avatar URL');
+      Finder nameField() => find.bySemanticsLabel('Name');
+      Finder emailField() => find.bySemanticsLabel('Email');
+      Finder avatarField() => find.bySemanticsLabel('Avatar URL');
 
-    expect(tester.widget<TextFormField>(nameField()).controller!.text, 'Old');
-    expect(
-      tester.widget<TextFormField>(emailField()).controller!.text,
-      'old@test.com',
-    );
+      expect(tester.widget<TextFormField>(nameField()).controller!.text, 'Old');
+      expect(
+        tester.widget<TextFormField>(emailField()).controller!.text,
+        'old@test.com',
+      );
 
-    await tester.enterText(nameField(), 'New Name');
-    await tester.enterText(emailField(), 'new@example.com');
-    await tester.enterText(avatarField(), 'http://example.com/avatar.png');
-    await tester.tap(find.text('Save'));
-    await tester.pumpAndSettle();
+      await tester.enterText(nameField(), 'New Name');
+      await tester.enterText(emailField(), 'new@example.com');
+      await tester.enterText(avatarField(), 'http://example.com/avatar.png');
+      await tester.tap(find.text('Save'));
+      await tester.pump();
 
-    final saved = box.get('currentUser')!;
-    expect(saved.name, 'New Name');
-    expect(saved.email, 'new@example.com');
-    expect(saved.avatarUrl, 'http://example.com/avatar.png');
+      final saved = box.get('currentUser')!;
+      expect(saved.name, 'New Name');
+      expect(saved.email, 'new@example.com');
+      expect(saved.avatarUrl, 'http://example.com/avatar.png');
 
-    await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+      await tester.pump();
 
-    expect(
-      tester.widget<TextFormField>(nameField()).controller!.text,
-      'New Name',
-    );
-    expect(
-      tester.widget<TextFormField>(emailField()).controller!.text,
-      'new@example.com',
-    );
-    expect(
-      tester.widget<TextFormField>(avatarField()).controller!.text,
-      'http://example.com/avatar.png',
-    );
+      expect(
+        tester.widget<TextFormField>(nameField()).controller!.text,
+        'New Name',
+      );
+      expect(
+        tester.widget<TextFormField>(emailField()).controller!.text,
+        'new@example.com',
+      );
+      expect(
+        tester.widget<TextFormField>(avatarField()).controller!.text,
+        'http://example.com/avatar.png',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- mock network images in `profile_page_test.dart`
- ensure widget binding is initialised
- add `network_image_mock` dev dependency

## Testing
- `flutter test test/sample_test.dart`
- `flutter test test/profile_page_test.dart --timeout=20s` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68416e9bfbd8832bb75b3b65af2879c8