### PR TITLE
Implement user profile update support

### DIFF
--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,0 +1,14 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class UserService extends ApiService {
+  UserService({super.client});
+
+  Future<User> updateProfile(User user) async {
+    return put(
+      '/users/me',
+      user.toJson(),
+      (json) => User.fromJson((json['data'] as Map<String, dynamic>)),
+    );
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -8,6 +8,7 @@ const bookingsRouter = require('../routes/bookings');
 const bulletinRouter = require('../routes/bulletin');
 const pinsRouter = require('../routes/pins');
 const notificationsRouter = require('../routes/notifications');
+const usersRouter = require('../routes/users');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -21,4 +22,5 @@ router.use('/bookings', bookingsRouter);
 router.use('/bulletin', bulletinRouter);
 router.use('/pins', pinsRouter);
 router.use('/notifications', notificationsRouter);
+router.use('/users', usersRouter);
 module.exports = router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const User = require('../models/User');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// PUT /users/me - update current user's profile
+router.put('/me', async (req, res) => {
+  try {
+    const { name, email, avatarUrl } = req.body;
+    const updates = { name, email, avatarUrl };
+    const user = await User.findByIdAndUpdate(req.userId, updates, {
+      new: true,
+    });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({
+      data: {
+        id: user._id,
+        name: user.name,
+        email: user.email,
+        avatarUrl: user.avatarUrl,
+        isAdmin: user.isAdmin,
+      },
+    });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/users.test.js
+++ b/server/tests/users.test.js
@@ -1,0 +1,54 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const apiRouter = require('../api');
+const User = require('../models/User');
+const bcrypt = require('bcryptjs');
+
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('Users API', () => {
+  test('PUT /users/me updates profile', async () => {
+    const hash = await bcrypt.hash('pass', 1);
+    const user = await User.create({
+      name: 'Old',
+      email: 'old@test.com',
+      passwordHash: hash,
+    });
+    const token = jwt.sign({ userId: user._id.toString() }, SECRET);
+
+    const res = await request(app)
+      .put('/api/users/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New', email: 'new@test.com', avatarUrl: 'pic' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('New');
+    const updated = await User.findById(user._id);
+    expect(updated.name).toBe('New');
+    expect(updated.email).toBe('new@test.com');
+    expect(updated.avatarUrl).toBe('pic');
+  });
+});

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -5,6 +5,16 @@ import 'package:network_image_mock/network_image_mock.dart';
 import 'package:hive/hive.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/profile_page.dart';
+import 'package:oly_app/services/user_service.dart';
+
+class FakeUserService extends UserService {
+  User? updated;
+  @override
+  Future<User> updateProfile(User user) async {
+    updated = user;
+    return user;
+  }
+}
 
 void main() {
   late Directory dir;
@@ -15,6 +25,7 @@ void main() {
     Hive.init(dir.path);
     Hive.registerAdapter(UserAdapter());
     await Hive.openBox<User>('userBox');
+    await Hive.openBox('settingsBox');
   });
 
   tearDown(() async {
@@ -30,8 +41,10 @@ void main() {
         final box = Hive.box<User>('userBox');
         await box.put('currentUser', User(name: 'Old', email: 'old@test.com'));
 
+        final service = FakeUserService();
+
         // 2) Pump ProfilePage:
-        await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+        await tester.pumpWidget(MaterialApp(home: ProfilePage(service: service)));
         // Give 300ms for any images/animations to complete (instead of pumpAndSettle):
         await tester.pump(const Duration(milliseconds: 300));
  
@@ -60,13 +73,16 @@ void main() {
         // Wait 300ms for any save‐animation or Hive write to complete:
         await tester.pump(const Duration(milliseconds: 300));
 
-        // 7) Verify that Hive actually wrote the updated user:
+        // 7) Verify that service was called and Hive wrote the updated user:
+        expect(service.updated!.name, 'New Name');
+        expect(service.updated!.email, 'new@example.com');
+        
         final saved = Hive.box<User>('userBox').get('currentUser')!;
         expect(saved.name, 'New Name');
         expect(saved.email, 'new@example.com');
 
         // 8) Re‐pump the ProfilePage and give it time to rebuild:
-        await tester.pumpWidget(const MaterialApp(home: ProfilePage()));
+        await tester.pumpWidget(MaterialApp(home: ProfilePage(service: service)));
         await tester.pump(const Duration(milliseconds: 300));
 
         // 9) Finally, confirm that the text fields now show “New Name” / “new@example.com”:


### PR DESCRIPTION
## Summary
- add `/users/me` endpoint on the backend
- expose profile update API through new `UserService`
- wire `ProfilePage` to use `UserService.updateProfile`
- cover profile updates with unit tests

## Testing
- `npm test`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6841fe9c5fac832ba69f48938aa08e70