### PR TITLE
Add resident directory with private chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ OlyApp is a mobile app built by and for residents of the Olympiadorf (Olydorf) i
 - Submit issues in your room or building directly from the app.
 - Attach photos, chat with admins and track ticket status.
 
+### ✅ Directory
+- Browse residents who opted in to be listed and start private chats.
+
 ### ✅ Map
 - Interactive map of Olydorf with filterable pins and route planning.
 

--- a/lib/pages/directory_page.dart
+++ b/lib/pages/directory_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/directory_service.dart';
+import 'user_chat_page.dart';
+
+class DirectoryPage extends StatefulWidget {
+  final DirectoryService? service;
+  const DirectoryPage({super.key, this.service});
+
+  @override
+  State<DirectoryPage> createState() => _DirectoryPageState();
+}
+
+class _DirectoryPageState extends State<DirectoryPage> {
+  late final DirectoryService _service;
+  final TextEditingController _searchCtrl = TextEditingController();
+  List<User> _users = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? DirectoryService();
+    _loadUsers();
+  }
+
+  Future<void> _loadUsers() async {
+    final users = await _service.fetchUsers(search: _searchCtrl.text);
+    if (!mounted) return;
+    setState(() => _users = users);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _searchCtrl,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                hintText: 'Search residents…',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: _loadUsers,
+                ),
+              ),
+              onChanged: (_) => _loadUsers(),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: ListView.builder(
+                itemCount: _users.length,
+                itemBuilder: (context, index) {
+                  final user = _users[index];
+                  return ListTile(
+                    leading: user.avatarUrl != null
+                        ? CircleAvatar(
+                            backgroundImage: NetworkImage(user.avatarUrl!),
+                          )
+                        : const CircleAvatar(child: Icon(Icons.person)),
+                    title: Text(user.name),
+                    subtitle: Text(user.email),
+                    onTap: () {
+                      if (user.id == null) return;
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => UserChatPage(user: user),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -9,6 +9,7 @@ import 'profile_page.dart';
 import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
 import 'notifications_page.dart';
+import 'directory_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -43,6 +44,7 @@ class _MainPageState extends State<MainPage> {
     'Booking',
     'Item Exchange',
     'Maintenance',
+    'Directory',
   ];
 
   late final List<Widget> _pages;
@@ -57,6 +59,7 @@ class _MainPageState extends State<MainPage> {
       widget.bookingPage ?? const BookingPage(),
       widget.itemExchangePage ?? const ItemExchangePage(),
       widget.maintenancePage ?? const MaintenancePage(),
+      const DirectoryPage(),
     ];
   }
 
@@ -115,6 +118,7 @@ class _MainPageState extends State<MainPage> {
             label: 'Exchange',
           ),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
+          NavigationDestination(icon: Icon(Icons.people), label: 'Directory'),
         ],
       ),
     );

