### PR TITLE
Add booking routes and model

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -4,6 +4,7 @@ const authRouter = require('../routes/auth');
 const eventsRouter = require('../routes/events');
 const itemsRouter = require('../routes/items');
 const maintenanceRouter = require('../routes/maintenance');
+const bookingsRouter = require('../routes/bookings');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -13,5 +14,6 @@ router.use('/auth', authRouter);
 router.use('/events', eventsRouter);
 router.use('/items', itemsRouter);
 router.use('/maintenance', maintenanceRouter);
+router.use('/bookings', bookingsRouter);
 
 module.exports = router;

--- a/server/models/BookingSlot.js
+++ b/server/models/BookingSlot.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const BookingSlotSchema = new mongoose.Schema({
+  time: { type: Date, required: true, unique: true },
+  name: { type: String }
+});
+
+module.exports = mongoose.model('BookingSlot', BookingSlotSchema);

--- a/server/routes/bookings.js
+++ b/server/routes/bookings.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const BookingSlot = require('../models/BookingSlot');
+
+const router = express.Router();
+
+// GET /bookings/slots - list available booking slots
+router.get('/slots', async (req, res) => {
+  try {
+    const slots = await BookingSlot.find({ name: { $exists: false } }).sort('time');
+    res.json({ data: slots.map(s => s.time.toISOString()) });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /bookings - reserve a slot
+router.post('/', async (req, res) => {
+  const { time, name } = req.body;
+  if (!time || !name) return res.status(400).json({ error: 'time and name required' });
+
+  try {
+    const slot = await BookingSlot.findOneAndUpdate(
+      { time: new Date(time), name: { $exists: false } },
+      { name },
+      { new: true }
+    );
+
+    if (!slot) return res.status(400).json({ error: 'Slot unavailable' });
+    res.json({ data: slot });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create BookingSlot mongoose model
- add bookings API routes to list and reserve slots
- register bookings router

## Testing
- `flutter analyze`
- `flutter test`
- `npm test` (no tests)

------
https://chatgpt.com/codex/tasks/task_e_6841b28ae9c0832b844126e0dff8168b