### PR TITLE
Add item edit/delete flows

### DIFF
--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -47,4 +47,19 @@ class ItemService extends ApiService {
   Future<void> requestItem(int itemId) async {
     await post('/items/$itemId/request', {}, (_) => null);
   }
+
+  /// Updates an existing [item].
+  Future<Item> updateItem(Item item) async {
+    if (item.id == null) throw ArgumentError('Item id required');
+    return post(
+      '/items/${item.id}',
+      item.toJson(),
+      (json) => Item.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Deletes the item with the given [id].
+  Future<void> deleteItem(int id) async {
+    await post('/items/$id/delete', {}, (_) => null);
+  }
 }

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -5,15 +5,47 @@ import 'package:oly_app/pages/item_exchange_page.dart';
 import 'package:oly_app/pages/item_detail_page.dart';
 import 'package:oly_app/services/item_service.dart';
 import 'package:oly_app/widgets/item_card.dart';
+import 'package:hive/hive.dart';
+import 'dart:io';
 
 class FakeItemService extends ItemService {
   final List<Item> items;
+  Item? updated;
+  int? deletedId;
   FakeItemService(this.items);
   @override
   Future<List<Item>> fetchItems() async => items;
+
+  @override
+  Future<Item> updateItem(Item item) async {
+    updated = item;
+    return item;
+  }
+
+  @override
+  Future<void> deleteItem(int id) async {
+    deletedId = id;
+  }
 }
 
 void main() {
+  late Directory dir;
+
+  setUpAll(() {
+    Hive.registerAdapter(UserAdapter());
+  });
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox<User>('userBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
   testWidgets('Search text or category filters items', (tester) async {
     final service = FakeItemService([
       Item(ownerId: 1, title: 'Dart Book', category: ItemCategory.books),
@@ -61,5 +93,56 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(ItemDetailPage), findsOneWidget);
+  });
+
+  testWidgets('Owner can edit an item', (tester) async {
+    await tester.runAsync(() async {
+      await Hive.box<User>('userBox')
+          .put('currentUser', User(id: 1, name: 'Owner', email: 'o@test.com'));
+
+    final item = Item(id: 1, ownerId: 1, title: 'Old', category: ItemCategory.books);
+    final service = FakeItemService([item]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ItemDetailPage(item: item, service: service),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('editItem')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('editItem')));
+    await tester.pumpAndSettle();
+
+    // title field prefilled
+    final titleEditable = tester.widget<EditableText>(find.descendant(
+        of: find.byType(TextFormField).first, matching: find.byType(EditableText)));
+    expect(titleEditable.controller.text, 'Old');
+
+    await tester.enterText(find.byType(TextFormField).first, 'New');
+    await tester.tap(find.text('Update Item'));
+    await tester.pump();
+
+    expect(service.updated?.title, 'New');
+
+    });
+  });
+
+  testWidgets('Owner can delete an item', (tester) async {
+    await tester.runAsync(() async {
+      await Hive.box<User>('userBox')
+          .put('currentUser', User(id: 1, name: 'Owner', email: 'o@test.com'));
+
+    final item = Item(id: 1, ownerId: 1, title: 'Del', category: ItemCategory.books);
+    final service = FakeItemService([item]);
+
+    await tester.pumpWidget(MaterialApp(
+      home: ItemDetailPage(item: item, service: service),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('deleteItem')));
+    await tester.pump();
+
+    expect(service.deletedId, 1);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- support updating and deleting marketplace items via API
- allow editing items in PostItemPage and show actions when viewing your own item
- add widget tests for editing and deleting items

## Testing
- `flutter analyze`
- `flutter test --timeout=60s`


------
https://chatgpt.com/codex/tasks/task_e_68419a94a938832babdd56a6a7613868