### PR TITLE
Implement notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ class OlyApp extends StatefulWidget {
 class _OlyAppState extends State<OlyApp> {
   bool _loggedIn = false;
   bool _isAdmin = false;
+  final List<Map<String, String?>> _notifications = [];
 
   @override
   void initState() {
@@ -68,6 +69,19 @@ class _OlyAppState extends State<OlyApp> {
       _loggedIn = true;
       _isAdmin = user.isAdmin;
     }
+    FirebaseMessaging.onMessage.listen((message) {
+      final notif = message.notification;
+      if (notif != null) {
+        if (mounted) {
+          setState(() {
+            _notifications.add({'title': notif.title, 'body': notif.body});
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(notif.title ?? 'Notification')),
+          );
+        }
+      }
+    });
   }
 
   Future<void> _handleLogin() async {
@@ -102,7 +116,11 @@ class _OlyAppState extends State<OlyApp> {
       ),
       home:
           _loggedIn
-              ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
+              ? MainPage(
+                  isAdmin: _isAdmin,
+                  onLogout: _logout,
+                  notifications: _notifications,
+                )
               : LoginPage(onLoginSuccess: () => _handleLogin()),
     );
   }

--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'event_admin_page.dart';
 import 'maintenance_admin_page.dart';
+import 'notification_admin_page.dart';
 
 class AdminHomePage extends StatelessWidget {
   const AdminHomePage({super.key});
@@ -21,15 +22,27 @@ class AdminHomePage extends StatelessWidget {
               child: const Text('Manage Events'),
             ),
             const SizedBox(height: 12),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const MaintenanceAdminPage()));
+                },
+                child: const Text('Maintenance Tickets'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const MaintenanceAdminPage()));
-              },
-              child: const Text('Maintenance Tickets'),
-            )
+                      builder: (_) => const NotificationAdminPage(),
+                    ),
+                  );
+                },
+                child: const Text('Send Notification'),
+              )
           ],
         ),
       ),

