### PR TITLE
Add favorites functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ void main() async {
   await Hive.openBox('itemsBox');
   await Hive.openBox('userBox');
   await Hive.openBox('authBox');
+  await Hive.openBox('favoritesBox');
 
   // Initialize tile caching store when not running tests
   if (!Platform.environment.containsKey('FLUTTER_TEST')) {
@@ -90,9 +91,10 @@ class _OlyAppState extends State<OlyApp> {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.white38),
         useMaterial3: true,
       ),
-      home: _loggedIn
-          ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
-          : LoginPage(onLoginSuccess: _handleLogin),
+      home:
+          _loggedIn
+              ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
+              : LoginPage(onLoginSuccess: _handleLogin),
     );
   }
 }

--- a/test/item_chat_test.dart
+++ b/test/item_chat_test.dart
@@ -4,6 +4,8 @@ import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/item_detail_page.dart';
 import 'package:oly_app/pages/item_chat_page.dart';
 import 'package:oly_app/services/item_service.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
 
 class FakeItemService extends ItemService {
   FakeItemService();
@@ -14,6 +16,20 @@ class FakeItemService extends ItemService {
 }
 
 void main() {
+  late Directory dir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('favoritesBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
   testWidgets('Chat Owner opens ItemChatPage', (tester) async {
     final item = Item(id: 1, ownerId: 1, title: 'Chair');
     await tester.pumpWidget(

--- a/test/item_request_test.dart
+++ b/test/item_request_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/item_detail_page.dart';
 import 'package:oly_app/services/item_service.dart';
+import 'dart:io';
+import 'package:hive/hive.dart';
 
 class FakeItemService extends ItemService {
   bool called = false;
@@ -14,10 +16,28 @@ class FakeItemService extends ItemService {
 }
 
 void main() {
-  testWidgets('Request button triggers service and shows snackbar', (tester) async {
+  late Directory dir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('favoritesBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('Request button triggers service and shows snackbar', (
+    tester,
+  ) async {
     final service = FakeItemService();
     final item = Item(id: 1, ownerId: 1, title: 'Chair');
-    await tester.pumpWidget(MaterialApp(home: ItemDetailPage(item: item, service: service)));
+    await tester.pumpWidget(
+      MaterialApp(home: ItemDetailPage(item: item, service: service)),
+    );
 
     await tester.tap(find.text('Request'));
     await tester.pump();


### PR DESCRIPTION
## Summary
- persist favorites in a new Hive box
- toggle favorites from ItemDetailPage and ItemExchangePage
- allow filtering only favorite items
- add tests for favorite toggling and filter
- update existing tests to open the new box

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841a3448fb0832b9134f864a791b1d4