### PR TITLE
Add new item categories and price filters

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -215,6 +215,10 @@ enum ItemCategory {
   electronics,
   @HiveField(3)
   other,
+  @HiveField(4)
+  appliances,
+  @HiveField(5)
+  clothing,
 }
 
 @HiveType(typeId: 5)

--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -272,6 +272,10 @@ class ItemCategoryAdapter extends TypeAdapter<ItemCategory> {
         return ItemCategory.electronics;
       case 3:
         return ItemCategory.other;
+      case 4:
+        return ItemCategory.appliances;
+      case 5:
+        return ItemCategory.clothing;
       default:
         return ItemCategory.furniture;
     }
@@ -291,6 +295,12 @@ class ItemCategoryAdapter extends TypeAdapter<ItemCategory> {
         return;
       case ItemCategory.other:
         writer.writeByte(3);
+        return;
+      case ItemCategory.appliances:
+        writer.writeByte(4);
+        return;
+      case ItemCategory.clothing:
+        writer.writeByte(5);
         return;
     }
   }

--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -18,10 +18,19 @@ class ItemExchangePage extends StatefulWidget {
 class _ItemExchangePageState extends State<ItemExchangePage> {
   late final ItemService _service;
   final _searchCtrl = TextEditingController();
+  final _minPriceCtrl = TextEditingController();
+  final _maxPriceCtrl = TextEditingController();
   String _selectedCategory = 'All';
   bool _onlyFavorites = false;
 
-  final _categories = ['All', 'Furniture', 'Books', 'Electronics'];
+  final _categories = [
+    'All',
+    'Furniture',
+    'Books',
+    'Electronics',
+    'Appliances',
+    'Clothing'
+  ];
 
   List<Item> _allItems = [];
   List<Item> _filteredItems = [];
@@ -46,12 +55,25 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
       _allItems = items;
       _filteredItems = List.from(_allItems);
     });
+    _filter();
   }
 
   void _filter() {
     final query = _searchCtrl.text;
+    final minPrice = double.tryParse(_minPriceCtrl.text);
+    final maxPrice = double.tryParse(_maxPriceCtrl.text);
     setState(() {
       var results = filterItems(_allItems, query, _selectedCategory);
+      if (minPrice != null) {
+        results = results
+            .where((item) => (item.price ?? 0) >= minPrice)
+            .toList();
+      }
+      if (maxPrice != null) {
+        results = results
+            .where((item) => (item.price ?? 0) <= maxPrice)
+            .toList();
+      }
       if (_onlyFavorites) {
         final favs = _favoriteIds();
         results =
@@ -136,6 +158,34 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                   });
                 },
               ),
+            ),
+
+            const SizedBox(height: 12),
+
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _minPriceCtrl,
+                    decoration:
+                        const InputDecoration(labelText: 'Min Price'),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    onChanged: (_) => _filter(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    controller: _maxPriceCtrl,
+                    decoration:
+                        const InputDecoration(labelText: 'Max Price'),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    onChanged: (_) => _filter(),
+                  ),
+                ),
+              ],
             ),
 
             const SizedBox(height: 16),

--- a/lib/pages/post_item_page.dart
+++ b/lib/pages/post_item_page.dart
@@ -140,6 +140,10 @@ class _PostItemPageState extends State<PostItemPage> {
                           label = 'Books';
                         case ItemCategory.electronics:
                           label = 'Electronics';
+                        case ItemCategory.appliances:
+                          label = 'Appliances';
+                        case ItemCategory.clothing:
+                          label = 'Clothing';
                         default:
                           label = 'Other';
                       }

--- a/lib/utils/item_filter.dart
+++ b/lib/utils/item_filter.dart
@@ -8,6 +8,10 @@ String itemCategory(Item item) {
       return 'Books';
     case ItemCategory.electronics:
       return 'Electronics';
+    case ItemCategory.appliances:
+      return 'Appliances';
+    case ItemCategory.clothing:
+      return 'Clothing';
     default:
       return 'Other';
   }

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -9,7 +9,7 @@ const ItemSchema = new mongoose.Schema({
   isFree: { type: Boolean, default: false },
   category: {
     type: String,
-    enum: ['furniture', 'books', 'electronics', 'other'],
+    enum: ['furniture', 'books', 'electronics', 'other', 'appliances', 'clothing'],
     default: 'other'
   },
   createdAt: { type: Date, default: Date.now },

--- a/test/item_filter_test.dart
+++ b/test/item_filter_test.dart
@@ -7,6 +7,8 @@ void main() {
     Item(ownerId: 1, title: 'Wooden Chair', category: ItemCategory.furniture),
     Item(ownerId: 1, title: 'Dart Book', category: ItemCategory.books),
     Item(ownerId: 1, title: 'Laptop', category: ItemCategory.electronics),
+    Item(ownerId: 1, title: 'Toaster', category: ItemCategory.appliances),
+    Item(ownerId: 1, title: 'Jacket', category: ItemCategory.clothing),
   ];
 
   test('search query filters items', () {
@@ -22,6 +24,16 @@ void main() {
   test('combined search and category filters items', () {
     final result = filterItems(items, 'laptop', 'Electronics');
     expect(result.map((e) => e.title).toList(), ['Laptop']);
+  });
+
+  test('appliances category works', () {
+    final result = filterItems(items, '', 'Appliances');
+    expect(result.map((e) => e.title).toList(), ['Toaster']);
+  });
+
+  test('clothing category works', () {
+    final result = filterItems(items, '', 'Clothing');
+    expect(result.map((e) => e.title).toList(), ['Jacket']);
   });
 
   test('no match returns empty list', () {


### PR DESCRIPTION
## Summary
- extend `ItemCategory` enum with `appliances` and `clothing`
- update filter utilities and posting UI for new categories
- expand exchange page chips and add min/max price filtering
- allow new categories in backend model
- add unit tests for new categories

## Testing
- `flutter test` *(fails: RootUnavailable errors)*
- `flutter test test/item_filter_test.dart` *(fails: Connection closed before test suite loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6843156d4c50832b88fb0ce64aef87d9