### PR TITLE
Add user registration flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'pages/login_page.dart';
 import 'pages/main_page.dart';
+import 'pages/register_page.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'dart:io';
@@ -100,10 +101,12 @@ class _OlyAppState extends State<OlyApp> {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.white38),
         useMaterial3: true,
       ),
-      home:
-          _loggedIn
-              ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
-              : LoginPage(onLoginSuccess: () => _handleLogin()),
+      routes: {
+        '/register': (_) => RegisterPage(onRegistered: _handleLogin),
+      },
+      home: _loggedIn
+          ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
+          : LoginPage(onLoginSuccess: () => _handleLogin()),
     );
   }
 }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -293,13 +293,20 @@ class _LoginPageState extends State<LoginPage> {
                               },
                       icon: const Icon(Icons.apple),
                       label: const Text('Apple'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: cs.primaryContainer,
-                        foregroundColor: cs.onPrimaryContainer,
-                      ),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: cs.primaryContainer,
+                      foregroundColor: cs.onPrimaryContainer,
                     ),
-                  ],
-                ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              TextButton(
+                onPressed: _isLoading
+                    ? null
+                    : () => Navigator.pushNamed(context, '/register'),
+                child: const Text('Create an account'),
+              ),
               ],
             ),
           ),

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/models.dart';
+import '../services/auth_service.dart';
+import '../utils/validators.dart';
+
+class RegisterPage extends StatefulWidget {
+  final VoidCallback? onRegistered;
+  const RegisterPage({super.key, this.onRegistered});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  final _emailCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
+  bool _loading = false;
+  bool _passwordVisible = false;
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _emailCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _register() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+    try {
+      final service = AuthService();
+      final res = await service.register(
+        _nameCtrl.text.trim(),
+        _emailCtrl.text.trim(),
+        _passwordCtrl.text,
+      );
+      final token = res['token'] as String;
+      final userMap = res['user'] as Map<String, dynamic>;
+      final user = User.fromMap(userMap);
+      await Hive.box('authBox').put('token', token);
+      await Hive.box<User>('userBox').put('currentUser', user);
+      widget.onRegistered?.call();
+      if (widget.onRegistered == null && mounted) {
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Registration failed: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: _nameCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Name',
+                    filled: true,
+                    fillColor: cs.surfaceContainerHighest,
+                    prefixIcon: const Icon(Icons.person),
+                  ),
+                  validator: (v) =>
+                      v == null || v.trim().isEmpty ? 'Name is required' : null,
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _emailCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Email',
+                    filled: true,
+                    fillColor: cs.surfaceContainerHighest,
+                    prefixIcon: const Icon(Icons.email),
+                  ),
+                  keyboardType: TextInputType.emailAddress,
+                  validator: validateEmail,
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Password',
+                    filled: true,
+                    fillColor: cs.surfaceContainerHighest,
+                    prefixIcon: const Icon(Icons.lock),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _passwordVisible
+                            ? Icons.visibility
+                            : Icons.visibility_off,
+                      ),
+                      onPressed: () => setState(
+                        () => _passwordVisible = !_passwordVisible,
+                      ),
+                    ),
+                  ),
+                  obscureText: !_passwordVisible,
+                  validator: validatePassword,
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _loading ? null : _register,
+                    child: _loading
+                        ? const SizedBox(
+                            height: 16,
+                            width: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Register'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,32 @@
+import 'api_service.dart';
+
+class AuthService extends ApiService {
+  AuthService({super.client});
+
+  Future<Map<String, dynamic>> register(
+    String name,
+    String email,
+    String password,
+  ) async {
+    return post(
+      '/auth/register',
+      {
+        'name': name,
+        'email': email,
+        'password': password,
+      },
+      (json) => Map<String, dynamic>.from(json as Map),
+    );
+  }
+
+  Future<Map<String, dynamic>> login(String email, String password) async {
+    return post(
+      '/auth/login',
+      {
+        'email': email,
+        'password': password,
+      },
+      (json) => Map<String, dynamic>.from(json as Map),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AuthService` with register API call
- implement `RegisterPage` for account creation
- add RegisterPage to router and link from LoginPage

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841e8e167b8832ba2c58d4ce2beeb4a