### PR TITLE
Add user tracking for bulletin posts

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -290,20 +290,23 @@ class Item {
 
 class BulletinPost {
   final int? id;
+  final int userId;
   final String content;
   final DateTime date;
 
-  BulletinPost({this.id, required this.content, DateTime? date})
+  BulletinPost({this.id, required this.userId, required this.content, DateTime? date})
     : date = date ?? DateTime.now();
 
   factory BulletinPost.fromMap(Map<String, dynamic> map) => BulletinPost(
     id: map['id'] as int?,
+    userId: map['userId'] as int,
     content: map['content'] as String,
     date: _parseDate(map['date']),
   );
 
   Map<String, dynamic> toMap() => {
     if (id != null) 'id': id,
+    'userId': userId,
     'content': content,
     'date': date.toIso8601String(),
   };
@@ -316,12 +319,14 @@ class BulletinPost {
 class BulletinComment {
   final int? id;
   final int postId;
+  final int userId;
   final String content;
   final DateTime date;
 
   BulletinComment({
     this.id,
     required this.postId,
+    required this.userId,
     required this.content,
     DateTime? date,
   }) : date = date ?? DateTime.now();
@@ -329,6 +334,7 @@ class BulletinComment {
   factory BulletinComment.fromMap(Map<String, dynamic> map) => BulletinComment(
     id: map['id'] as int?,
     postId: map['postId'] as int,
+    userId: map['userId'] as int,
     content: map['content'] as String,
     date: _parseDate(map['date']),
   );
@@ -336,6 +342,7 @@ class BulletinComment {
   Map<String, dynamic> toMap() => {
     if (id != null) 'id': id,
     'postId': postId,
+    'userId': userId,
     'content': content,
     'date': date.toIso8601String(),
   };

--- a/lib/pages/admin/bulletin_admin_page.dart
+++ b/lib/pages/admin/bulletin_admin_page.dart
@@ -49,6 +49,7 @@ class _BulletinAdminPageState extends State<BulletinAdminPage> {
     if (result != null && result.isNotEmpty) {
       final updated = BulletinPost(
         id: post.id,
+        userId: post.userId,
         content: result,
         date: post.date,
       );

--- a/server/models/BulletinComment.js
+++ b/server/models/BulletinComment.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const BulletinCommentSchema = new mongoose.Schema({
   id: { type: Number, required: true, unique: true },
   postId: { type: Number, required: true },
+  userId: { type: Number, required: true },
   content: { type: String, required: true },
   date: { type: Date, default: Date.now },
 });

--- a/server/models/BulletinPost.js
+++ b/server/models/BulletinPost.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 
 const BulletinPostSchema = new mongoose.Schema({
   id: { type: Number, required: true, unique: true },
+  userId: { type: Number, required: true },
   content: { type: String, required: true },
   date: { type: Date, default: Date.now },
 });

--- a/server/routes/bulletin.js
+++ b/server/routes/bulletin.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const BulletinPost = require('../models/BulletinPost');
 const BulletinComment = require('../models/BulletinComment');
+const auth = require('../middleware/auth');
 
 const router = express.Router();
+router.use(auth);
 
 // helper to get next numeric id for a model
 async function nextId(model) {
@@ -25,6 +27,7 @@ router.post('/', async (req, res) => {
   try {
     const post = await BulletinPost.create({
       id: await nextId(BulletinPost),
+      userId: Number(req.userId),
       content: req.body.content,
       date: req.body.date,
     });
@@ -50,6 +53,7 @@ router.post('/:id/comments', async (req, res) => {
     const comment = await BulletinComment.create({
       id: await nextId(BulletinComment),
       postId: Number(req.params.id),
+      userId: Number(req.userId),
       content: req.body.content,
       date: req.body.date,
     });

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -244,51 +244,66 @@ describe('Maintenance API', () => {
 
 describe('Bulletin API', () => {
   test('GET /bulletin returns list', async () => {
-    await BulletinPost.create({ id: 1, content: 'Hello' });
-    const res = await request(app).get('/api/bulletin');
+    await BulletinPost.create({ id: 1, userId: 1, content: 'Hello' });
+    const token = getToken();
+    const res = await request(app)
+      .get('/api/bulletin')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].content).toBe('Hello');
   });
 
   test('POST /bulletin creates post', async () => {
+    const token = getToken();
     const res = await request(app)
       .post('/api/bulletin')
+      .set('Authorization', `Bearer ${token}`)
       .send({ content: 'New' });
     expect(res.status).toBe(201);
     expect(res.body.data.content).toBe('New');
   });
 
   test('GET /bulletin/:id/comments returns comments', async () => {
-    await BulletinPost.create({ id: 1, content: 'p' });
-    await BulletinComment.create({ id: 1, postId: 1, content: 'c' });
-    const res = await request(app).get('/api/bulletin/1/comments');
+    await BulletinPost.create({ id: 1, userId: 1, content: 'p' });
+    await BulletinComment.create({ id: 1, postId: 1, userId: 1, content: 'c' });
+    const token = getToken();
+    const res = await request(app)
+      .get('/api/bulletin/1/comments')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].content).toBe('c');
   });
 
   test('POST /bulletin/:id/comments creates comment', async () => {
-    await BulletinPost.create({ id: 1, content: 'p' });
+    await BulletinPost.create({ id: 1, userId: 1, content: 'p' });
+    const token = getToken();
     const res = await request(app)
       .post('/api/bulletin/1/comments')
+      .set('Authorization', `Bearer ${token}`)
       .send({ content: 'c' });
     expect(res.status).toBe(201);
     expect(res.body.data.content).toBe('c');
   });
 
   test('PUT /bulletin/:id updates post', async () => {
-    await BulletinPost.create({ id: 1, content: 'old' });
+    await BulletinPost.create({ id: 1, userId: 1, content: 'old' });
+    const token = getToken();
     const res = await request(app)
       .put('/api/bulletin/1')
+      .set('Authorization', `Bearer ${token}`)
       .send({ content: 'new' });
     expect(res.status).toBe(200);
     expect(res.body.data.content).toBe('new');
   });
 
   test('DELETE /bulletin/:id deletes post', async () => {
-    await BulletinPost.create({ id: 1, content: 'old' });
-    const res = await request(app).delete('/api/bulletin/1');
+    await BulletinPost.create({ id: 1, userId: 1, content: 'old' });
+    const token = getToken();
+    const res = await request(app)
+      .delete('/api/bulletin/1')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);
     const posts = await BulletinPost.find();
     expect(posts).toHaveLength(0);

--- a/test/bulletin_board_page_test.dart
+++ b/test/bulletin_board_page_test.dart
@@ -18,6 +18,7 @@ class FakeBulletinService extends BulletinService {
   Future<BulletinPost> addPost(BulletinPost post) async {
     final newPost = BulletinPost(
       id: posts.length + 1,
+      userId: post.userId,
       content: post.content,
       date: post.date,
     );
@@ -36,6 +37,7 @@ class FakeBulletinService extends BulletinService {
     final saved = BulletinComment(
       id: list.length + 1,
       postId: comment.postId,
+      userId: comment.userId,
       content: comment.content,
       date: comment.date,
     );
@@ -62,9 +64,9 @@ class FakeBulletinService extends BulletinService {
 void main() {
   testWidgets('Existing posts are shown', (tester) async {
     final service = FakeBulletinService(
-      [BulletinPost(id: 1, content: 'Hello', date: DateTime.now())],
+      [BulletinPost(id: 1, userId: 1, content: 'Hello', date: DateTime.now())],
       {
-        1: [BulletinComment(postId: 1, content: 'Nice', date: DateTime.now())],
+        1: [BulletinComment(postId: 1, userId: 2, content: 'Nice', date: DateTime.now())],
       },
     );
     await tester.pumpWidget(
@@ -72,7 +74,7 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Hello'), findsOneWidget);
-    expect(find.text('Nice'), findsOneWidget);
+    expect(find.textContaining('Nice'), findsOneWidget);
   });
 
   testWidgets('Submitting adds new post', (tester) async {
@@ -91,7 +93,7 @@ void main() {
 
   testWidgets('Submitting comment displays it', (tester) async {
     final service = FakeBulletinService(
-      [BulletinPost(id: 1, content: 'Post', date: DateTime.now())],
+      [BulletinPost(id: 1, userId: 1, content: 'Post', date: DateTime.now())],
       {1: []},
     );
     await tester.pumpWidget(
@@ -103,12 +105,12 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('sendComment_1')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Hi'), findsWidgets);
+    expect(find.textContaining('Hi'), findsWidgets);
   });
 
   testWidgets('Edit icon updates post', (tester) async {
     final service = FakeBulletinService(
-      [BulletinPost(id: 1, content: 'Old', date: DateTime.now())],
+      [BulletinPost(id: 1, userId: 1, content: 'Old', date: DateTime.now())],
       {1: []},
     );
     await tester.pumpWidget(
@@ -127,7 +129,7 @@ void main() {
 
   testWidgets('Delete icon removes post', (tester) async {
     final service = FakeBulletinService(
-      [BulletinPost(id: 1, content: 'Bye', date: DateTime.now())],
+      [BulletinPost(id: 1, userId: 1, content: 'Bye', date: DateTime.now())],
       {1: []},
     );
     await tester.pumpWidget(

--- a/test/services/bulletin_service_test.dart
+++ b/test/services/bulletin_service_test.dart
@@ -21,6 +21,7 @@ void main() {
             'data': [
               {
                 'id': 1,
+                'userId': 2,
                 'content': 'Hello',
                 'date': '1970-01-01T00:00:00.000Z'
               }
@@ -37,13 +38,14 @@ void main() {
     });
 
     test('addPost sends POST and parses result', () async {
-      final input = BulletinPost(content: 'Hi', date: DateTime.fromMillisecondsSinceEpoch(0));
+      final input = BulletinPost(userId: 1, content: 'Hi', date: DateTime.fromMillisecondsSinceEpoch(0));
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
         expect(request.url.origin, Uri.parse(apiUrl).origin);
         expect(request.url.path, '/api/bulletin');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['content'], input.content);
+        expect(body['userId'], input.userId);
         return http.Response(
           jsonEncode({
             'data': {'id': 2, ...input.toJson()}
@@ -68,6 +70,7 @@ void main() {
               {
                 'id': 1,
                 'postId': 1,
+                'userId': 2,
                 'content': 'c',
                 'date': '1970-01-01T00:00:00.000Z'
               }
@@ -84,12 +87,13 @@ void main() {
     });
 
     test('addComment posts comment', () async {
-      final input = BulletinComment(postId: 1, content: 'x');
+      final input = BulletinComment(postId: 1, userId: 1, content: 'x');
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
         expect(request.url.path, '/api/bulletin/1/comments');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['content'], input.content);
+        expect(body['userId'], input.userId);
         return http.Response(
           jsonEncode({
             'data': {'id': 3, ...input.toJson()}
@@ -105,12 +109,13 @@ void main() {
     });
 
     test('updatePost sends PUT', () async {
-      final input = BulletinPost(id: 1, content: 'n', date: DateTime.fromMillisecondsSinceEpoch(0));
+      final input = BulletinPost(id: 1, userId: 1, content: 'n', date: DateTime.fromMillisecondsSinceEpoch(0));
       final mockClient = MockClient((request) async {
         expect(request.method, equals('PUT'));
         expect(request.url.path, '/api/bulletin/1');
         final body = jsonDecode(request.body) as Map<String, dynamic>;
         expect(body['content'], input.content);
+        expect(body['userId'], input.userId);
         return http.Response(jsonEncode({'data': input.toJson()}), 200);
       });
       final service = BulletinService(client: mockClient);


### PR DESCRIPTION
## Summary
- require auth for bulletin routes and include userId
- add userId field to BulletinPost and BulletinComment models
- include userId when creating or editing posts in Flutter
- show author names on the bulletin board
- update tests

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68420d597044832ba7db29ccd949493c