--- a/lib/pages/user_chat_page.dart
+++ b/lib/pages/user_chat_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/directory_service.dart';
+import '../utils/user_helpers.dart';
+
+class UserChatPage extends StatefulWidget {
+  final User user;
+  final DirectoryService? service;
+  const UserChatPage({super.key, required this.user, this.service});
+
+  @override
+  State<UserChatPage> createState() => _UserChatPageState();
+}
+
+class _UserChatPageState extends State<UserChatPage> {
+  late final DirectoryService _service;
+  final TextEditingController _messageCtrl = TextEditingController();
+  List<Message> _messages = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? DirectoryService();
+    _loadMessages();
+  }
+
+  Future<void> _loadMessages() async {
+    if (widget.user.id == null) return;
+    final msgs = await _service.fetchMessages(widget.user.id!);
+    if (!mounted) return;
+    setState(() => _messages = msgs);
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _messageCtrl.text.trim();
+    if (text.isEmpty || widget.user.id == null) return;
+    final msg = await _service.sendMessage(widget.user.id!, text);
+    if (!mounted) return;
+    setState(() => _messages.add(msg));
+    _messageCtrl.clear();
+  }
+
+  @override
+  void dispose() {
+    _messageCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.user.name),
+        backgroundColor: colorScheme.primaryContainer,
+        foregroundColor: colorScheme.onPrimaryContainer,
+        elevation: 1,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                final isMe = msg.senderId == currentUserId();
+                return Align(
+                  alignment:
+                      isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: isMe
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(msg.content),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _messageCtrl,
+                    decoration: const InputDecoration(hintText: 'Type a message'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _sendMessage,
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/directory_service.dart
+++ b/lib/services/directory_service.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/models.dart';
+import 'api_service.dart';
+
+class DirectoryService extends ApiService {
+  DirectoryService({super.client});
+
+  Future<List<User>> fetchUsers({String? search}) async {
+    final uri = buildUri('/directory',
+        search != null && search.isNotEmpty ? {'search': search} : null);
+    final res = await client.get(uri, headers: _authHeaders());
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>;
+      return list.map((e) => User.fromJson(e as Map<String, dynamic>)).toList();
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+
+  Future<List<Message>> fetchMessages(int userId) async {
+    return get('/directory/$userId/messages', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<Message> sendMessage(int userId, String content) async {
+    return post('/directory/$userId/messages', {'content': content}, (json) {
+      return Message.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Map<String, String> _authHeaders([Map<String, String>? headers]) {
+    final box = Hive.isBoxOpen('authBox') ? Hive.box('authBox') : null;
+    final token = box?.get('token') as String?;
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+      if (headers != null) ...headers,
+    };
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -9,6 +9,7 @@ const bulletinRouter = require('../routes/bulletin');
 const pinsRouter = require('../routes/pins');
 const notificationsRouter = require('../routes/notifications');
 const usersRouter = require('../routes/users');
+const directoryRouter = require('../routes/directory');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -23,4 +24,5 @@ router.use('/bulletin', bulletinRouter);
 router.use('/pins', pinsRouter);
 router.use('/notifications', notificationsRouter);
 router.use('/users', usersRouter);
+router.use('/directory', directoryRouter);
 module.exports = router;

--- a/server/models/Conversation.js
+++ b/server/models/Conversation.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const ConversationSchema = new mongoose.Schema({
+  participants: {
+    type: [String],
+    required: true
+  }
+});
+
+module.exports = mongoose.model('Conversation', ConversationSchema);

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,15 +1,17 @@
 const mongoose = require('mongoose');
 
 const MessageSchema = new mongoose.Schema({
+  conversationId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Conversation'
+  },
   requestType: {
     type: String,
-    required: true,
     enum: ['Item', 'MaintenanceRequest']
   },
   requestId: {
     type: mongoose.Schema.Types.ObjectId,
-    refPath: 'requestType',
-    required: true
+    refPath: 'requestType'
   },
   senderId: { type: Number, required: true },
   content: { type: String, required: true },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -7,6 +7,8 @@ const UserSchema = new mongoose.Schema({
   // Path to user's avatar image under /uploads
   avatarUrl: String,
   isAdmin: { type: Boolean, default: false },
+  // Whether the user opted into the public directory
+  isListed: { type: Boolean, default: false },
   deviceTokens: { type: [String], default: [] },
   passwordResetToken: String,
   passwordResetExpires: Date,

--- a/server/routes/directory.js
+++ b/server/routes/directory.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const User = require('../models/User');
+const Conversation = require('../models/Conversation');
+const Message = require('../models/Message');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /directory - list/search opt-in residents
+router.get('/', async (req, res) => {
+  try {
+    const query = { isListed: true };
+    if (req.query.search) {
+      query.name = { $regex: req.query.search, $options: 'i' };
+    }
+    const users = await User.find(query).select('name email avatarUrl');
+    res.json({ data: users });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+async function getConversation(userId, otherId) {
+  let convo = await Conversation.findOne({
+    participants: { $all: [userId, otherId] }
+  });
+  if (!convo) {
+    convo = await Conversation.create({ participants: [userId, otherId] });
+  }
+  return convo;
+}
+
+// GET /directory/:id/messages - fetch direct messages
+router.get('/:id/messages', async (req, res) => {
+  try {
+    const otherId = String(req.params.id);
+    const convo = await getConversation(String(req.userId), otherId);
+    const messages = await Message.find({ conversationId: convo._id });
+    res.json({ data: messages });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /directory/:id/messages - send message
+router.post('/:id/messages', async (req, res) => {
+  try {
+    const otherId = String(req.params.id);
+    const convo = await getConversation(String(req.userId), otherId);
+    const message = await Message.create({
+      conversationId: convo._id,
+      senderId: req.userId,
+      content: req.body.content
+    });
+    res.status(201).json({ data: message });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -365,3 +365,39 @@ describe('Bulletin API', () => {
     expect(posts).toHaveLength(0);
   });
 });
+
+describe('Directory API', () => {
+  test('GET /directory returns listed users', async () => {
+    await User.create({
+      name: 'Alice',
+      email: 'a@b.c',
+      passwordHash: 'x',
+      isListed: true
+    });
+    const token = getToken();
+    const res = await request(app)
+      .get('/api/directory')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe('Alice');
+  });
+
+  test('POST /directory/:id/messages creates conversation', async () => {
+    const bob = await User.create({
+      name: 'Bob',
+      email: 'b@c.d',
+      passwordHash: 'x',
+      isListed: true
+    });
+    const token = getToken();
+    const res = await request(app)
+      .post(`/api/directory/${bob._id}/messages`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: 'Hi' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.content).toBe('Hi');
+    const convoMessages = await Message.find();
+    expect(convoMessages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- create Conversation model and extend Message model
- implement `/api/directory` endpoints and mount router
- add DirectoryService, page and chat UI in Flutter
- add navigation item in main page
- document directory feature
- add tests for directory API

## Testing
- `flutter analyze`
- `flutter test`
- `npm install` & `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432e9ee4e4832b8b92b8288ad8d095