### PR TITLE
Add auth route tests

### DIFF
--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const apiRouter = require('../api');
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('Auth API', () => {
+  test('successful login returns token and user info', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@example.com', password: 'password' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token');
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body).toHaveProperty('user');
+    expect(res.body.user).toEqual({
+      id: 1,
+      name: 'Test User',
+      email: 'user@example.com',
+      avatarUrl: null,
+      isAdmin: false,
+    });
+  });
+
+  test('invalid credentials return HTTP 401', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@example.com', password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Invalid credentials' });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for auth/login route verifying successful and failed logins

## Testing
- `npm test` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6841c10c0ef4832b9c0ff2a4f4c0f643