### PR TITLE
Add pins API and integrate map service

### DIFF
--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -3,51 +3,23 @@ import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 
 import '../models/map_pin.dart';
+import 'api_service.dart';
 
 class MapService {
   MapService({http.Client? client}) : _client = client ?? http.Client();
 
   final http.Client _client;
   Future<List<MapPin>> fetchPins() async {
-    // In real implementation, fetch from API
-    await Future.delayed(const Duration(milliseconds: 100));
-    return [
-      MapPin(
-        id: 'building1',
-        title: 'Dormitory',
-        lat: 48.1745,
-        lon: 11.548,
-        category: MapPinCategory.building,
-      ),
-      MapPin(
-        id: 'venue1',
-        title: 'Event Hall',
-        lat: 48.1740,
-        lon: 11.547,
-        category: MapPinCategory.venue,
-      ),
-      MapPin(
-        id: 'amenity1',
-        title: 'Laundry',
-        lat: 48.1735,
-        lon: 11.549,
-        category: MapPinCategory.amenity,
-      ),
-      MapPin(
-        id: 'rec1',
-        title: 'Basketball Court',
-        lat: 48.1742,
-        lon: 11.546,
-        category: MapPinCategory.recreation,
-      ),
-      MapPin(
-        id: 'food1',
-        title: 'Cafeteria',
-        lat: 48.1738,
-        lon: 11.5485,
-        category: MapPinCategory.food,
-      ),
-    ];
+    final uri = ApiService().buildUri('/pins');
+    final res = await _client.get(uri);
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>;
+      return list
+          .map((e) => MapPin.fromMap(e as Map<String, dynamic>))
+          .toList();
+    }
+    return [];
   }
 
   Future<List<LatLng>> fetchRoute(LatLng start, LatLng end) async {

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -5,6 +5,7 @@ const eventsRouter = require('../routes/events');
 const itemsRouter = require('../routes/items');
 const maintenanceRouter = require('../routes/maintenance');
 const bookingsRouter = require('../routes/bookings');
+const pinsRouter = require('../routes/pins');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -15,5 +16,6 @@ router.use('/events', eventsRouter);
 router.use('/items', itemsRouter);
 router.use('/maintenance', maintenanceRouter);
 router.use('/bookings', bookingsRouter);
+router.use('/pins', pinsRouter);
 
 module.exports = router;

--- a/server/models/MapPin.js
+++ b/server/models/MapPin.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const MapPinSchema = new mongoose.Schema({
+  id: { type: String, required: true, unique: true },
+  title: { type: String, required: true },
+  lat: { type: Number, required: true },
+  lon: { type: Number, required: true },
+  category: {
+    type: String,
+    enum: ['building', 'venue', 'amenity', 'recreation', 'food'],
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('MapPin', MapPinSchema);

--- a/server/routes/pins.js
+++ b/server/routes/pins.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const MapPin = require('../models/MapPin');
+
+const router = express.Router();
+
+// GET /pins - list map pins
+router.get('/', async (req, res) => {
+  try {
+    const pins = await MapPin.find();
+    res.json({ data: pins });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /pins - create a new pin
+router.post('/', async (req, res) => {
+  try {
+    const pin = await MapPin.create(req.body);
+    res.status(201).json({ data: pin });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /pins/:id - update an existing pin
+router.post('/:id', async (req, res) => {
+  try {
+    const pin = await MapPin.findOneAndUpdate({ id: req.params.id }, req.body, {
+      new: true,
+    });
+    if (!pin) return res.status(404).json({ error: 'Pin not found' });
+    res.json({ data: pin });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/pins.test.js
+++ b/server/tests/pins.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const apiRouter = require('../api');
+const MapPin = require('../models/MapPin');
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('Pins API', () => {
+  test('GET /pins returns list', async () => {
+    await MapPin.create({
+      id: '1',
+      title: 'Dorm',
+      lat: 0,
+      lon: 0,
+      category: 'building',
+    });
+    const res = await request(app).get('/api/pins');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].title).toBe('Dorm');
+  });
+
+  test('POST /pins creates pin', async () => {
+    const res = await request(app)
+      .post('/api/pins')
+      .send({ id: '2', title: 'Cafe', lat: 1, lon: 1, category: 'food' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.title).toBe('Cafe');
+  });
+});

--- a/test/services/map_service_test.dart
+++ b/test/services/map_service_test.dart
@@ -1,26 +1,37 @@
 import 'package:test/test.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:oly_app/services/map_service.dart';
 
 void main() {
   group('MapService', () {
-    test('fetchPins returns built in pins', () async {
-      final service = MapService();
+    test('fetchPins retrieves pins from API', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/api/pins');
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': '1',
+                'title': 'Dorm',
+                'lat': 0,
+                'lon': 0,
+                'category': 'building'
+              }
+            ]
+          }),
+          200,
+        );
+      });
+
+      final service = MapService(client: mockClient);
       final pins = await service.fetchPins();
 
-      expect(pins, hasLength(5));
-      expect(pins[0].id, 'building1');
-      expect(pins[0].lat, 48.1745);
-      expect(pins[0].lon, 11.548);
-
-      expect(pins[1].id, 'venue1');
-      expect(pins[1].lat, 48.1740);
-      expect(pins[1].lon, 11.547);
-
-      expect(pins[2].id, 'amenity1');
-      expect(pins[2].lat, 48.1735);
-      expect(pins[2].lon, 11.549);
-      expect(pins[3].id, 'rec1');
-      expect(pins[4].id, 'food1');
+      expect(pins, hasLength(1));
+      expect(pins.first.id, '1');
+      expect(pins.first.title, 'Dorm');
     });
   });
 }


### PR DESCRIPTION
## Summary
- create `MapPin` model for storing map pins
- add routes for `/api/pins` and register router
- provide tests for new endpoints
- update Flutter `MapService` to fetch pins from backend
- adjust unit tests for new fetch logic

## Testing
- `npm test`
- `flutter test` *(fails: VersionCheckError: bad object)*

------
https://chatgpt.com/codex/tasks/task_e_6841ccc69d7c832bbaffc588f7d9548f