### PR TITLE
Enable offline caching and manual refresh

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ void main() async {
   await Hive.openBox('maintenanceBox');
   await Hive.openBox('messagesBox');
   await Hive.openBox('calendarBox');
+  await Hive.openBox('eventsBox');
   await Hive.openBox('itemsBox');
   await Hive.openBox('userBox');
   await Hive.openBox('authBox');

--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -252,6 +252,13 @@ class _CalendarPageState extends State<CalendarPage> {
             ),
           ),
           const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: _loadEvents,
+            ),
+          ),
           Expanded(
             child: ValueListenableBuilder<List<CalendarEvent>>(
               valueListenable: _selectedEvents,

--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -70,22 +70,32 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            // Search field
-            TextField(
-              controller: _searchCtrl,
-              decoration: InputDecoration(
-                prefixIcon: const Icon(Icons.search),
-                hintText: 'Search items…',
-                filled: true,
-                fillColor:
-                    Theme.of(context).colorScheme.surfaceContainerHighest,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide.none,
+          // Search field with refresh
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _searchCtrl,
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.search),
+                    hintText: 'Search items…',
+                    filled: true,
+                    fillColor:
+                        Theme.of(context).colorScheme.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                  onChanged: (_) => _filter(),
                 ),
               ),
-              onChanged: (_) => _filter(),
-            ),
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                onPressed: _loadItems,
+              ),
+            ],
+          ),
             const SizedBox(height: 12),
 
             // Category chips


### PR DESCRIPTION
## Summary
- open additional Hive `eventsBox` for caching event data
- cache events and items in their services and fall back to cached data when offline
- add manual refresh buttons on Calendar and Item Exchange pages

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841dc572044832b9ffc18465cca2463