### PR TITLE
Add maintenance endpoints

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const authRouter = require('../routes/auth');
 const eventsRouter = require('../routes/events');
 const itemsRouter = require('../routes/items');
+const maintenanceRouter = require('../routes/maintenance');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -11,5 +12,6 @@ router.get('/', (req, res) => {
 router.use('/auth', authRouter);
 router.use('/events', eventsRouter);
 router.use('/items', itemsRouter);
+router.use('/maintenance', maintenanceRouter);
 
 module.exports = router;

--- a/server/models/MaintenanceRequest.js
+++ b/server/models/MaintenanceRequest.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const MaintenanceRequestSchema = new mongoose.Schema({
+  userId: { type: Number, required: true },
+  subject: { type: String, required: true },
+  description: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+  status: { type: String, default: 'open' },
+  imageUrl: String
+});
+
+module.exports = mongoose.model('MaintenanceRequest', MaintenanceRequestSchema);

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const MaintenanceRequest = require('../models/MaintenanceRequest');
+const Message = require('../models/Message');
+
+const router = express.Router();
+
+// GET /maintenance - list maintenance requests
+router.get('/', async (req, res) => {
+  try {
+    const requests = await MaintenanceRequest.find();
+    res.json({ data: requests });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /maintenance - create maintenance request
+router.post('/', async (req, res) => {
+  try {
+    const request = await MaintenanceRequest.create(req.body);
+    res.status(201).json({ data: request });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /maintenance/:id/messages - list messages for a request
+router.get('/:id/messages', async (req, res) => {
+  try {
+    const messages = await Message.find({ requestId: req.params.id });
+    res.json({ data: messages });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /maintenance/:id/messages - create message for a request
+router.post('/:id/messages', async (req, res) => {
+  try {
+    const messageData = { ...req.body, requestId: req.params.id };
+    const message = await Message.create(messageData);
+    res.status(201).json({ data: message });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /maintenance/:id - update status
+router.post('/:id', async (req, res) => {
+  try {
+    const request = await MaintenanceRequest.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!request) return res.status(404).json({ error: 'Request not found' });
+    res.json(request);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add MaintenanceRequest mongoose model
- create maintenance routes for CRUD endpoints
- mount maintenance router under `/api/maintenance`

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841b02e3b8c832b956a21a846fab1c9