### PR TITLE
Add bulletin board feature

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -49,7 +49,8 @@ class User {
   factory User.fromJson(Map<String, dynamic> json) => User.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
   String toJsonString() => jsonEncode(toJson());
-  factory User.fromJsonString(String source) => User.fromMap(jsonDecode(source));
+  factory User.fromJsonString(String source) =>
+      User.fromMap(jsonDecode(source));
 }
 
 @HiveType(typeId: 1)
@@ -96,10 +97,12 @@ class MaintenanceRequest {
     'status': status,
   };
 
-  factory MaintenanceRequest.fromJson(Map<String, dynamic> json) => MaintenanceRequest.fromMap(json);
+  factory MaintenanceRequest.fromJson(Map<String, dynamic> json) =>
+      MaintenanceRequest.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
   String toJsonString() => jsonEncode(toJson());
-  factory MaintenanceRequest.fromJsonString(String source) => MaintenanceRequest.fromMap(jsonDecode(source));
+  factory MaintenanceRequest.fromJsonString(String source) =>
+      MaintenanceRequest.fromMap(jsonDecode(source));
 }
 
 @HiveType(typeId: 2)
@@ -142,7 +145,8 @@ class Message {
   factory Message.fromJson(Map<String, dynamic> json) => Message.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
   String toJsonString() => jsonEncode(toJson());
-  factory Message.fromJsonString(String source) => Message.fromMap(jsonDecode(source));
+  factory Message.fromJsonString(String source) =>
+      Message.fromMap(jsonDecode(source));
 }
 
 @HiveType(typeId: 3)
@@ -171,8 +175,7 @@ class CalendarEvent {
     title: map['title'] as String,
     date: _parseDate(map['date']),
     description: map['description'] as String?,
-    attendees:
-        (map['attendees'] as List<dynamic>? ?? const []).cast<int>(),
+    attendees: (map['attendees'] as List<dynamic>? ?? const []).cast<int>(),
   );
 
   Map<String, dynamic> toMap() => {
@@ -183,10 +186,12 @@ class CalendarEvent {
     'attendees': attendees,
   };
 
-  factory CalendarEvent.fromJson(Map<String, dynamic> json) => CalendarEvent.fromMap(json);
+  factory CalendarEvent.fromJson(Map<String, dynamic> json) =>
+      CalendarEvent.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
   String toJsonString() => jsonEncode(toJson());
-  factory CalendarEvent.fromJsonString(String source) => CalendarEvent.fromMap(jsonDecode(source));
+  factory CalendarEvent.fromJsonString(String source) =>
+      CalendarEvent.fromMap(jsonDecode(source));
 }
 
 @HiveType(typeId: 4)
@@ -246,8 +251,9 @@ class Item {
         : (map['isFree'] as int) == 1,
     category: map['category'] is int
         ? ItemCategory.values[map['category'] as int]
-        : ItemCategory.values
-            .firstWhere((e) => e.name == map['category'] as String),
+        : ItemCategory.values.firstWhere(
+            (e) => e.name == map['category'] as String,
+          ),
     createdAt: _parseDate(map['createdAt']),
   );
 
@@ -266,5 +272,31 @@ class Item {
   factory Item.fromJson(Map<String, dynamic> json) => Item.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
   String toJsonString() => jsonEncode(toJson());
-  factory Item.fromJsonString(String source) => Item.fromMap(jsonDecode(source));
+  factory Item.fromJsonString(String source) =>
+      Item.fromMap(jsonDecode(source));
+}
+
+class BulletinPost {
+  final int? id;
+  final String content;
+  final DateTime date;
+
+  BulletinPost({this.id, required this.content, DateTime? date})
+    : date = date ?? DateTime.now();
+
+  factory BulletinPost.fromMap(Map<String, dynamic> map) => BulletinPost(
+    id: map['id'] as int?,
+    content: map['content'] as String,
+    date: _parseDate(map['date']),
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'content': content,
+    'date': date.toIso8601String(),
+  };
+
+  factory BulletinPost.fromJson(Map<String, dynamic> json) =>
+      BulletinPost.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
 }

