### PR TITLE
Add search, filter and route display to MapPage

### DIFF
--- a/lib/pages/map_page.dart
+++ b/lib/pages/map_page.dart
@@ -18,61 +18,178 @@ class MapPage extends StatefulWidget {
 
 class _MapPageState extends State<MapPage> {
   late final MapService _service;
-  List<MapPin> _pins = [];
+  List<MapPin> _allPins = [];
+  List<MapPin> _visiblePins = [];
+  final TextEditingController _searchCtrl = TextEditingController();
+  Set<MapPinCategory> _selectedCats = {};
+  List<MapPin> _selectedPins = [];
+  List<LatLng>? _route;
 
   @override
   void initState() {
     super.initState();
     _service = widget.service ?? MapService();
+    _selectedCats = Set.from(MapPinCategory.values);
+    _route = widget.route;
     _loadPins();
   }
 
   Future<void> _loadPins() async {
     final pins = await _service.fetchPins();
-    setState(() => _pins = pins);
+    setState(() {
+      _allPins = pins;
+      _applyFilters();
+    });
+  }
+
+  void _applyFilters() {
+    final query = _searchCtrl.text.toLowerCase();
+    setState(() {
+      _visiblePins =
+          _allPins.where((p) {
+            final matchesText = p.title.toLowerCase().contains(query);
+            final matchesCat = _selectedCats.contains(p.category);
+            return matchesText && matchesCat;
+          }).toList();
+    });
+  }
+
+  Future<void> _onPinTap(MapPin pin) async {
+    setState(() {
+      if (_selectedPins.contains(pin)) {
+        _selectedPins.remove(pin);
+      } else {
+        _selectedPins.add(pin);
+        if (_selectedPins.length > 2) {
+          _selectedPins.removeAt(0);
+        }
+      }
+    });
+    await _updateRoute();
+  }
+
+  Future<void> _updateRoute() async {
+    if (_selectedPins.length == 2) {
+      final start = LatLng(_selectedPins[0].lat, _selectedPins[0].lon);
+      final end = LatLng(_selectedPins[1].lat, _selectedPins[1].lon);
+      final r = await _service.fetchRoute(start, end);
+      setState(() => _route = r);
+    } else {
+      setState(() => _route = null);
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: FlutterMap(
-        options: MapOptions(
-          initialCenter: const LatLng(48.1740, 11.5475),
-          initialZoom: 16,
-        ),
+      body: Stack(
         children: [
-          if (widget.loadTiles)
-            TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-              userAgentPackageName: 'com.example.olyapp',
-              tileProvider: _safeProvider(),
+          FlutterMap(
+            options: MapOptions(
+              initialCenter: const LatLng(48.1740, 11.5475),
+              initialZoom: 16,
             ),
-          MarkerLayer(
-            markers: _pins
-                .map(
-                  (p) => Marker(
-                    width: 40,
-                    height: 40,
-                    point: LatLng(p.lat, p.lon),
-                    child: Icon(
-                      Icons.location_pin,
-                      color: _colorFor(p.category),
-                      size: 32,
+            children: [
+              if (widget.loadTiles)
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  userAgentPackageName: 'com.example.olyapp',
+                  tileProvider: _safeProvider(),
+                ),
+              MarkerLayer(
+                markers:
+                    _visiblePins
+                        .map(
+                          (p) => Marker(
+                            width: 40,
+                            height: 40,
+                            point: LatLng(p.lat, p.lon),
+                            child: GestureDetector(
+                              key: ValueKey(p.id),
+                              onTap: () => _onPinTap(p),
+                              child: Semantics(
+                                label: p.id,
+                                child: Icon(
+                                  Icons.location_pin,
+                                  color: _colorFor(p.category),
+                                  size: 32,
+                                ),
+                              ),
+                            ),
+                          ),
+                        )
+                        .toList(),
+              ),
+              if (_route != null)
+                PolylineLayer(
+                  polylines: [
+                    Polyline(
+                      points: _route!,
+                      strokeWidth: 4,
+                      color: Colors.orange,
+                    ),
+                  ],
+                ),
+            ],
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: _searchCtrl,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.search),
+                      hintText: 'Search…',
+                      filled: true,
+                      fillColor:
+                          Theme.of(context).colorScheme.surfaceContainerHighest,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    onChanged: (_) => _applyFilters(),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    height: 36,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: MapPinCategory.values.length,
+                      separatorBuilder: (_, __) => const SizedBox(width: 8),
+                      itemBuilder: (_, i) {
+                        final cat = MapPinCategory.values[i];
+                        final selected = _selectedCats.contains(cat);
+                        return FilterChip(
+                          label: Text(_catName(cat)),
+                          selected: selected,
+                          onSelected: (_) {
+                            setState(() {
+                              if (selected) {
+                                _selectedCats.remove(cat);
+                              } else {
+                                _selectedCats.add(cat);
+                              }
+                              _applyFilters();
+                            });
+                          },
+                        );
+                      },
                     ),
                   ),
-                )
-                .toList(),
-          ),
-          if (widget.route != null)
-            PolylineLayer(
-              polylines: [
-                Polyline(
-                  points: widget.route!,
-                  strokeWidth: 4,
-                  color: Colors.orange,
-                ),
-              ],
+                ],
+              ),
             ),
+          ),
         ],
       ),
     );
