### PR TITLE
Enable injecting http client into MapService

### DIFF
--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -5,6 +5,9 @@ import 'package:latlong2/latlong.dart';
 import '../models/map_pin.dart';
 
 class MapService {
+  MapService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
   Future<List<MapPin>> fetchPins() async {
     // In real implementation, fetch from API
     await Future.delayed(const Duration(milliseconds: 100));
@@ -50,7 +53,7 @@ class MapService {
   Future<List<LatLng>> fetchRoute(LatLng start, LatLng end) async {
     final url =
         'https://router.project-osrm.org/route/v1/foot/${start.longitude},${start.latitude};${end.longitude},${end.latitude}?overview=full&geometries=geojson';
-    final res = await http.get(Uri.parse(url));
+    final res = await _client.get(Uri.parse(url));
     if (res.statusCode == 200) {
       final data = jsonDecode(res.body) as Map<String, dynamic>;
       final coords = (data['routes'][0]['geometry']['coordinates'] as List)

--- a/test/services/map_service_route_test.dart
+++ b/test/services/map_service_route_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:oly_app/services/map_service.dart';
+
+void main() {
+  group('MapService.fetchRoute', () {
+    test('returns decoded coordinates', () async {
+      final coords = [
+        [0.0, 0.0],
+        [1.0, 1.0]
+      ];
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.host, 'router.project-osrm.org');
+        return http.Response(
+          jsonEncode({
+            'routes': [
+              {
+                'geometry': {'coordinates': coords}
+              }
+            ]
+          }),
+          200,
+        );
+      });
+
+      final service = MapService(client: mockClient);
+      final route =
+          await service.fetchRoute(const LatLng(0, 0), const LatLng(1, 1));
+
+      expect(route, [const LatLng(0, 0), const LatLng(1, 1)]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow `MapService` to accept an optional `http.Client`
- wire the injected client through `fetchRoute`
- add tests for `fetchRoute` using `MockClient`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841be254c64832b978732ce8e008e17