### PR TITLE
Add server env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ The optional Node.js backend lives in the `server/` directory.
    npm install
    ```
 
-2. Create a `.env` file to configure your MongoDB connection (optional):
-   ```env
-   MONGODB_URI=mongodb://localhost:27017/olyapp
-   PORT=3000
+2. Copy the example environment file and adjust values if needed:
+   ```bash
+   cp .env.example .env
    ```
-   If no `MONGODB_URI` is provided, an in-memory database is used.
+   This file sets `MONGODB_URI` and `PORT`. If no `MONGODB_URI` is provided,
+   an in-memory database is used.
 
 ### Running
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+MONGODB_URI=mongodb://localhost:27017/olyapp
+PORT=3000


### PR DESCRIPTION
## Summary
- add an example env file for the Node backend
- document how to copy it in the README

## Testing
- `flutter analyze --no-pub`
- `flutter test --no-pub`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca0bff24832bb2c321cf659a19e0