### PR TITLE
Implement user bookings

### DIFF
--- a/lib/pages/booking_page.dart
+++ b/lib/pages/booking_page.dart
@@ -99,6 +99,7 @@ class _BookingPageState extends State<BookingPage> {
           _slots[key]?.remove(slot);
         });
         await _loadBookings();
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Booking confirmed')),
         );

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -16,4 +16,19 @@ class BookingService extends ApiService {
       'name': name,
     }, (_) => null);
   }
+
+  Future<List<Map<String, dynamic>>> fetchMyBookings() async {
+    return get('/bookings/my', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list.map<Map<String, dynamic>>((e) {
+        final map = Map<String, dynamic>.from(e as Map);
+        map['time'] = DateTime.parse(map['time'] as String);
+        return map;
+      }).toList();
+    });
+  }
+
+  Future<void> cancelBooking(String id) async {
+    await delete('/bookings/$id', (_) => null);
+  }
 }

--- a/server/models/BookingSlot.js
+++ b/server/models/BookingSlot.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const BookingSlotSchema = new mongoose.Schema({
   time: { type: Date, required: true, unique: true },
-  name: { type: String }
+  name: { type: String },
+  userId: { type: Number }
 });
 
 module.exports = mongoose.model('BookingSlot', BookingSlotSchema);

--- a/server/routes/bookings.js
+++ b/server/routes/bookings.js
@@ -23,11 +23,36 @@ router.post('/', async (req, res) => {
   try {
     const slot = await BookingSlot.findOneAndUpdate(
       { time: new Date(time), name: { $exists: false } },
-      { name },
+      { name, userId: Number(req.userId) },
       { new: true }
     );
 
     if (!slot) return res.status(400).json({ error: 'Slot unavailable' });
+    res.json({ data: slot });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /bookings/my - list current user's bookings
+router.get('/my', async (req, res) => {
+  try {
+    const bookings = await BookingSlot.find({ userId: Number(req.userId) });
+    res.json({ data: bookings });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /bookings/:id - cancel a booking
+router.delete('/:id', async (req, res) => {
+  try {
+    const slot = await BookingSlot.findByIdAndUpdate(
+      req.params.id,
+      { $unset: { name: '', userId: '' } },
+      { new: true }
+    );
+    if (!slot) return res.status(404).json({ error: 'Slot not found' });
     res.json({ data: slot });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/test/booking_page_test.dart
+++ b/test/booking_page_test.dart
@@ -6,6 +6,7 @@ import 'package:oly_app/services/booking_service.dart';
 class FakeBookingService extends BookingService {
   final List<DateTime> slots;
   FakeBookingService(this.slots);
+  final List<Map<String, dynamic>> bookings = [];
 
   @override
   Future<List<DateTime>> fetchAvailableTimes() async => slots;
@@ -13,12 +14,24 @@ class FakeBookingService extends BookingService {
   @override
   Future<void> createBooking(DateTime time, String name) async {
     slots.remove(time);
+    bookings.add({'_id': '1', 'time': time, 'name': name});
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchMyBookings() async => bookings;
+
+  @override
+  Future<void> cancelBooking(String id) async {
+    bookings.removeWhere((b) => b['_id'] == id);
   }
 }
 
 class ErrorBookingService extends BookingService {
   @override
   Future<List<DateTime>> fetchAvailableTimes() async => throw Exception('fail');
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchMyBookings() async => [];
 }
 
 void main() {
@@ -38,7 +51,8 @@ void main() {
     await tester.tap(find.widgetWithText(ElevatedButton, 'Book'));
     await tester.pumpAndSettle();
 
-    expect(find.text('10:00'), findsNothing);
+    expect(find.widgetWithText(TextButton, 'Book'), findsNothing);
+    expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
     expect(find.text('Booking confirmed'), findsOneWidget);
   });
 

--- a/test/services/booking_service_test.dart
+++ b/test/services/booking_service_test.dart
@@ -46,6 +46,42 @@ void main() {
       await service.createBooking(time, name);
     });
 
+    test('fetchMyBookings parses list', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.path, '/api/bookings/my');
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                '_id': '1',
+                'time': '2024-01-02T10:00:00.000Z',
+                'name': 'Me'
+              }
+            ]
+          }),
+          200,
+        );
+      });
+
+      final service = BookingService(client: mockClient);
+      final result = await service.fetchMyBookings();
+      expect(result, hasLength(1));
+      expect(result.first['_id'], '1');
+      expect(result.first['time'], DateTime.parse('2024-01-02T10:00:00.000Z'));
+    });
+
+    test('cancelBooking uses DELETE', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('DELETE'));
+        expect(request.url.path, '/api/bookings/1');
+        return http.Response('{}', 200);
+      });
+
+      final service = BookingService(client: mockClient);
+      await service.cancelBooking('1');
+    });
+
     test('throws on error status', () async {
       final mockClient =
           MockClient((_) async => http.Response('error', 500));


### PR DESCRIPTION
## Summary
- store `userId` on booking slots
- add endpoints to list and delete user bookings
- support cancellation in booking service
- show current bookings with cancel button in booking page
- test booking features

## Testing
- `MONGOMS_DOWNLOAD_DIR=/tmp npm test --prefix server`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841f89c6eb4832ba05ce467282f9790