### PR TITLE
Use current user ID from Hive

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,14 +51,14 @@ void main() async {
 class OlyApp extends StatefulWidget {
   const OlyApp({super.key});
 
-  static _OlyAppState? of(BuildContext context) =>
-      context.findAncestorStateOfType<_OlyAppState>();
+  static OlyAppState? of(BuildContext context) =>
+      context.findAncestorStateOfType<OlyAppState>();
 
   @override
-  State<OlyApp> createState() => _OlyAppState();
+  State<OlyApp> createState() => OlyAppState();
 }
 
-class _OlyAppState extends State<OlyApp> {
+class OlyAppState extends State<OlyApp> {
   bool _loggedIn = false;
   bool _isAdmin = false;
   ThemeMode _themeMode = ThemeMode.light;

--- a/lib/pages/admin/event_admin_page.dart
+++ b/lib/pages/admin/event_admin_page.dart
@@ -58,6 +58,11 @@ class _EventAdminPageState extends State<EventAdminPage> {
     }
   }
 
+  Future<void> _deleteEvent(int id) async {
+    await _service.deleteEvent(id);
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -77,7 +82,23 @@ class _EventAdminPageState extends State<EventAdminPage> {
         itemCount: _events.length,
         itemBuilder: (ctx, i) {
           final e = _events[i];
-          return ListTile(title: Text(e.title), onTap: () => _editEvent(e));
+          return ListTile(
+            title: Text(e.title),
+            onTap: () => _editEvent(e),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => _editEvent(e),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: () => _deleteEvent(e.id!),
+                ),
+              ],
+            ),
+          );
         },
       ),
     );

--- a/lib/pages/item_chat_page.dart
+++ b/lib/pages/item_chat_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/models.dart';
 import '../services/item_service.dart';
+import '../utils/user_helpers.dart';
 
 class ItemChatPage extends StatefulWidget {
   final Item item;
@@ -40,7 +41,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
     if (text.isEmpty || widget.item.id == null) return;
     final message = Message(
       requestId: widget.item.id!,
-      senderId: 1,
+      senderId: currentUserId(),
       content: text,
     );
     try {
@@ -77,7 +78,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
               itemCount: _messages.length,
               itemBuilder: (context, index) {
                 final msg = _messages[index];
-                final isMe = msg.senderId == 1;
+                final isMe = msg.senderId == currentUserId();
                 return Align(
                   alignment:
                       isMe ? Alignment.centerRight : Alignment.centerLeft,

--- a/lib/pages/maintenance_chat_page.dart
+++ b/lib/pages/maintenance_chat_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/models.dart';
 import '../services/maintenance_service.dart';
+import '../utils/user_helpers.dart';
 
 class MaintenanceChatPage extends StatefulWidget {
   final MaintenanceRequest request;
@@ -33,7 +34,7 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
     if (text.isEmpty || widget.request.id == null) return;
     final message = Message(
       requestId: widget.request.id!,
-      senderId: 1,
+      senderId: currentUserId(),
       content: text,
     );
     final saved = await _service.sendMessage(message);
@@ -65,7 +66,7 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
               itemCount: _messages.length,
               itemBuilder: (context, index) {
                 final msg = _messages[index];
-                final isMe = msg.senderId == 1;
+                final isMe = msg.senderId == currentUserId();
                 return Align(
                   alignment:
                       isMe ? Alignment.centerRight : Alignment.centerLeft,

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -5,6 +5,7 @@ import '../models/models.dart';
 import 'package:image_picker/image_picker.dart';
 import '../services/maintenance_service.dart';
 import 'maintenance_chat_page.dart';
+import '../utils/user_helpers.dart';
 
 class MaintenancePage extends StatefulWidget {
   final MaintenanceService? service;
@@ -133,7 +134,7 @@ class _MaintenancePageState extends State<MaintenancePage> {
               if (subject.isEmpty || desc.isEmpty) return;
               await _service.createRequest(
                 MaintenanceRequest(
-                  userId: 1,
+                  userId: currentUserId(),
                   subject: subject,
                   description: desc,
                 ),

--- a/lib/pages/post_item_page.dart
+++ b/lib/pages/post_item_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import '../models/models.dart';
 import '../services/item_service.dart';
+import '../utils/user_helpers.dart';
 
 class PostItemPage extends StatefulWidget {
   final Item? item;
@@ -70,7 +71,7 @@ class _PostItemPageState extends State<PostItemPage> {
       final editing = _editing;
       final item = Item(
         id: editing ? widget.item!.id : null,
-        ownerId: editing ? widget.item!.ownerId : 1,
+        ownerId: editing ? widget.item!.ownerId : currentUserId(),
         title: _titleCtrl.text.trim(),
         description:
             _descCtrl.text.trim().isEmpty ? null : _descCtrl.text.trim(),

--- a/lib/services/event_service.dart
+++ b/lib/services/event_service.dart
@@ -52,4 +52,8 @@ class EventService extends ApiService {
       return list.map((e) => e as int).toList();
     });
   }
+
+  Future<void> deleteEvent(int id) async {
+    await delete('/events/$id', (_) => null);
+  }
 }

--- a/lib/utils/user_helpers.dart
+++ b/lib/utils/user_helpers.dart
@@ -1,0 +1,9 @@
+import 'package:hive/hive.dart';
+import '../models/models.dart';
+
+/// Returns the id of the currently logged in user or 0 if unavailable.
+int currentUserId() {
+  if (!Hive.isBoxOpen('userBox')) return 0;
+  final user = Hive.box<User>('userBox').get('currentUser');
+  return user?.id ?? 0;
+}

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -39,6 +39,17 @@ router.put('/:id', requireAdmin, async (req, res) => {
   }
 });
 
+// DELETE /events/:id - remove event
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const event = await Event.findByIdAndDelete(req.params.id);
+    if (!event) return res.status(404).json({ error: 'Event not found' });
+    res.json({ data: event });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 // POST /events/:id/rsvp - add attendee
 router.post('/:id/rsvp', async (req, res) => {
   try {

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -73,6 +73,19 @@ describe('Events API', () => {
     expect(res.body.data.title).toBe('New');
   });
 
+  test('DELETE /events/:id removes event', async () => {
+    const event = await Event.create({ title: 'Temp', date: new Date(0) });
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = jwt.sign({ userId: admin._id }, SECRET);
+
+    const res = await request(app)
+      .delete(`/api/events/${event._id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const remaining = await Event.findById(event._id);
+    expect(remaining).toBeNull();
+  });
+
   test('POST /events/:id/rsvp adds attendee', async () => {
     const event = await Event.create({ title: 'Party', date: new Date(0) });
     const token = await getToken();

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -15,6 +15,7 @@ void main() {
     Hive.init(dir.path);
     Hive.registerAdapter(UserAdapter());
     await Hive.openBox<User>('userBox');
+    await Hive.openBox('settingsBox');
   });
 
   tearDown(() async {


### PR DESCRIPTION
## Summary
- add `currentUserId` helper for reading the logged in user's id
- use helper when creating items, maintenance requests, and messages
- update chat message alignment checks to rely on the helper
- merge latest changes from `main`

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`
- `npm install` && `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841fe999888832bbe549baa99bd1197