### PR TITLE
Add booking page and service

### DIFF
--- a/lib/pages/booking_page.dart
+++ b/lib/pages/booking_page.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import '../services/booking_service.dart';
+
+class BookingPage extends StatefulWidget {
+  final BookingService? service;
+  const BookingPage({super.key, this.service});
+
+  @override
+  State<BookingPage> createState() => _BookingPageState();
+}
+
+class _BookingPageState extends State<BookingPage> {
+  late final BookingService _service;
+  final Map<DateTime, List<DateTime>> _slots = {};
+  DateTime _focusedDay = DateTime.now();
+  DateTime _selectedDay = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? BookingService();
+    _loadSlots();
+  }
+
+  Future<void> _loadSlots() async {
+    try {
+      final slots = await _service.fetchAvailableTimes();
+      if (!mounted) return;
+      setState(() {
+        _slots.clear();
+        for (final s in slots) {
+          final key = DateTime(s.year, s.month, s.day);
+          _slots.putIfAbsent(key, () => []).add(s);
+        }
+      });
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to load slots')),
+      );
+    }
+  }
+
+  List<DateTime> _getSlotsForDay(DateTime day) {
+    return _slots[DateTime(day.year, day.month, day.day)] ?? [];
+  }
+
+  void _onDaySelected(DateTime selectedDay, DateTime focusedDay) {
+    setState(() {
+      _selectedDay = selectedDay;
+      _focusedDay = focusedDay;
+    });
+  }
+
+  Future<void> _book(DateTime slot) async {
+    final controller = TextEditingController();
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Book Slot'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Book'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      try {
+        await _service.createBooking(slot, controller.text);
+        if (!mounted) return;
+        setState(() {
+          final key = DateTime(slot.year, slot.month, slot.day);
+          _slots[key]?.remove(slot);
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Booking confirmed')),
+        );
+      } catch (_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to create booking')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final slots = _getSlotsForDay(_selectedDay);
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: Column(
+        children: [
+          TableCalendar(
+            firstDay: DateTime.utc(2020),
+            lastDay: DateTime.utc(2030),
+            focusedDay: _focusedDay,
+            selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+            onDaySelected: _onDaySelected,
+            headerStyle: HeaderStyle(
+              formatButtonVisible: false,
+              titleCentered: true,
+              leftChevronIcon: Icon(Icons.chevron_left, color: cs.primary),
+              rightChevronIcon: Icon(Icons.chevron_right, color: cs.primary),
+              titleTextStyle: TextStyle(
+                color: cs.primary,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            calendarStyle: CalendarStyle(
+              todayDecoration: BoxDecoration(
+                color: cs.primaryContainer,
+                shape: BoxShape.circle,
+              ),
+              selectedDecoration: BoxDecoration(
+                color: cs.secondary,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: slots.isEmpty
+                ? const Center(child: Text('No slots available.'))
+                : ListView.builder(
+                    itemCount: slots.length,
+                    itemBuilder: (ctx, i) {
+                      final slot = slots[i];
+                      final label =
+                          '${slot.hour.toString().padLeft(2, '0')}:${slot.minute.toString().padLeft(2, '0')}';
+                      return ListTile(
+                        title: Text(label),
+                        trailing: TextButton(
+                          onPressed: () => _book(slot),
+                          child: const Text('Book'),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'calendar_page.dart';
 import 'item_exchange_page.dart';
 import 'maintenance_page.dart';
+import 'booking_page.dart';
 import 'admin/admin_home_page.dart';
 import 'map_page.dart';
 import 'profile_page.dart';
@@ -12,6 +13,7 @@ import '../services/event_service.dart';
 
 class MainPage extends StatefulWidget {
   final CalendarPage? calendarPage;
+  final BookingPage? bookingPage;
   final MaintenancePage? maintenancePage;
   final ItemExchangePage? itemExchangePage;
   final bool isAdmin;
@@ -20,6 +22,7 @@ class MainPage extends StatefulWidget {
     super.key,
     this.calendarPage,
     this.maintenancePage,
+    this.bookingPage,
     this.itemExchangePage,
     this.isAdmin = false,
     this.onLogout,
@@ -36,6 +39,7 @@ class _MainPageState extends State<MainPage> {
     'Dashboard',
     'Map',
     'Calendar',
+    'Booking',
     'Item Exchange',
     'Maintenance',
   ];
@@ -49,6 +53,7 @@ class _MainPageState extends State<MainPage> {
       DashboardPage(onNavigate: _onDashboardNavigate, isAdmin: widget.isAdmin),
       const MapPage(),
       widget.calendarPage ?? const CalendarPage(),
+      widget.bookingPage ?? const BookingPage(),
       widget.itemExchangePage ?? const ItemExchangePage(),
       widget.maintenancePage ?? const MaintenancePage(),
     ];
@@ -104,6 +109,10 @@ class _MainPageState extends State<MainPage> {
             label: 'Calendar',
           ),
           NavigationDestination(
+            icon: Icon(Icons.schedule),
+            label: 'Booking',
+          ),
+          NavigationDestination(
             icon: Icon(Icons.swap_horiz),
             label: 'Exchange',
           ),
@@ -122,6 +131,8 @@ class _MainPageState extends State<MainPage> {
       case 2:
         return Icons.event;
       case 3:
+        return Icons.book_online;
+      case 4:
         return Icons.add_shopping_cart;
       default:
         return Icons.add;
@@ -150,6 +161,8 @@ class _MainPageState extends State<MainPage> {
           });
         };
       case 3:
+        return null;
+      case 4:
         return () {
           Navigator.push(
             context,
@@ -231,10 +244,16 @@ class DashboardPage extends StatelessWidget {
                   onTap: () => _navigate(2),
                 ),
                 DashboardCard(
+                  icon: Icons.schedule,
+                  label: 'Booking',
+                  colorScheme: colorScheme,
+                  onTap: () => _navigate(3),
+                ),
+                DashboardCard(
                   icon: Icons.swap_horiz,
                   label: 'Exchange',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(3),
+                  onTap: () => _navigate(4),
                 ),
                 DashboardCard(
                   icon: Icons.message,
@@ -251,7 +270,7 @@ class DashboardPage extends StatelessWidget {
                   icon: Icons.build,
                   label: 'Maintenance',
                   colorScheme: colorScheme,
-                  onTap: () => _navigate(4),
+                  onTap: () => _navigate(5),
                 ),
                 if (isAdmin)
                   DashboardCard(

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -1,0 +1,19 @@
+import 'api_service.dart';
+
+class BookingService extends ApiService {
+  BookingService({super.client});
+
+  Future<List<DateTime>> fetchAvailableTimes() async {
+    return get('/bookings/slots', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list.map((e) => DateTime.parse(e as String)).toList();
+    });
+  }
+
+  Future<void> createBooking(DateTime time, String name) async {
+    await post('/bookings', {
+      'time': time.toIso8601String(),
+      'name': name,
+    }, (_) => null);
+  }
+}

--- a/test/booking_page_test.dart
+++ b/test/booking_page_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/pages/booking_page.dart';
+import 'package:oly_app/services/booking_service.dart';
+
+class FakeBookingService extends BookingService {
+  final List<DateTime> slots;
+  FakeBookingService(this.slots);
+
+  @override
+  Future<List<DateTime>> fetchAvailableTimes() async => slots;
+
+  @override
+  Future<void> createBooking(DateTime time, String name) async {
+    slots.remove(time);
+  }
+}
+
+class ErrorBookingService extends BookingService {
+  @override
+  Future<List<DateTime>> fetchAvailableTimes() async => throw Exception('fail');
+}
+
+void main() {
+  testWidgets('Booking a slot removes it from list', (tester) async {
+    final now = DateTime.now();
+    final slot = DateTime(now.year, now.month, now.day, 10);
+    final service = FakeBookingService([slot]);
+    await tester.pumpWidget(MaterialApp(home: BookingPage(service: service)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('10:00'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Book').first);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'John');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Book'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('10:00'), findsNothing);
+    expect(find.text('Booking confirmed'), findsOneWidget);
+  });
+
+  testWidgets('Shows snackbar on load error', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: BookingPage(service: ErrorBookingService())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load slots'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `BookingPage` with calendar and booking form
- create `BookingService` for fetching slots and creating bookings
- integrate booking screen into main navigation/dashboard
- add widget tests for booking flow

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841925119d8832b9a9eadf4e6787aaa