### PR TITLE
Fix calendar dialog attendees label

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -140,7 +140,12 @@ class _CalendarPageState extends State<CalendarPage> {
     if (event.id == null) return;
     try {
       final attendees = await _service.fetchAttendees(event.id!);
-      final comments = await _service.fetchComments(event.id!);
+      List<EventComment> comments = [];
+      try {
+        comments = await _service.fetchComments(event.id!);
+      } catch (_) {
+        // Ignore comment loading errors
+      }
       MapPin? pin;
       if (event.location != null) {
         final pins = await MapService().fetchPins();
@@ -162,6 +167,7 @@ class _CalendarPageState extends State<CalendarPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  const Text('Attendees'),
                   Text(attendees.isEmpty ? 'None' : attendees.join(', ')),
                   if (event.location != null)
                     Padding(

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -1,6 +1,7 @@
 const express = require('express');
-const Event = require('../models/Event'); 
-const EventComment = require('../models/EventComment'); 
+const Event = require('../models/Event');
+const EventComment = require('../models/EventComment');
+const User = require('../models/User');
 const auth = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
 


### PR DESCRIPTION
## Summary
- show 'Attendees' label in the event dialog
- handle comment load failures gracefully

## Testing
- `flutter test test/calendar_page_test.dart --reporter expanded -j1`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68421220a268832b9330f2f49686af9a