### PR TITLE
Add admin-only event and maintenance editing

### DIFF
--- a/lib/pages/admin/event_admin_page.dart
+++ b/lib/pages/admin/event_admin_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/models.dart';
 import '../../services/event_service.dart';
+import '../calendar_page.dart' show showAddEventDialog;
 
 class EventAdminPage extends StatefulWidget {
   final EventService? service;
@@ -35,7 +36,9 @@ class _EventAdminPageState extends State<EventAdminPage> {
         content: TextField(controller: controller),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
           ElevatedButton(
             onPressed: () => Navigator.pop(ctx, controller.text),
             child: const Text('Save'),
@@ -45,7 +48,11 @@ class _EventAdminPageState extends State<EventAdminPage> {
     );
     if (result != null && result.isNotEmpty) {
       final updated = CalendarEvent(
-          id: event.id, title: result, date: event.date, description: event.description);
+        id: event.id,
+        title: result,
+        date: event.date,
+        description: event.description,
+      );
       await _service.updateEvent(updated);
       _load();
     }
@@ -55,14 +62,22 @@ class _EventAdminPageState extends State<EventAdminPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Manage Events')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await showAddEventDialog(context, (title, date, location) async {
+            await _service.createEvent(
+              CalendarEvent(title: title, date: date, location: location),
+            );
+            _load();
+          });
+        },
+        child: const Icon(Icons.add),
+      ),
       body: ListView.builder(
         itemCount: _events.length,
         itemBuilder: (ctx, i) {
           final e = _events[i];
-          return ListTile(
-            title: Text(e.title),
-            onTap: () => _editEvent(e),
-          );
+          return ListTile(title: Text(e.title), onTap: () => _editEvent(e));
         },
       ),
     );

--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -9,7 +9,8 @@ import 'package:latlong2/latlong.dart';
 
 class CalendarPage extends StatefulWidget {
   final EventService? service;
-  const CalendarPage({super.key, this.service});
+  final bool isAdmin;
+  const CalendarPage({super.key, this.service, this.isAdmin = false});
 
   @override
   State<CalendarPage> createState() => _CalendarPageState();
@@ -115,7 +116,11 @@ class _CalendarPageState extends State<CalendarPage> {
           attendees: attendees,
           location: event.location,
         );
-        final dayKey = DateTime(event.date.year, event.date.month, event.date.day);
+        final dayKey = DateTime(
+          event.date.year,
+          event.date.month,
+          event.date.day,
+        );
         final list = _events[dayKey];
         if (list != null) {
           final index = list.indexWhere((e) => e.id == event.id);
@@ -125,8 +130,9 @@ class _CalendarPageState extends State<CalendarPage> {
       });
     } catch (_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Failed to RSVP')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to RSVP')));
     }
   }
 
@@ -195,7 +201,11 @@ class _CalendarPageState extends State<CalendarPage> {
           attendees: attendees,
           location: event.location,
         );
-        final dayKey = DateTime(event.date.year, event.date.month, event.date.day);
+        final dayKey = DateTime(
+          event.date.year,
+          event.date.month,
+          event.date.day,
+        );
         final list = _events[dayKey];
         if (list != null) {
           final index = list.indexWhere((e) => e.id == event.id);
@@ -205,8 +215,9 @@ class _CalendarPageState extends State<CalendarPage> {
       });
     } catch (_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Failed to load attendees')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to load attendees')));
     }
   }
 
