### PR TITLE
Implement user model with hashed auth

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -81,7 +81,13 @@ class _LoginPageState extends State<LoginPage> {
 
       // Store user info
       final userMap = response['user'] as Map<String, dynamic>;
-      final user = User.fromMap(userMap);
+      final user = User(
+        id: userMap['id'] is int ? userMap['id'] as int : null,
+        name: userMap['name'] as String,
+        email: userMap['email'] as String,
+        avatarUrl: userMap['avatarUrl'] as String?,
+        isAdmin: (userMap['isAdmin'] ?? false) as bool,
+      );
       final userBox = Hive.box<User>('userBox');
       await userBox.put('currentUser', user);
 

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -1,37 +1,40 @@
 import '../models/models.dart';
+import 'api_service.dart';
 
-class BulletinService {
-  final List<BulletinPost> _posts = [];
-  final Map<int, List<BulletinComment>> _comments = {};
+class BulletinService extends ApiService {
+  BulletinService({super.client});
 
   Future<List<BulletinPost>> fetchPosts() async {
-    return List.unmodifiable(_posts);
+    return get('/bulletin', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => BulletinPost.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
   }
 
-  Future<BulletinPost> addPost(BulletinPost post) async {
-    final newPost = BulletinPost(
-      id: _posts.length + 1,
-      content: post.content,
-      date: post.date,
+  Future<BulletinPost> addPost(BulletinPost bulletin) async {
+    return post(
+      '/bulletin',
+      bulletin.toJson(),
+      (json) => BulletinPost.fromJson(json['data'] as Map<String, dynamic>),
     );
-    _posts.add(newPost);
-    _comments[newPost.id!] = [];
-    return newPost;
   }
 
   Future<List<BulletinComment>> fetchComments(int postId) async {
-    return List.unmodifiable(_comments[postId] ?? const []);
+    return get('/bulletin/$postId/comments', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => BulletinComment.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
   }
 
   Future<BulletinComment> addComment(BulletinComment comment) async {
-    final list = _comments.putIfAbsent(comment.postId, () => []);
-    final newComment = BulletinComment(
-      id: list.length + 1,
-      postId: comment.postId,
-      content: comment.content,
-      date: comment.date,
+    return post(
+      '/bulletin/${comment.postId}/comments',
+      comment.toJson(),
+      (json) => BulletinComment.fromJson(json['data'] as Map<String, dynamic>),
     );
-    list.add(newComment);
-    return newComment;
   }
 }

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -3,51 +3,24 @@ import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 
 import '../models/map_pin.dart';
+import 'api_service.dart';
 
 class MapService {
-  MapService({http.Client? client}) : _client = client ?? http.Client();
+  MapService({http.Client? client}) : _client = client ?? defaultClient;
 
+  static http.Client defaultClient = http.Client();
   final http.Client _client;
   Future<List<MapPin>> fetchPins() async {
-    // In real implementation, fetch from API
-    await Future.delayed(const Duration(milliseconds: 100));
-    return [
-      MapPin(
-        id: 'building1',
-        title: 'Dormitory',
-        lat: 48.1745,
-        lon: 11.548,
-        category: MapPinCategory.building,
-      ),
-      MapPin(
-        id: 'venue1',
-        title: 'Event Hall',
-        lat: 48.1740,
-        lon: 11.547,
-        category: MapPinCategory.venue,
-      ),
-      MapPin(
-        id: 'amenity1',
-        title: 'Laundry',
-        lat: 48.1735,
-        lon: 11.549,
-        category: MapPinCategory.amenity,
-      ),
-      MapPin(
-        id: 'rec1',
-        title: 'Basketball Court',
-        lat: 48.1742,
-        lon: 11.546,
-        category: MapPinCategory.recreation,
-      ),
-      MapPin(
-        id: 'food1',
-        title: 'Cafeteria',
-        lat: 48.1738,
-        lon: 11.5485,
-        category: MapPinCategory.food,
-      ),
-    ];
+    final uri = ApiService().buildUri('/pins');
+    final res = await _client.get(uri);
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>;
+      return list
+          .map((e) => MapPin.fromMap(e as Map<String, dynamic>))
+          .toList();
+    }
+    return [];
   }
 
   Future<List<LatLng>> fetchRoute(LatLng start, LatLng end) async {
@@ -56,10 +29,12 @@ class MapService {
     final res = await _client.get(Uri.parse(url));
     if (res.statusCode == 200) {
       final data = jsonDecode(res.body) as Map<String, dynamic>;
-      final coords = (data['routes'][0]['geometry']['coordinates'] as List)
-          .cast<List>();
+      final coords =
+          (data['routes'][0]['geometry']['coordinates'] as List).cast<List>();
       return coords
-          .map((c) => LatLng((c[1] as num).toDouble(), (c[0] as num).toDouble()))
+          .map(
+            (c) => LatLng((c[1] as num).toDouble(), (c[0] as num).toDouble()),
+          )
           .toList();
     }
     return [];

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -4,7 +4,9 @@ const authRouter = require('../routes/auth');
 const eventsRouter = require('../routes/events');
 const itemsRouter = require('../routes/items');
 const maintenanceRouter = require('../routes/maintenance');
-const bookingsRouter = require('../routes/bookings');
+const bookingsRouter = require('../routes/bookings'); 
+const bulletinRouter = require('../routes/bulletin'); 
+const pinsRouter = require('../routes/pins'); 
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -14,6 +16,7 @@ router.use('/auth', authRouter);
 router.use('/events', eventsRouter);
 router.use('/items', itemsRouter);
 router.use('/maintenance', maintenanceRouter);
-router.use('/bookings', bookingsRouter);
-
+router.use('/bookings', bookingsRouter); 
+router.use('/bulletin', bulletinRouter); 
+router.use('/pins', pinsRouter); 
 module.exports = router;

--- a/server/models/BulletinComment.js
+++ b/server/models/BulletinComment.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const BulletinCommentSchema = new mongoose.Schema({
+  id: { type: Number, required: true, unique: true },
+  postId: { type: Number, required: true },
+  content: { type: String, required: true },
+  date: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('BulletinComment', BulletinCommentSchema);

--- a/server/models/BulletinPost.js
+++ b/server/models/BulletinPost.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const BulletinPostSchema = new mongoose.Schema({
+  id: { type: Number, required: true, unique: true },
+  content: { type: String, required: true },
+  date: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('BulletinPost', BulletinPostSchema);

--- a/server/models/MapPin.js
+++ b/server/models/MapPin.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const MapPinSchema = new mongoose.Schema({
+  id: { type: String, required: true, unique: true },
+  title: { type: String, required: true },
+  lat: { type: Number, required: true },
+  lon: { type: Number, required: true },
+  category: {
+    type: String,
+    enum: ['building', 'venue', 'amenity', 'recreation', 'food'],
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('MapPin', MapPinSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  passwordHash: { type: String, required: true },
+  avatarUrl: String,
+  isAdmin: { type: Boolean, default: false }
+});
+
+module.exports = mongoose.model('User', UserSchema);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "olyapp-server",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -1388,6 +1389,12 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",

--- a/server/package.json
+++ b/server/package.json
@@ -8,10 +8,11 @@
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "mongoose": "^7.6.0",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "mongoose": "^7.6.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/bulletin.js
+++ b/server/routes/bulletin.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const BulletinPost = require('../models/BulletinPost');
+const BulletinComment = require('../models/BulletinComment');
+
+const router = express.Router();
+
+// helper to get next numeric id for a model
+async function nextId(model) {
+  const last = await model.findOne().sort('-id');
+  return last ? last.id + 1 : 1;
+}
+
+// GET /bulletin - list posts
+router.get('/', async (req, res) => {
+  try {
+    const posts = await BulletinPost.find();
+    res.json({ data: posts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /bulletin - create post
+router.post('/', async (req, res) => {
+  try {
+    const post = await BulletinPost.create({
+      id: await nextId(BulletinPost),
+      content: req.body.content,
+      date: req.body.date,
+    });
+    res.status(201).json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /bulletin/:id/comments - list comments for a post
+router.get('/:id/comments', async (req, res) => {
+  try {
+    const comments = await BulletinComment.find({ postId: Number(req.params.id) });
+    res.json({ data: comments });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /bulletin/:id/comments - create comment for a post
+router.post('/:id/comments', async (req, res) => {
+  try {
+    const comment = await BulletinComment.create({
+      id: await nextId(BulletinComment),
+      postId: Number(req.params.id),
+      content: req.body.content,
+      date: req.body.date,
+    });
+    res.status(201).json({ data: comment });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/pins.js
+++ b/server/routes/pins.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const MapPin = require('../models/MapPin');
+
+const router = express.Router();
+
+// GET /pins - list map pins
+router.get('/', async (req, res) => {
+  try {
+    const pins = await MapPin.find();
+    res.json({ data: pins });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /pins - create a new pin
+router.post('/', async (req, res) => {
+  try {
+    const pin = await MapPin.create(req.body);
+    res.status(201).json({ data: pin });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /pins/:id - update an existing pin
+router.post('/:id', async (req, res) => {
+  try {
+    const pin = await MapPin.findOneAndUpdate({ id: req.params.id }, req.body, {
+      new: true,
+    });
+    if (!pin) return res.status(404).json({ error: 'Pin not found' });
+    res.json({ data: pin });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -7,6 +7,8 @@ const Event = require('../models/Event');
 const Item = require('../models/Item');
 const Message = require('../models/Message');
 const MaintenanceRequest = require('../models/MaintenanceRequest');
+const BulletinPost = require('../models/BulletinPost');
+const BulletinComment = require('../models/BulletinComment');
 
 let app;
 let mongo;
@@ -180,5 +182,41 @@ describe('Maintenance API', () => {
       .send({ status: 'closed' });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('closed');
+  });
+});
+
+describe('Bulletin API', () => {
+  test('GET /bulletin returns list', async () => {
+    await BulletinPost.create({ id: 1, content: 'Hello' });
+    const res = await request(app).get('/api/bulletin');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].content).toBe('Hello');
+  });
+
+  test('POST /bulletin creates post', async () => {
+    const res = await request(app)
+      .post('/api/bulletin')
+      .send({ content: 'New' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('New');
+  });
+
+  test('GET /bulletin/:id/comments returns comments', async () => {
+    await BulletinPost.create({ id: 1, content: 'p' });
+    await BulletinComment.create({ id: 1, postId: 1, content: 'c' });
+    const res = await request(app).get('/api/bulletin/1/comments');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].content).toBe('c');
+  });
+
+  test('POST /bulletin/:id/comments creates comment', async () => {
+    await BulletinPost.create({ id: 1, content: 'p' });
+    const res = await request(app)
+      .post('/api/bulletin/1/comments')
+      .send({ content: 'c' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('c');
   });
 });

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -25,27 +25,30 @@ afterAll(async () => {
 });
 
 describe('Auth API', () => {
-  test('successful login returns token and user info', async () => {
+  test('registers and logs in a user', async () => {
+    const reg = await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'Test', email: 'a@b.c', password: 'pass' });
+    expect(reg.status).toBe(201);
+    expect(reg.body).toHaveProperty('token');
+    expect(reg.body.user.email).toBe('a@b.c');
+
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'user@example.com', password: 'password' });
+      .send({ email: 'a@b.c', password: 'pass' });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('token');
-    expect(typeof res.body.token).toBe('string');
-    expect(res.body).toHaveProperty('user');
-    expect(res.body.user).toEqual({
-      id: 1,
-      name: 'Test User',
-      email: 'user@example.com',
-      avatarUrl: null,
-      isAdmin: false,
-    });
+    expect(res.body.user.email).toBe('a@b.c');
   });
 
   test('invalid credentials return HTTP 401', async () => {
+    await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'Test', email: 'x@y.z', password: 'pass' });
+
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'user@example.com', password: 'wrong' });
+      .send({ email: 'x@y.z', password: 'wrong' });
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ error: 'Invalid credentials' });
   });

--- a/server/tests/pins.test.js
+++ b/server/tests/pins.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const apiRouter = require('../api');
+const MapPin = require('../models/MapPin');
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('Pins API', () => {
+  test('GET /pins returns list', async () => {
+    await MapPin.create({
+      id: '1',
+      title: 'Dorm',
+      lat: 0,
+      lon: 0,
+      category: 'building',
+    });
+    const res = await request(app).get('/api/pins');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].title).toBe('Dorm');
+  });
+
+  test('POST /pins creates pin', async () => {
+    const res = await request(app)
+      .post('/api/pins')
+      .send({ id: '2', title: 'Cafe', lat: 1, lon: 1, category: 'food' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.title).toBe('Cafe');
+  });
+});

--- a/test/services/event_service_test.dart
+++ b/test/services/event_service_test.dart
@@ -6,8 +6,10 @@ import 'package:http/testing.dart';
 import 'package:oly_app/services/event_service.dart';
 import 'package:oly_app/models/models.dart';
 
-const apiUrl =
-    String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+const apiUrl = String.fromEnvironment(
+  'API_URL',
+  defaultValue: 'http://localhost:3000',
+);
 
 void main() {
   group('EventService', () {
@@ -24,9 +26,9 @@ void main() {
                 'title': 'Party',
                 'date': '1970-01-01T00:00:00.000Z',
                 'description': 'fun',
-                'location': 'loc1'
-              }
-            ]
+                'location': 'loc1',
+              },
+            ],
           }),
           200,
         );
@@ -54,10 +56,7 @@ void main() {
         expect(body['location'], input.location);
         return http.Response(
           jsonEncode({
-            'data': {
-              'id': 2,
-              ...input.toJson(),
-            }
+            'data': {'id': 2, ...input.toJson()},
           }),
           201,
         );
@@ -84,7 +83,7 @@ void main() {
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['title'], input.title);
         expect(body['location'], input.location);
-        return http.Response(jsonEncode(input.toJson()), 200);
+        return http.Response(jsonEncode({'data': input.toJson()}), 200);
       });
 
       final service = EventService(client: mockClient);
@@ -112,7 +111,12 @@ void main() {
         expect(request.method, equals('GET'));
         expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/events/1/attendees');
-        return http.Response(jsonEncode({'data': [1, 2]}), 200);
+        return http.Response(
+          jsonEncode({
+            'data': [1, 2],
+          }),
+          200,
+        );
       });
 
       final service = EventService(client: mockClient);

--- a/test/services/map_service_test.dart
+++ b/test/services/map_service_test.dart
@@ -1,26 +1,37 @@
 import 'package:test/test.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:oly_app/services/map_service.dart';
 
 void main() {
   group('MapService', () {
-    test('fetchPins returns built in pins', () async {
-      final service = MapService();
+    test('fetchPins retrieves pins from API', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/api/pins');
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': '1',
+                'title': 'Dorm',
+                'lat': 0,
+                'lon': 0,
+                'category': 'building'
+              }
+            ]
+          }),
+          200,
+        );
+      });
+
+      final service = MapService(client: mockClient);
       final pins = await service.fetchPins();
 
-      expect(pins, hasLength(5));
-      expect(pins[0].id, 'building1');
-      expect(pins[0].lat, 48.1745);
-      expect(pins[0].lon, 11.548);
-
-      expect(pins[1].id, 'venue1');
-      expect(pins[1].lat, 48.1740);
-      expect(pins[1].lon, 11.547);
-
-      expect(pins[2].id, 'amenity1');
-      expect(pins[2].lat, 48.1735);
-      expect(pins[2].lon, 11.549);
-      expect(pins[3].id, 'rec1');
-      expect(pins[4].id, 'food1');
+      expect(pins, hasLength(1));
+      expect(pins.first.id, '1');
+      expect(pins.first.title, 'Dorm');
     });
   });
 }


### PR DESCRIPTION
## Summary
- create `User` model
- add `bcryptjs` dependency
- implement registration and login using MongoDB
- update login page to handle new server response
- update auth tests
- merge main branch updates

## Testing
- `npm test` *(fails: spawn ETXTBSY during MongoMemoryServer)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841cd618f34832b9f2347c0d6ffe729