### PR TITLE
Implement maintenance request deletion

### DIFF
--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -88,4 +88,15 @@ router.put('/:id', requireAdmin, async (req, res) => {
   }
 });
 
+// DELETE /maintenance/:id - remove request
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const request = await MaintenanceRequest.findByIdAndDelete(req.params.id);
+    if (!request) return res.status(404).json({ error: 'Request not found' });
+    res.json({ data: request });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -280,6 +280,22 @@ describe('Maintenance API', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('closed');
   });
+
+  test('DELETE /maintenance/:id removes request', async () => {
+    const reqItem = await MaintenanceRequest.create({
+      userId: 1,
+      subject: 'Leak',
+      description: 'Water',
+    });
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = jwt.sign({ userId: admin._id }, SECRET);
+    const res = await request(app)
+      .delete(`/api/maintenance/${reqItem._id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const remaining = await MaintenanceRequest.findById(reqItem._id);
+    expect(remaining).toBeNull();
+  });
 });
 
 describe('Bulletin API', () => {

--- a/test/services/maintenance_service_test.dart
+++ b/test/services/maintenance_service_test.dart
@@ -141,6 +141,18 @@ void main() {
       expect(result.status, 'closed');
     });
 
+    test('deleteRequest sends DELETE', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('DELETE'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
+        expect(request.url.path, '/api/maintenance/1');
+        return http.Response('{}', 200);
+      });
+
+      final service = MaintenanceService(client: mockClient);
+      await service.deleteRequest(1);
+    });
+
     test('throws on error status', () async {
       final mockClient = MockClient((_) async => http.Response('err', 500));
       final service = MaintenanceService(client: mockClient);


### PR DESCRIPTION
## Summary
- allow admins to delete maintenance requests
- test DELETE /maintenance/:id in API tests
- exercise deleteRequest in MaintenanceService tests

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68431d4d36b8832b95b157b6d10da4ff