--- a/lib/pages/admin/notification_admin_page.dart
+++ b/lib/pages/admin/notification_admin_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import '../../services/notification_service.dart';
+
+class NotificationAdminPage extends StatefulWidget {
+  const NotificationAdminPage({super.key});
+
+  @override
+  State<NotificationAdminPage> createState() => _NotificationAdminPageState();
+}
+
+class _NotificationAdminPageState extends State<NotificationAdminPage> {
+  final TextEditingController _titleCtrl = TextEditingController();
+  final TextEditingController _bodyCtrl = TextEditingController();
+
+  bool _sending = false;
+  String? _result;
+
+  Future<void> _send() async {
+    final token = await FirebaseMessaging.instance.getToken();
+    if (token == null) return;
+    setState(() => _sending = true);
+    try {
+      final count = await NotificationService().sendNotification(
+        tokens: [token],
+        title: _titleCtrl.text.trim(),
+        body: _bodyCtrl.text.trim(),
+      );
+      setState(() => _result = 'Sent to $count device(s)');
+    } catch (e) {
+      setState(() => _result = 'Error: $e');
+    } finally {
+      setState(() => _sending = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _bodyCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Send Notification')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleCtrl,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _bodyCtrl,
+              decoration: const InputDecoration(labelText: 'Body'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _sending ? null : _send,
+              child: const Text('Send'),
+            ),
+            if (_result != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(_result!),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -8,6 +8,7 @@ import 'map_page.dart';
 import 'profile_page.dart';
 import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
+import 'notifications_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -18,6 +19,7 @@ class MainPage extends StatefulWidget {
   final ItemExchangePage? itemExchangePage;
   final bool isAdmin;
   final VoidCallback? onLogout;
+  final List<Map<String, String?>> notifications;
   const MainPage({
     super.key,
     this.calendarPage,
@@ -26,6 +28,7 @@ class MainPage extends StatefulWidget {
     this.itemExchangePage,
     this.isAdmin = false,
     this.onLogout,
+    this.notifications = const [],
   });
 
   @override
@@ -143,9 +146,14 @@ class _MainPageState extends State<MainPage> {
     switch (_currentIndex) {
       case 0:
         return () {
-          ScaffoldMessenger.of(
+          Navigator.push(
             context,
-          ).showSnackBar(const SnackBar(content: Text('No notifications')));
+            MaterialPageRoute(
+              builder: (_) => NotificationsPage(
+                notifications: widget.notifications,
+              ),
+            ),
+          );
         };
       case 1:
         return () {

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class NotificationsPage extends StatelessWidget {
+  final List<Map<String, String?>> notifications;
+  const NotificationsPage({super.key, required this.notifications});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notifications')),
+      body: notifications.isEmpty
+          ? const Center(child: Text('No notifications'))
+          : ListView.builder(
+              itemCount: notifications.length,
+              itemBuilder: (_, i) {
+                final n = notifications[i];
+                return ListTile(
+                  title: Text(n['title'] ?? ''),
+                  subtitle: Text(n['body'] ?? ''),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -6,4 +6,12 @@ class NotificationService extends ApiService {
   Future<void> registerToken(String token) async {
     await post('/notifications/register', {'token': token}, (_) => null);
   }
+
+  Future<int> sendNotification({required List<String> tokens, required String title, required String body}) async {
+    final result = await post('/notifications/send', {
+      'tokens': tokens,
+      'notification': {'title': title, 'body': body},
+    }, (json) => json['successCount'] as int);
+    return result;
+  }
 }

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -48,6 +48,7 @@ void main() {
           calendarPage: CalendarPage(service: fakeEventService),
           maintenancePage: MaintenancePage(service: fakeMaintenanceService),
           onLogout: () {},
+          notifications: const [],
         ),
       ),
     );
@@ -82,7 +83,9 @@ void main() {
 
   testWidgets('Admin card visible for admins', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: MainPage(isAdmin: true, onLogout: null)),
+      const MaterialApp(
+        home: MainPage(isAdmin: true, onLogout: null, notifications: []),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -90,7 +93,9 @@ void main() {
   });
 
   testWidgets('Admin card hidden for regular user', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: MainPage(onLogout: null)));
+    await tester.pumpWidget(
+      const MaterialApp(home: MainPage(onLogout: null, notifications: [])),
+    );
     await tester.pumpAndSettle();
     expect(find.text('Admin'), findsNothing);
   });
@@ -103,6 +108,7 @@ void main() {
         home: MainPage(
           calendarPage: CalendarPage(service: fakeEventService),
           onLogout: () {},
+          notifications: const [],
         ),
       ),
     );
@@ -131,6 +137,7 @@ void main() {
         home: MainPage(
           itemExchangePage: ItemExchangePage(service: fakeItemService),
           onLogout: null,
+          notifications: const [],
         ),
       ),
     );

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:oly_app/services/notification_service.dart';
+
+const apiUrl = String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+
+void main() {
+  group('NotificationService', () {
+    test('registerToken posts token', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
+        expect(request.url.path, '/api/notifications/register');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['token'], 'abc');
+        return http.Response('{}', 200);
+      });
+
+      final service = NotificationService(client: mockClient);
+      await service.registerToken('abc');
+    });
+
+    test('sendNotification posts data and returns count', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('POST'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
+        expect(request.url.path, '/api/notifications/send');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['tokens'], ['t1']);
+        expect((body['notification'] as Map)['title'], 'hi');
+        return http.Response(jsonEncode({'successCount': 1}), 200);
+      });
+
+      final service = NotificationService(client: mockClient);
+      final count = await service.sendNotification(tokens: ['t1'], title: 'hi', body: 'b');
+      expect(count, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `NotificationService.sendNotification`
- add admin page to send notifications
- add notifications page and integrate with dashboard
- handle Firebase messages and show toasts
- test `NotificationService`

## Testing
- `dart format -o none --set-exit-if-changed lib test`
- `flutter test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6841e971ca4c832bbb1f3c9db60fcc5d