### PR TITLE
Add event deletion support

### DIFF
--- a/lib/pages/admin/event_admin_page.dart
+++ b/lib/pages/admin/event_admin_page.dart
@@ -58,6 +58,11 @@ class _EventAdminPageState extends State<EventAdminPage> {
     }
   }
 
+  Future<void> _deleteEvent(int id) async {
+    await _service.deleteEvent(id);
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -77,7 +82,23 @@ class _EventAdminPageState extends State<EventAdminPage> {
         itemCount: _events.length,
         itemBuilder: (ctx, i) {
           final e = _events[i];
-          return ListTile(title: Text(e.title), onTap: () => _editEvent(e));
+          return ListTile(
+            title: Text(e.title),
+            onTap: () => _editEvent(e),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => _editEvent(e),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: () => _deleteEvent(e.id!),
+                ),
+              ],
+            ),
+          );
         },
       ),
     );

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -52,4 +52,8 @@ class EventService extends ApiService {
       return list.map((e) => e as int).toList();
     });
   }
+
+  Future<void> deleteEvent(int id) async {
+    await delete('/events/$id', (_) => null);
+  }
 }

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -39,6 +39,17 @@ router.put('/:id', requireAdmin, async (req, res) => {
   }
 });
 
+// DELETE /events/:id - remove event
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const event = await Event.findByIdAndDelete(req.params.id);
+    if (!event) return res.status(404).json({ error: 'Event not found' });
+    res.json({ data: event });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 // POST /events/:id/rsvp - add attendee
 router.post('/:id/rsvp', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- implement DELETE /events/:id endpoint
- add deleteEvent helper in Dart service
- show edit & delete icons in EventAdminPage
- refresh events list after deleting

## Testing
- `npm test`
- `flutter test` *(fails: Edits persist and reload, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841fe970e60832b931960148cbb33ac