### PR TITLE
Fix event update response shape

### DIFF
--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -20,8 +20,12 @@ class EventService extends ApiService {
   }
 
   Future<CalendarEvent> updateEvent(CalendarEvent event) async {
-    return post('/events/${event.id}', event.toJson(),
-        (json) => CalendarEvent.fromJson(json as Map<String, dynamic>));
+    return post(
+      '/events/${event.id}',
+      event.toJson(),
+      (json) =>
+          CalendarEvent.fromJson(json['data'] as Map<String, dynamic>),
+    );
   }
 
   Future<void> rsvpEvent(int eventId, int userId) async {

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -26,9 +26,11 @@ router.post('/', async (req, res) => {
 // POST /events/:id - update event
 router.post('/:id', async (req, res) => {
   try {
-    const event = await Event.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const event = await Event.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
     if (!event) return res.status(404).json({ error: 'Event not found' });
-    res.json(event);
+    res.json({ data: event });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -51,7 +51,7 @@ describe('Events API', () => {
       .post(`/api/events/${event._id}`)
       .send({ title: 'New' });
     expect(res.status).toBe(200);
-    expect(res.body.title).toBe('New');
+    expect(res.body.data.title).toBe('New');
   });
 
   test('POST /events/:id/rsvp adds attendee', async () => {


### PR DESCRIPTION
## Summary
- return `{ data: event }` when updating events on the server
- expect new response shape in tests
- parse updated event response in Flutter service

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c99efb00832b94769d7f5a260af6