### PR TITLE
Enable messages for multiple request types

### DIFF
--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,7 +1,16 @@
 const mongoose = require('mongoose');
 
 const MessageSchema = new mongoose.Schema({
-  requestId: { type: mongoose.Schema.Types.ObjectId, ref: 'Item', required: true },
+  requestType: {
+    type: String,
+    required: true,
+    enum: ['Item', 'MaintenanceRequest']
+  },
+  requestId: {
+    type: mongoose.Schema.Types.ObjectId,
+    refPath: 'requestType',
+    required: true
+  },
   senderId: { type: Number, required: true },
   content: { type: String, required: true },
   timestamp: { type: Date, default: Date.now }

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -27,7 +27,10 @@ router.post('/', async (req, res) => {
 // GET /items/:id/messages - list messages
 router.get('/:id/messages', async (req, res) => {
   try {
-    const messages = await Message.find({ requestId: req.params.id });
+    const messages = await Message.find({
+      requestId: req.params.id,
+      requestType: 'Item'
+    });
     res.json(messages);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -37,7 +40,11 @@ router.get('/:id/messages', async (req, res) => {
 // POST /items/:id/messages - create message
 router.post('/:id/messages', async (req, res) => {
   try {
-    const messageData = { ...req.body, requestId: req.params.id };
+    const messageData = {
+      ...req.body,
+      requestId: req.params.id,
+      requestType: 'Item'
+    };
     const message = await Message.create(messageData);
     res.status(201).json(message);
   } catch (err) {

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -27,7 +27,10 @@ router.post('/', async (req, res) => {
 // GET /maintenance/:id/messages - list messages for a request
 router.get('/:id/messages', async (req, res) => {
   try {
-    const messages = await Message.find({ requestId: req.params.id });
+    const messages = await Message.find({
+      requestId: req.params.id,
+      requestType: 'MaintenanceRequest'
+    });
     res.json({ data: messages });
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -37,7 +40,11 @@ router.get('/:id/messages', async (req, res) => {
 // POST /maintenance/:id/messages - create message for a request
 router.post('/:id/messages', async (req, res) => {
   try {
-    const messageData = { ...req.body, requestId: req.params.id };
+    const messageData = {
+      ...req.body,
+      requestId: req.params.id,
+      requestType: 'MaintenanceRequest'
+    };
     const message = await Message.create(messageData);
     res.status(201).json({ data: message });
   } catch (err) {

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -95,7 +95,12 @@ describe('Items API', () => {
 
   test('GET /items/:id/messages returns messages', async () => {
     const item = await Item.create({ ownerId: 1, title: 'Chair' });
-    await Message.create({ requestId: item._id, senderId: 2, content: 'Hi' });
+    await Message.create({
+      requestType: 'Item',
+      requestId: item._id,
+      senderId: 2,
+      content: 'Hi'
+    });
     const res = await request(app).get(`/api/items/${item._id}/messages`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
@@ -139,7 +144,12 @@ describe('Maintenance API', () => {
       subject: 'Leak',
       description: 'Water'
     });
-    await Message.create({ requestId: req._id, senderId: 2, content: 'Hi' });
+    await Message.create({
+      requestType: 'MaintenanceRequest',
+      requestId: req._id,
+      senderId: 2,
+      content: 'Hi'
+    });
     const res = await request(app).get(`/api/maintenance/${req._id}/messages`);
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);


### PR DESCRIPTION
## Summary
- allow messages to reference either `Item` or `MaintenanceRequest`
- set proper `requestType` when creating messages
- update tests for the new `requestType` field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c998c220832b9ff8efa6e99ce879