--- a/lib/pages/bulletin_board_page.dart
+++ b/lib/pages/bulletin_board_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import '../models/models.dart';
+import '../services/bulletin_service.dart';
+
+class BulletinBoardPage extends StatefulWidget {
+  final BulletinService? service;
+  const BulletinBoardPage({super.key, this.service});
+
+  @override
+  State<BulletinBoardPage> createState() => _BulletinBoardPageState();
+}
+
+class _BulletinBoardPageState extends State<BulletinBoardPage> {
+  late final BulletinService _service;
+  final TextEditingController _textCtrl = TextEditingController();
+  List<BulletinPost> _posts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? BulletinService();
+    _loadPosts();
+  }
+
+  Future<void> _loadPosts() async {
+    final posts = await _service.fetchPosts();
+    if (!mounted) return;
+    setState(() => _posts = posts);
+  }
+
+  Future<void> _submit() async {
+    final text = _textCtrl.text.trim();
+    if (text.isEmpty) return;
+    final post = await _service.addPost(BulletinPost(content: text));
+    if (!mounted) return;
+    setState(() => _posts.add(post));
+    _textCtrl.clear();
+  }
+
+  @override
+  void dispose() {
+    _textCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Bulletin Board'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _posts.isEmpty
+                ? const Center(child: Text('No posts yet.'))
+                : ListView.separated(
+                    itemCount: _posts.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (_, i) {
+                      final p = _posts[i];
+                      return ListTile(
+                        title: Text(p.content),
+                        subtitle: Text(
+                          '${p.date.day}/${p.date.month}/${p.date.year}',
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _textCtrl,
+                    decoration: const InputDecoration(
+                      hintText: 'Write a post...',
+                    ),
+                  ),
+                ),
+                IconButton(icon: const Icon(Icons.send), onPressed: _submit),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -6,6 +6,7 @@ import 'admin/admin_home_page.dart';
 import 'map_page.dart';
 import 'profile_page.dart';
 import 'post_item_page.dart';
+import 'bulletin_board_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -234,6 +235,17 @@ class DashboardPage extends StatelessWidget {
                   label: 'Exchange',
                   colorScheme: colorScheme,
                   onTap: () => _navigate(3),
+                ),
+                DashboardCard(
+                  icon: Icons.message,
+                  label: 'Bulletin',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const BulletinBoardPage(),
+                    ),
+                  ),
                 ),
                 DashboardCard(
                   icon: Icons.build,

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -1,0 +1,19 @@
+import '../models/models.dart';
+
+class BulletinService {
+  final List<BulletinPost> _posts = [];
+
+  Future<List<BulletinPost>> fetchPosts() async {
+    return List.unmodifiable(_posts);
+  }
+
+  Future<BulletinPost> addPost(BulletinPost post) async {
+    final newPost = BulletinPost(
+      id: _posts.length + 1,
+      content: post.content,
+      date: post.date,
+    );
+    _posts.add(newPost);
+    return newPost;
+  }
+}

--- a/test/bulletin_board_page_test.dart
+++ b/test/bulletin_board_page_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/pages/bulletin_board_page.dart';
+import 'package:oly_app/services/bulletin_service.dart';
+import 'package:oly_app/models/models.dart';
+
+class FakeBulletinService extends BulletinService {
+  final List<BulletinPost> posts;
+  FakeBulletinService(this.posts);
+  @override
+  Future<List<BulletinPost>> fetchPosts() async => posts;
+  @override
+  Future<BulletinPost> addPost(BulletinPost post) async {
+    final newPost = BulletinPost(
+      id: posts.length + 1,
+      content: post.content,
+      date: post.date,
+    );
+    posts.add(newPost);
+    return newPost;
+  }
+}
+
+void main() {
+  testWidgets('Existing posts are shown', (tester) async {
+    final service = FakeBulletinService([
+      BulletinPost(id: 1, content: 'Hello', date: DateTime.now()),
+    ]);
+    await tester.pumpWidget(
+      MaterialApp(home: BulletinBoardPage(service: service)),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Hello'), findsOneWidget);
+  });
+
+  testWidgets('Submitting adds new post', (tester) async {
+    final service = FakeBulletinService([]);
+    await tester.pumpWidget(
+      MaterialApp(home: BulletinBoardPage(service: service)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'New Post');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    expect(find.text('New Post'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce BulletinBoardPage with ability to list and create posts
- implement simple in‑memory BulletinService
- link bulletin board from dashboard
- cover bulletin board behaviour with widget tests

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68418f2e9c48832bb0cacbad90226c1c