### PR TITLE
Implement Item API and models

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const authRouter = require('../routes/auth');
 const eventsRouter = require('../routes/events');
+const itemsRouter = require('../routes/items');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -9,5 +10,6 @@ router.get('/', (req, res) => {
 
 router.use('/auth', authRouter);
 router.use('/events', eventsRouter);
+router.use('/items', itemsRouter);
 
 module.exports = router;

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const ItemSchema = new mongoose.Schema({
+  ownerId: { type: Number, required: true },
+  title: { type: String, required: true },
+  description: String,
+  imageUrl: String,
+  price: Number,
+  isFree: { type: Boolean, default: false },
+  category: {
+    type: String,
+    enum: ['furniture', 'books', 'electronics', 'other'],
+    default: 'other'
+  },
+  createdAt: { type: Date, default: Date.now },
+  requested: { type: Boolean, default: false }
+});
+
+module.exports = mongoose.model('Item', ItemSchema);

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const MessageSchema = new mongoose.Schema({
+  requestId: { type: mongoose.Schema.Types.ObjectId, ref: 'Item', required: true },
+  senderId: { type: Number, required: true },
+  content: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Message', MessageSchema);

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const Item = require('../models/Item');
+const Message = require('../models/Message');
+
+const router = express.Router();
+
+// GET /items - list items
+router.get('/', async (req, res) => {
+  try {
+    const items = await Item.find();
+    res.json({ data: items });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /items - create item
+router.post('/', async (req, res) => {
+  try {
+    const item = await Item.create(req.body);
+    res.status(201).json({ data: item });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /items/:id/messages - list messages
+router.get('/:id/messages', async (req, res) => {
+  try {
+    const messages = await Message.find({ requestId: req.params.id });
+    res.json(messages);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /items/:id/messages - create message
+router.post('/:id/messages', async (req, res) => {
+  try {
+    const messageData = { ...req.body, requestId: req.params.id };
+    const message = await Message.create(messageData);
+    res.status(201).json(message);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /items/:id/request - mark as requested/claimed
+router.post('/:id/request', async (req, res) => {
+  try {
+    await Item.findByIdAndUpdate(req.params.id, { requested: true });
+    res.json({});
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /items/:id - update item
+router.post('/:id', async (req, res) => {
+  try {
+    const item = await Item.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
+    if (!item) return res.status(404).json({ error: 'Item not found' });
+    res.json({ data: item });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /items/:id/delete - delete item
+router.post('/:id/delete', async (req, res) => {
+  try {
+    await Item.findByIdAndDelete(req.params.id);
+    res.json({});
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Item and Message mongoose models
- implement `/items` routes for CRUD, messages, and requests
- register items router with the API router

## Testing
- `npm --prefix server install`
- `npm --prefix server test`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6841add45254832bac03ff98a6b8c2e4