@@ -273,8 +284,7 @@ class _CalendarPageState extends State<CalendarPage> {
                     return ListTile(
                       leading: const Icon(Icons.event_note),
                       title: Text(event.title),
-                      subtitle:
-                          Text('Attendees: ${event.attendees.length}'),
+                      subtitle: Text('Attendees: ${event.attendees.length}'),
                       trailing: TextButton(
                         onPressed: () => _rsvp(event),
                         child: const Text('RSVP'),
@@ -288,12 +298,14 @@ class _CalendarPageState extends State<CalendarPage> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: cs.secondary,
-        foregroundColor: cs.onSecondary,
-        onPressed: _addEvent,
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: widget.isAdmin
+          ? FloatingActionButton(
+              backgroundColor: cs.secondary,
+              foregroundColor: cs.onSecondary,
+              onPressed: _addEvent,
+              child: const Icon(Icons.add),
+            )
+          : null,
     );
   }
 }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -52,7 +52,7 @@ class _MainPageState extends State<MainPage> {
     _pages = [
       DashboardPage(onNavigate: _onDashboardNavigate, isAdmin: widget.isAdmin),
       const MapPage(),
-      widget.calendarPage ?? const CalendarPage(),
+      widget.calendarPage ?? CalendarPage(isAdmin: widget.isAdmin),
       widget.bookingPage ?? const BookingPage(),
       widget.itemExchangePage ?? const ItemExchangePage(),
       widget.maintenancePage ?? const MaintenancePage(),
@@ -108,10 +108,7 @@ class _MainPageState extends State<MainPage> {
             icon: Icon(Icons.calendar_today),
             label: 'Calendar',
           ),
-          NavigationDestination(
-            icon: Icon(Icons.schedule),
-            label: 'Booking',
-          ),
+          NavigationDestination(icon: Icon(Icons.schedule), label: 'Booking'),
           NavigationDestination(
             icon: Icon(Icons.swap_horiz),
             label: 'Exchange',
@@ -154,6 +151,7 @@ class _MainPageState extends State<MainPage> {
           ).showSnackBar(const SnackBar(content: Text('No map action')));
         };
       case 2:
+        if (!widget.isAdmin) return null;
         return () async {
           await showAddEventDialog(context, (title, date, location) async {
             final service = EventService();

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -17,8 +17,8 @@ class EventService extends ApiService {
       await box?.put('events', events.map((e) => e.toJson()).toList());
       return events;
     } catch (e) {
-      final cached = box?.get('events', defaultValue: const <dynamic>[])
-          as List?;
+      final cached =
+          box?.get('events', defaultValue: const <dynamic>[]) as List?;
       if (cached == null || cached.isEmpty) {
         rethrow;
       }
@@ -35,11 +35,10 @@ class EventService extends ApiService {
   }
 
   Future<CalendarEvent> updateEvent(CalendarEvent event) async {
-    return post(
+    return put(
       '/events/${event.id}',
       event.toJson(),
-      (json) =>
-          CalendarEvent.fromJson(json['data'] as Map<String, dynamic>),
+      (json) => CalendarEvent.fromJson(json['data'] as Map<String, dynamic>),
     );
   }
 

--- a/lib/services/maintenance_service.dart
+++ b/lib/services/maintenance_service.dart
@@ -23,14 +23,11 @@ class MaintenanceService extends ApiService {
     File? imageFile,
   }) async {
     if (imageFile != null) {
-      final req =
-          http.MultipartRequest('POST', buildUri('/maintenance'))
-            ..fields.addAll(
-              request.toJson().map((key, value) => MapEntry(key, '$value')),
-            )
-            ..files.add(
-              await http.MultipartFile.fromPath('image', imageFile.path),
-            );
+      final req = http.MultipartRequest('POST', buildUri('/maintenance'))
+        ..fields.addAll(
+          request.toJson().map((key, value) => MapEntry(key, '$value')),
+        )
+        ..files.add(await http.MultipartFile.fromPath('image', imageFile.path));
       final streamed = await client.send(req);
       final response = await http.Response.fromStream(streamed);
       if (response.statusCode == 201 || response.statusCode == 200) {
@@ -66,7 +63,7 @@ class MaintenanceService extends ApiService {
   }
 
   Future<MaintenanceRequest> updateStatus(int id, String status) async {
-    return post(
+    return put(
       '/maintenance/$id',
       {'status': status},
       (json) => MaintenanceRequest.fromJson(json as Map<String, dynamic>),

--- a/server/middleware/requireAdmin.js
+++ b/server/middleware/requireAdmin.js
@@ -1,0 +1,13 @@
+const User = require('../models/User');
+
+module.exports = async function(req, res, next) {
+  try {
+    const user = await User.findById(req.userId);
+    if (!user || !user.isAdmin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const Event = require('../models/Event');
 const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
 
 const router = express.Router();
 router.use(auth);
@@ -16,7 +17,7 @@ router.get('/', async (req, res) => {
 });
 
 // POST /events - create event
-router.post('/', async (req, res) => {
+router.post('/', requireAdmin, async (req, res) => {
   try {
     const event = await Event.create(req.body);
     res.json({ data: event });
@@ -25,8 +26,8 @@ router.post('/', async (req, res) => {
   }
 });
 
-// POST /events/:id - update event
-router.post('/:id', async (req, res) => {
+// PUT /events/:id - update event
+router.put('/:id', requireAdmin, async (req, res) => {
   try {
     const event = await Event.findByIdAndUpdate(req.params.id, req.body, {
       new: true

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -2,6 +2,7 @@ const express = require('express');
 const MaintenanceRequest = require('../models/MaintenanceRequest');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
 const multer = require('multer');
 const path = require('path');
 
@@ -72,8 +73,8 @@ router.post('/:id/messages', async (req, res) => {
   }
 });
 
-// POST /maintenance/:id - update status
-router.post('/:id', async (req, res) => {
+// PUT /maintenance/:id - update status
+router.put('/:id', requireAdmin, async (req, res) => {
   try {
     const request = await MaintenanceRequest.findByIdAndUpdate(
       req.params.id,

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -9,6 +9,7 @@ const Message = require('../models/Message');
 const MaintenanceRequest = require('../models/MaintenanceRequest');
 const BulletinPost = require('../models/BulletinPost');
 const BulletinComment = require('../models/BulletinComment');
+const User = require('../models/User');
 
 function getToken(id = 1) {
   return Buffer.from(`${id}:${Date.now()}`).toString('base64');
@@ -47,7 +48,8 @@ describe('Events API', () => {
   });
 
   test('POST /events creates event', async () => {
-    const token = await getToken();
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = Buffer.from(`${admin._id}:${Date.now()}`).toString('base64');
     const res = await request(app)
       .post('/api/events')
       .set('Authorization', `Bearer ${token}`)
@@ -56,11 +58,12 @@ describe('Events API', () => {
     expect(res.body.data.title).toBe('Meet');
   });
 
-  test('POST /events/:id updates event', async () => {
+  test('PUT /events/:id updates event', async () => {
     const event = await Event.create({ title: 'Old', date: new Date(0) });
-    const token = await getToken();
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = Buffer.from(`${admin._id}:${Date.now()}`).toString('base64');
     const res = await request(app)
-      .post(`/api/events/${event._id}`)
+      .put(`/api/events/${event._id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ title: 'New' });
     expect(res.status).toBe(200);
@@ -206,15 +209,16 @@ describe('Maintenance API', () => {
     expect(res.body.data.content).toBe('Hello');
   });
 
-  test('POST /maintenance/:id updates status', async () => {
+  test('PUT /maintenance/:id updates status', async () => {
     const req = await MaintenanceRequest.create({
       userId: 1,
       subject: 'Leak',
       description: 'Water'
     });
-    const token = await getToken();
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = Buffer.from(`${admin._id}:${Date.now()}`).toString('base64');
     const res = await request(app)
-      .post(`/api/maintenance/${req._id}`)
+      .put(`/api/maintenance/${req._id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({ status: 'closed' });
     expect(res.status).toBe(200);

--- a/test/calendar_page_test.dart
+++ b/test/calendar_page_test.dart
@@ -16,17 +16,16 @@ class FakeEventService extends EventService {
   Future<List<CalendarEvent>> fetchEvents() async => events;
   @override
   Future<CalendarEvent> createEvent(CalendarEvent event) async {
-    final newEvent =
-        event.id != null
-            ? event
-            : CalendarEvent(
-              id: events.length + 1,
-              title: event.title,
-              date: event.date,
-              description: event.description,
-              attendees: event.attendees,
-              location: event.location,
-            );
+    final newEvent = event.id != null
+        ? event
+        : CalendarEvent(
+            id: events.length + 1,
+            title: event.title,
+            date: event.date,
+            description: event.description,
+            attendees: event.attendees,
+            location: event.location,
+          );
     events.add(newEvent);
     return newEvent;
   }
@@ -62,7 +61,9 @@ class ErrorEventService extends EventService {
 void main() {
   testWidgets('Add event displays in list', (tester) async {
     final service = FakeEventService();
-    await tester.pumpWidget(MaterialApp(home: CalendarPage(service: service)));
+    await tester.pumpWidget(
+      MaterialApp(home: CalendarPage(service: service, isAdmin: true)),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('No events for this day.'), findsOneWidget);

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -65,8 +65,8 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.widgetWithText(AppBar, 'Calendar'), findsOneWidget);
-    // Calendar page includes its own FAB so at least one is present.
-    expect(find.byType(FloatingActionButton), findsWidgets);
+    // No FABs visible for regular user.
+    expect(find.byType(FloatingActionButton), findsNothing);
 
     // Navigate to Maintenance tab
     await tester.tap(
@@ -102,6 +102,7 @@ void main() {
       MaterialApp(
         home: MainPage(
           calendarPage: CalendarPage(service: fakeEventService),
+          isAdmin: true,
           onLogout: () {},
         ),
       ),

--- a/test/services/event_service_test.dart
+++ b/test/services/event_service_test.dart
@@ -69,7 +69,7 @@ void main() {
       expect(event.location, input.location);
     });
 
-    test('updateEvent posts to event id', () async {
+    test('updateEvent uses PUT', () async {
       final input = CalendarEvent(
         id: 1,
         title: 'Edit',
@@ -77,7 +77,7 @@ void main() {
         location: 'loc3',
       );
       final mockClient = MockClient((request) async {
-        expect(request.method, equals('POST'));
+        expect(request.method, equals('PUT'));
         expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/events/1');
         final body = jsonDecode(request.body) as Map<String, dynamic>;

--- a/test/services/maintenance_service_test.dart
+++ b/test/services/maintenance_service_test.dart
@@ -116,9 +116,9 @@ void main() {
       expect(message.id, 3);
     });
 
-    test('updateStatus posts update', () async {
+    test('updateStatus uses PUT', () async {
       final mockClient = MockClient((request) async {
-        expect(request.method, equals('POST'));
+        expect(request.method, equals('PUT'));
         expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/maintenance/1');
         final body = jsonDecode(request.body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- support admin checks on events and maintenance routes
- allow admins to create events directly from AdminEventPage
- hide event creation from non-admins in CalendarPage/MainPage
- switch services to use new PUT endpoints
- update tests for the new behaviour

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841e8db8658832b94caa9aaaa93294c