### PR TITLE
Add user account deletion

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,9 +96,9 @@ class OlyAppState extends State<OlyApp> {
         setState(() {
           _notifications.add({'title': data['title'], 'body': data['body']});
         });
-        Hive.box<NotificationRecord>('notificationsBox').add(
-          NotificationRecord(title: data['title'], body: data['body']),
-        );
+        Hive.box<NotificationRecord>(
+          'notificationsBox',
+        ).add(NotificationRecord(title: data['title'], body: data['body']));
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(data['title'] ?? 'Notification')),
         );
@@ -128,6 +128,8 @@ class OlyAppState extends State<OlyApp> {
     });
   }
 
+  Future<void> logout() => _logout();
+
   void updateThemeMode(ThemeMode mode) {
     setState(() => _themeMode = mode);
     Hive.box('settingsBox').put('themeMode', mode.name);
@@ -149,13 +151,9 @@ class OlyAppState extends State<OlyApp> {
         '/forgot': (_) => const ForgotPasswordPage(),
         '/reset': (_) => const ResetPasswordPage(),
       },
-      home:
-          _loggedIn
-              ? MainPage(
-                isAdmin: _isAdmin,
-                onLogout: _logout,
-              )
-              : LoginPage(onLoginSuccess: () => _handleLogin()),
+      home: _loggedIn
+          ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
+          : LoginPage(onLoginSuccess: () => _handleLogin()),
     );
   }
 }

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -65,8 +65,9 @@ class _ProfilePageState extends State<ProfilePage> {
         _avatarCtrl.text = path;
       } catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('Upload failed: $e')));
         }
         return;
       }
@@ -91,8 +92,39 @@ class _ProfilePageState extends State<ProfilePage> {
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Failed: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed: $e')));
+    }
+  }
+
+  Future<void> _deleteAccount() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Account'),
+        content: const Text('This action cannot be undone. Continue?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    try {
+      await _service.deleteAccount();
+      await OlyApp.of(context)?.logout();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed: $e')));
     }
   }
 
@@ -168,6 +200,15 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
               const SizedBox(height: 20),
               ElevatedButton(onPressed: _save, child: const Text('Save')),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: _deleteAccount,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                  foregroundColor: Theme.of(context).colorScheme.onError,
+                ),
+                child: const Text('Delete Account'),
+              ),
             ],
           ),
         ),

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -30,4 +30,8 @@ class UserService extends ApiService {
       throw Exception('Request failed: ${response.statusCode}');
     }
   }
+
+  Future<void> deleteAccount() async {
+    await delete('/users/me', (_) => null);
+  }
 }

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -53,4 +53,15 @@ router.post('/me/avatar', upload.single('avatar'), async (req, res) => {
   }
 });
 
+// DELETE /users/me - remove current user
+router.delete('/me', async (req, res) => {
+  try {
+    const user = await User.findByIdAndDelete(req.userId);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ message: 'Account deleted' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;

--- a/server/tests/users.test.js
+++ b/server/tests/users.test.js
@@ -51,4 +51,22 @@ describe('Users API', () => {
     expect(updated.email).toBe('new@test.com');
     expect(updated.avatarUrl).toBe('pic');
   });
+
+  test('DELETE /users/me removes account', async () => {
+    const hash = await bcrypt.hash('pass', 1);
+    const user = await User.create({
+      name: 'Del',
+      email: 'del@test.com',
+      passwordHash: hash,
+    });
+    const token = jwt.sign({ userId: user._id.toString() }, SECRET);
+
+    const res = await request(app)
+      .delete('/api/users/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const remaining = await User.findById(user._id);
+    expect(remaining).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- allow deleting the current user on the server
- expose a `deleteAccount` API in the Flutter UserService
- add a public `logout` helper to `OlyAppState`
- confirm account deletion from profile page and log out afterwards
- test new `DELETE /users/me` endpoint

## Testing
- `npm test --prefix server` *(fails: Exceeded timeout of 5000 ms)*

------
https://chatgpt.com/codex/tasks/task_e_684329a98734832b9b7104df517a8672