### PR TITLE
Add bulletin board backend and API integration

### DIFF
--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -1,37 +1,40 @@
 import '../models/models.dart';
+import 'api_service.dart';
 
-class BulletinService {
-  final List<BulletinPost> _posts = [];
-  final Map<int, List<BulletinComment>> _comments = {};
+class BulletinService extends ApiService {
+  BulletinService({super.client});
 
   Future<List<BulletinPost>> fetchPosts() async {
-    return List.unmodifiable(_posts);
+    return get('/bulletin', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => BulletinPost.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
   }
 
-  Future<BulletinPost> addPost(BulletinPost post) async {
-    final newPost = BulletinPost(
-      id: _posts.length + 1,
-      content: post.content,
-      date: post.date,
+  Future<BulletinPost> addPost(BulletinPost bulletin) async {
+    return post(
+      '/bulletin',
+      bulletin.toJson(),
+      (json) => BulletinPost.fromJson(json['data'] as Map<String, dynamic>),
     );
-    _posts.add(newPost);
-    _comments[newPost.id!] = [];
-    return newPost;
   }
 
   Future<List<BulletinComment>> fetchComments(int postId) async {
-    return List.unmodifiable(_comments[postId] ?? const []);
+    return get('/bulletin/$postId/comments', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => BulletinComment.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
   }
 
   Future<BulletinComment> addComment(BulletinComment comment) async {
-    final list = _comments.putIfAbsent(comment.postId, () => []);
-    final newComment = BulletinComment(
-      id: list.length + 1,
-      postId: comment.postId,
-      content: comment.content,
-      date: comment.date,
+    return post(
+      '/bulletin/${comment.postId}/comments',
+      comment.toJson(),
+      (json) => BulletinComment.fromJson(json['data'] as Map<String, dynamic>),
     );
-    list.add(newComment);
-    return newComment;
   }
 }

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -5,6 +5,7 @@ const eventsRouter = require('../routes/events');
 const itemsRouter = require('../routes/items');
 const maintenanceRouter = require('../routes/maintenance');
 const bookingsRouter = require('../routes/bookings');
+const bulletinRouter = require('../routes/bulletin');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -15,5 +16,6 @@ router.use('/events', eventsRouter);
 router.use('/items', itemsRouter);
 router.use('/maintenance', maintenanceRouter);
 router.use('/bookings', bookingsRouter);
+router.use('/bulletin', bulletinRouter);
 
 module.exports = router;

--- a/server/models/BulletinComment.js
+++ b/server/models/BulletinComment.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const BulletinCommentSchema = new mongoose.Schema({
+  id: { type: Number, required: true, unique: true },
+  postId: { type: Number, required: true },
+  content: { type: String, required: true },
+  date: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('BulletinComment', BulletinCommentSchema);

--- a/server/models/BulletinPost.js
+++ b/server/models/BulletinPost.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const BulletinPostSchema = new mongoose.Schema({
+  id: { type: Number, required: true, unique: true },
+  content: { type: String, required: true },
+  date: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('BulletinPost', BulletinPostSchema);

--- a/server/routes/bulletin.js
+++ b/server/routes/bulletin.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const BulletinPost = require('../models/BulletinPost');
+const BulletinComment = require('../models/BulletinComment');
+
+const router = express.Router();
+
+// helper to get next numeric id for a model
+async function nextId(model) {
+  const last = await model.findOne().sort('-id');
+  return last ? last.id + 1 : 1;
+}
+
+// GET /bulletin - list posts
+router.get('/', async (req, res) => {
+  try {
+    const posts = await BulletinPost.find();
+    res.json({ data: posts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /bulletin - create post
+router.post('/', async (req, res) => {
+  try {
+    const post = await BulletinPost.create({
+      id: await nextId(BulletinPost),
+      content: req.body.content,
+      date: req.body.date,
+    });
+    res.status(201).json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /bulletin/:id/comments - list comments for a post
+router.get('/:id/comments', async (req, res) => {
+  try {
+    const comments = await BulletinComment.find({ postId: Number(req.params.id) });
+    res.json({ data: comments });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /bulletin/:id/comments - create comment for a post
+router.post('/:id/comments', async (req, res) => {
+  try {
+    const comment = await BulletinComment.create({
+      id: await nextId(BulletinComment),
+      postId: Number(req.params.id),
+      content: req.body.content,
+      date: req.body.date,
+    });
+    res.status(201).json({ data: comment });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -7,6 +7,8 @@ const Event = require('../models/Event');
 const Item = require('../models/Item');
 const Message = require('../models/Message');
 const MaintenanceRequest = require('../models/MaintenanceRequest');
+const BulletinPost = require('../models/BulletinPost');
+const BulletinComment = require('../models/BulletinComment');
 
 let app;
 let mongo;
@@ -180,5 +182,41 @@ describe('Maintenance API', () => {
       .send({ status: 'closed' });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('closed');
+  });
+});
+
+describe('Bulletin API', () => {
+  test('GET /bulletin returns list', async () => {
+    await BulletinPost.create({ id: 1, content: 'Hello' });
+    const res = await request(app).get('/api/bulletin');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].content).toBe('Hello');
+  });
+
+  test('POST /bulletin creates post', async () => {
+    const res = await request(app)
+      .post('/api/bulletin')
+      .send({ content: 'New' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('New');
+  });
+
+  test('GET /bulletin/:id/comments returns comments', async () => {
+    await BulletinPost.create({ id: 1, content: 'p' });
+    await BulletinComment.create({ id: 1, postId: 1, content: 'c' });
+    const res = await request(app).get('/api/bulletin/1/comments');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].content).toBe('c');
+  });
+
+  test('POST /bulletin/:id/comments creates comment', async () => {
+    await BulletinPost.create({ id: 1, content: 'p' });
+    const res = await request(app)
+      .post('/api/bulletin/1/comments')
+      .send({ content: 'c' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('c');
   });
 });


### PR DESCRIPTION
## Summary
- implement bulletin board backend models and routes
- mount bulletin routes in API router
- add Dart service to call HTTP API instead of local lists
- expand API and service tests for bulletin board

## Testing
- `npm test`
- `flutter test` *(fails: RootUnavailable messages)*

------
https://chatgpt.com/codex/tasks/task_e_6841cca2477c832b9e7621048ade0cb7