### PR TITLE
Add map pin admin management

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -4,6 +4,7 @@ import 'maintenance_admin_page.dart';
 import 'notification_admin_page.dart';
 import 'bulletin_admin_page.dart';
 import 'booking_admin_page.dart';
+import 'map_admin_page.dart';
 
 class AdminHomePage extends StatelessWidget {
   const AdminHomePage({super.key});
@@ -68,6 +69,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Booking Slots'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MapAdminPage()),
+                );
+              },
+              child: const Text('Map Pins'),
             ),
           ],
         ),

--- a/lib/pages/admin/map_admin_page.dart
+++ b/lib/pages/admin/map_admin_page.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import '../../models/map_pin.dart';
+import '../../services/map_service.dart';
+
+class MapAdminPage extends StatefulWidget {
+  final MapService? service;
+  const MapAdminPage({super.key, this.service});
+
+  @override
+  State<MapAdminPage> createState() => _MapAdminPageState();
+}
+
+class _MapAdminPageState extends State<MapAdminPage> {
+  late final MapService _service;
+  List<MapPin> _pins = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? MapService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final pins = await _service.fetchPins();
+    setState(() => _pins = pins);
+  }
+
+  Future<void> _addPin() async {
+    final pin = await _showPinDialog();
+    if (pin != null) {
+      await _service.createPin(pin);
+      _load();
+    }
+  }
+
+  Future<void> _editPin(MapPin pin) async {
+    final result = await _showPinDialog(pin);
+    if (result != null) {
+      await _service.updatePin(result);
+      _load();
+    }
+  }
+
+  Future<void> _deletePin(String id) async {
+    await _service.deletePin(id);
+    _load();
+  }
+
+  Future<MapPin?> _showPinDialog([MapPin? pin]) async {
+    final idCtrl = TextEditingController(text: pin?.id ?? '');
+    final titleCtrl = TextEditingController(text: pin?.title ?? '');
+    final latCtrl = TextEditingController(text: pin?.lat.toString() ?? '');
+    final lonCtrl = TextEditingController(text: pin?.lon.toString() ?? '');
+    MapPinCategory category = pin?.category ?? MapPinCategory.building;
+    return showDialog<MapPin>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setState) {
+            return AlertDialog(
+              title: Text(pin == null ? 'Add Pin' : 'Edit Pin'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: idCtrl,
+                      decoration: const InputDecoration(labelText: 'ID'),
+                    ),
+                    TextField(
+                      controller: titleCtrl,
+                      decoration: const InputDecoration(labelText: 'Title'),
+                    ),
+                    TextField(
+                      controller: latCtrl,
+                      decoration: const InputDecoration(labelText: 'Latitude'),
+                      keyboardType: TextInputType.number,
+                    ),
+                    TextField(
+                      controller: lonCtrl,
+                      decoration: const InputDecoration(labelText: 'Longitude'),
+                      keyboardType: TextInputType.number,
+                    ),
+                    DropdownButton<MapPinCategory>(
+                      value: category,
+                      onChanged: (v) => setState(() => category = v!),
+                      items: MapPinCategory.values
+                          .map(
+                            (c) => DropdownMenuItem(
+                              value: c,
+                              child: Text(c.name[0].toUpperCase() + c.name.substring(1)),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx),
+                  child: const Text('Cancel'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    final id = idCtrl.text.trim();
+                    final title = titleCtrl.text.trim();
+                    final lat = double.tryParse(latCtrl.text) ?? 0;
+                    final lon = double.tryParse(lonCtrl.text) ?? 0;
+                    if (id.isEmpty || title.isEmpty) return;
+                    Navigator.pop(
+                      ctx,
+                      MapPin(
+                        id: id,
+                        title: title,
+                        lat: lat,
+                        lon: lon,
+                        category: category,
+                      ),
+                    );
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manage Map Pins')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addPin,
+        child: const Icon(Icons.add),
+      ),
+      body: ListView.builder(
+        itemCount: _pins.length,
+        itemBuilder: (ctx, i) {
+          final p = _pins[i];
+          return ListTile(
+            title: Text(p.title),
+            subtitle: Text('${p.lat}, ${p.lon} (${p.category.name})'),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => _editPin(p),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: () => _deletePin(p.id),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -51,4 +51,40 @@ class MapService {
     }
     return [];
   }
+
+  Future<MapPin> createPin(MapPin pin) async {
+    final uri = ApiService().buildUri('/pins');
+    final res = await _client.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(pin.toMap()),
+    );
+    if (res.statusCode == 200 || res.statusCode == 201) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      return MapPin.fromMap(data['data'] as Map<String, dynamic>);
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+
+  Future<MapPin> updatePin(MapPin pin) async {
+    final uri = ApiService().buildUri('/pins/${pin.id}');
+    final res = await _client.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(pin.toMap()),
+    );
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      return MapPin.fromMap(data['data'] as Map<String, dynamic>);
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+
+  Future<void> deletePin(String id) async {
+    final uri = ApiService().buildUri('/pins/$id');
+    final res = await _client.delete(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Request failed: ${res.statusCode}');
+    }
+  }
 }

--- a/server/routes/pins.js
+++ b/server/routes/pins.js
@@ -36,4 +36,15 @@ router.post('/:id', async (req, res) => {
   }
 });
 
+// DELETE /pins/:id - remove a pin
+router.delete('/:id', async (req, res) => {
+  try {
+    const pin = await MapPin.findOneAndDelete({ id: req.params.id });
+    if (!pin) return res.status(404).json({ error: 'Pin not found' });
+    res.json({ data: pin });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/tests/pins.test.js
+++ b/server/tests/pins.test.js
@@ -47,4 +47,18 @@ describe('Pins API', () => {
     expect(res.status).toBe(201);
     expect(res.body.data.title).toBe('Cafe');
   });
+
+  test('DELETE /pins/:id removes pin', async () => {
+    await MapPin.create({
+      id: '3',
+      title: 'Hall',
+      lat: 2,
+      lon: 2,
+      category: 'venue',
+    });
+    const res = await request(app).delete('/api/pins/3');
+    expect(res.status).toBe(200);
+    const remaining = await MapPin.find();
+    expect(remaining).toHaveLength(0);
+  });
 });

--- a/test/services/map_service_test.dart
+++ b/test/services/map_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:oly_app/services/map_service.dart';
+import 'package:oly_app/models/map_pin.dart';
 
 void main() {
   group('MapService', () {
@@ -31,7 +32,46 @@ void main() {
 
       expect(pins, hasLength(1));
       expect(pins.first.id, '1');
-      expect(pins.first.title, 'Dorm');
+    expect(pins.first.title, 'Dorm');
+  });
+
+    test('create/update/delete pin uses correct endpoints', () async {
+      int step = 0;
+      final mockClient = MockClient((request) async {
+        if (step == 0) {
+          expect(request.method, equals('POST'));
+          expect(request.url.path, '/api/pins');
+          step++;
+          return http.Response(
+            jsonEncode({'data': jsonDecode(request.body)}),
+            201,
+          );
+        } else if (step == 1) {
+          expect(request.method, equals('POST'));
+          expect(request.url.path, '/api/pins/1');
+          step++;
+          return http.Response(
+            jsonEncode({'data': jsonDecode(request.body)}),
+            200,
+          );
+        } else {
+          expect(request.method, equals('DELETE'));
+          expect(request.url.path, '/api/pins/1');
+          return http.Response('{}', 200);
+        }
+      });
+
+      final service = MapService(client: mockClient);
+      final pin = MapPin(
+        id: '1',
+        title: 't',
+        lat: 0,
+        lon: 0,
+        category: MapPinCategory.building,
+      );
+      await service.createPin(pin);
+      await service.updatePin(pin);
+      await service.deletePin('1');
     });
   });
 }


### PR DESCRIPTION
## Summary
- add DELETE endpoint for map pins on server
- enable pins deletion test
- expand MapService with create/update/delete
- create admin page for managing map pins
- link map admin page from admin home

## Testing
- `npm test`
- `flutter test` *(fails: unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68420d45e854832b8445ab348f517786