@@ -93,9 +210,16 @@ class _MapPageState extends State<MapPage> {
     }
   }
 
+  String _catName(MapPinCategory category) {
+    final name = category.name;
+    return name[0].toUpperCase() + name.substring(1);
+  }
+
   TileProvider _safeProvider() {
     try {
-      return FMTCTileProvider(stores: {'mapTiles': BrowseStoreStrategy.readUpdateCreate});
+      return FMTCTileProvider(
+        stores: {'mapTiles': BrowseStoreStrategy.readUpdateCreate},
+      );
     } catch (_) {
       return NetworkTileProvider();
     }

--- a/test/map_page_test.dart
+++ b/test/map_page_test.dart
@@ -4,6 +4,7 @@ import 'package:oly_app/models/map_pin.dart';
 import 'package:oly_app/pages/map_page.dart';
 import 'package:oly_app/services/map_service.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
 
 class FakeMapService extends MapService {
   final List<MapPin> pins;
@@ -12,33 +13,53 @@ class FakeMapService extends MapService {
   Future<List<MapPin>> fetchPins() async => pins;
 }
 
+class RouteMapService extends FakeMapService {
+  bool called = false;
+  RouteMapService(super.pins);
+
+  @override
+  Future<List<LatLng>> fetchRoute(LatLng start, LatLng end) async {
+    called = true;
+    return [start, end];
+  }
+}
+
 void main() {
+  int markerCount(WidgetTester tester) {
+    final layer = tester.widget<MarkerLayer>(find.byType(MarkerLayer));
+    return layer.markers.length;
+  }
+
   testWidgets('Map loads and displays pins', (tester) async {
     final service = FakeMapService([
       MapPin(
-          id: '1',
-          title: 'Test',
-          lat: 0,
-          lon: 0,
-          category: MapPinCategory.building),
+        id: '1',
+        title: 'Test',
+        lat: 0,
+        lon: 0,
+        category: MapPinCategory.building,
+      ),
       MapPin(
-          id: '2',
-          title: 'Another',
-          lat: 1,
-          lon: 1,
-          category: MapPinCategory.venue),
+        id: '2',
+        title: 'Another',
+        lat: 1,
+        lon: 1,
+        category: MapPinCategory.venue,
+      ),
       MapPin(
-          id: '3',
-          title: 'Playground',
-          lat: 2,
-          lon: 2,
-          category: MapPinCategory.recreation),
+        id: '3',
+        title: 'Playground',
+        lat: 2,
+        lon: 2,
+        category: MapPinCategory.recreation,
+      ),
       MapPin(
-          id: '4',
-          title: 'Cafe',
-          lat: 3,
-          lon: 3,
-          category: MapPinCategory.food),
+        id: '4',
+        title: 'Cafe',
+        lat: 3,
+        lon: 3,
+        category: MapPinCategory.food,
+      ),
     ]);
 
     await tester.pumpWidget(
@@ -47,9 +68,60 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(FlutterMap), findsOneWidget);
-    final markerLayerFinder = find.byType(MarkerLayer);
-    expect(markerLayerFinder, findsOneWidget);
-    final layer = tester.widget<MarkerLayer>(markerLayerFinder);
-    expect(layer.markers.length, 4);
+    expect(markerCount(tester), 4);
+  });
+
+  testWidgets('Search text or category filters pins', (tester) async {
+    final service = FakeMapService([
+      MapPin(
+        id: '1',
+        title: 'Dorm',
+        lat: 0,
+        lon: 0,
+        category: MapPinCategory.building,
+      ),
+      MapPin(
+        id: '2',
+        title: 'Cafe',
+        lat: 1,
+        lon: 1,
+        category: MapPinCategory.food,
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: MapPage(service: service, loadTiles: false)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(markerCount(tester), 2);
+
+    await tester.enterText(find.byType(TextField), 'cafe');
+    await tester.pumpAndSettle();
+    expect(markerCount(tester), 1);
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Food'));
+    await tester.pumpAndSettle();
+    expect(markerCount(tester), 1); // only building pin remains
+  });
+
+  testWidgets('Provided route draws polyline', (tester) async {
+    final service = FakeMapService([]);
+    final route = [const LatLng(0, 0), const LatLng(1, 1)];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MapPage(service: service, loadTiles: false, route: route),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final polyFinder = find.byType(PolylineLayer);
+    expect(polyFinder, findsOneWidget);
+    final layer = tester.widget<PolylineLayer>(polyFinder);
+    expect(layer.polylines.first.points, route);
   });
 }


### PR DESCRIPTION
## Summary
- enhance `MapPage` with search bar, filter chips and routing logic
- draw route polyline when pins selected or provided via parameter
- test map page search filtering and polyline drawing

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68419264bb64832ba1a11eea7bec8193