### PR TITLE
Add transit page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ OlyApp is a mobile app built by and for residents of the Olympiadorf (Olydorf) i
 ### ✅ Map
 - Interactive map of Olydorf with filterable pins and route planning.
 
+### ✅ Transit
+- Check upcoming departures and pin your favorite stops.
+
 ### ✅ Booking
 - Reserve shared spaces and manage your bookings.
 

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -426,3 +426,47 @@ class NotificationRecord {
   factory NotificationRecord.fromJsonString(String source) =>
       NotificationRecord.fromMap(jsonDecode(source));
 }
+@HiveType(typeId: 7)
+class TransitStop {
+  @HiveField(0)
+  final String id;
+  @HiveField(1)
+  final String name;
+
+  TransitStop({required this.id, required this.name});
+
+  factory TransitStop.fromMap(Map<String, dynamic> map) => TransitStop(
+        id: map['id'].toString(),
+        name: map['name'] as String,
+      );
+
+  Map<String, dynamic> toMap() => {'id': id, 'name': name};
+
+  factory TransitStop.fromJson(Map<String, dynamic> json) =>
+      TransitStop.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}
+
+class TransitDeparture {
+  final String line;
+  final String destination;
+  final DateTime time;
+
+  TransitDeparture({
+    required this.line,
+    required this.destination,
+    required this.time,
+  });
+
+  factory TransitDeparture.fromMap(Map<String, dynamic> map) => TransitDeparture(
+        line: map['line'] as String,
+        destination: map['destination'] as String,
+        time: _parseDate(map['time']),
+      );
+
+  Map<String, dynamic> toMap() => {
+        'line': line,
+        'destination': destination,
+        'time': time.toIso8601String(),
+      };
+}

--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -257,65 +257,6 @@ class ItemAdapter extends TypeAdapter<Item> {
           typeId == other.typeId;
 }
 
-class ItemCategoryAdapter extends TypeAdapter<ItemCategory> {
-  @override
-  final int typeId = 4;
-
-  @override
-  ItemCategory read(BinaryReader reader) {
-    switch (reader.readByte()) {
-      case 0:
-        return ItemCategory.furniture;
-      case 1:
-        return ItemCategory.books;
-      case 2:
-        return ItemCategory.electronics;
-      case 3:
-        return ItemCategory.other;
-      case 4:
-        return ItemCategory.appliances;
-      case 5:
-        return ItemCategory.clothing;
-      default:
-        return ItemCategory.furniture;
-    }
-  }
-
-  @override
-  void write(BinaryWriter writer, ItemCategory obj) {
-    switch (obj) {
-      case ItemCategory.furniture:
-        writer.writeByte(0);
-        return;
-      case ItemCategory.books:
-        writer.writeByte(1);
-        return;
-      case ItemCategory.electronics:
-        writer.writeByte(2);
-        return;
-      case ItemCategory.other:
-        writer.writeByte(3);
-        return;
-      case ItemCategory.appliances:
-        writer.writeByte(4);
-        return;
-      case ItemCategory.clothing:
-        writer.writeByte(5);
-        return;
-    }
-  }
-
-  @override
-  int get hashCode => typeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ItemCategoryAdapter &&
-          runtimeType == other.runtimeType &&
-          typeId == other.typeId;
-}
-
 class NotificationRecordAdapter extends TypeAdapter<NotificationRecord> {
   @override
   final int typeId = 6;
@@ -352,6 +293,102 @@ class NotificationRecordAdapter extends TypeAdapter<NotificationRecord> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is NotificationRecordAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class TransitStopAdapter extends TypeAdapter<TransitStop> {
+  @override
+  final int typeId = 7;
+
+  @override
+  TransitStop read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return TransitStop(
+      id: fields[0] as String,
+      name: fields[1] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, TransitStop obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransitStopAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class ItemCategoryAdapter extends TypeAdapter<ItemCategory> {
+  @override
+  final int typeId = 4;
+
+  @override
+  ItemCategory read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return ItemCategory.furniture;
+      case 1:
+        return ItemCategory.books;
+      case 2:
+        return ItemCategory.electronics;
+      case 3:
+        return ItemCategory.other;
+      case 4:
+        return ItemCategory.appliances;
+      case 5:
+        return ItemCategory.clothing;
+      default:
+        return ItemCategory.furniture;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, ItemCategory obj) {
+    switch (obj) {
+      case ItemCategory.furniture:
+        writer.writeByte(0);
+        break;
+      case ItemCategory.books:
+        writer.writeByte(1);
+        break;
+      case ItemCategory.electronics:
+        writer.writeByte(2);
+        break;
+      case ItemCategory.other:
+        writer.writeByte(3);
+        break;
+      case ItemCategory.appliances:
+        writer.writeByte(4);
+        break;
+      case ItemCategory.clothing:
+        writer.writeByte(5);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ItemCategoryAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -9,6 +9,7 @@ import 'profile_page.dart';
 import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
 import 'notifications_page.dart';
+import 'transit_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -43,6 +44,7 @@ class _MainPageState extends State<MainPage> {
     'Booking',
     'Item Exchange',
     'Maintenance',
+    'Transit',
   ];
 
   late final List<Widget> _pages;
@@ -57,6 +59,7 @@ class _MainPageState extends State<MainPage> {
       widget.bookingPage ?? const BookingPage(),
       widget.itemExchangePage ?? const ItemExchangePage(),
       widget.maintenancePage ?? const MaintenancePage(),
+      const TransitPage(),
     ];
   }
 
@@ -115,6 +118,7 @@ class _MainPageState extends State<MainPage> {
             label: 'Exchange',
           ),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
+          NavigationDestination(icon: Icon(Icons.directions_bus), label: 'Transit'),
         ],
       ),
     );
@@ -275,6 +279,12 @@ class DashboardPage extends StatelessWidget {
                   label: 'Maintenance',
                   colorScheme: colorScheme,
                   onTap: () => _navigate(5),
+                ),
+                DashboardCard(
+                  icon: Icons.directions_bus,
+                  label: 'Transit',
+                  colorScheme: colorScheme,
+                  onTap: () => _navigate(6),
                 ),
                 if (isAdmin)
                   DashboardCard(

--- a/lib/pages/transit_page.dart
+++ b/lib/pages/transit_page.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/transit_service.dart';
+
+class TransitPage extends StatefulWidget {
+  final TransitService? service;
+  const TransitPage({super.key, this.service});
+
+  @override
+  State<TransitPage> createState() => _TransitPageState();
+}
+
+class _TransitPageState extends State<TransitPage> {
+  late final TransitService _service;
+  final TextEditingController _searchCtrl = TextEditingController();
+  List<TransitStop> _searchResults = [];
+  List<TransitStop> _pinned = [];
+  TransitStop? _selected;
+  List<TransitDeparture> _departures = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? TransitService();
+    _loadPinned();
+  }
+
+  Future<void> _loadPinned() async {
+    final list = await _service.loadPinnedStops();
+    if (!mounted) return;
+    setState(() => _pinned = list);
+  }
+
+  Future<void> _search(String q) async {
+    if (q.isEmpty) {
+      setState(() => _searchResults = []);
+      return;
+    }
+    try {
+      final results = await _service.searchStops(q);
+      if (!mounted) return;
+      setState(() => _searchResults = results);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Search failed')));
+    }
+  }
+
+  Future<void> _selectStop(TransitStop stop) async {
+    try {
+      final deps = await _service.fetchDepartures(stop.id);
+      if (!mounted) return;
+      setState(() {
+        _selected = stop;
+        _departures = deps;
+        _searchResults = [];
+        _searchCtrl.text = stop.name;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Failed to load')));
+    }
+  }
+
+  Future<void> _togglePin(TransitStop stop) async {
+    final exists = _pinned.any((p) => p.id == stop.id);
+    if (exists) {
+      await _service.unpinStop(stop.id);
+    } else {
+      await _service.pinStop(stop);
+    }
+    await _loadPinned();
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              controller: _searchCtrl,
+              decoration: const InputDecoration(labelText: 'Search Stop'),
+              onChanged: _search,
+            ),
+          ),
+          if (_pinned.isNotEmpty)
+            SizedBox(
+              height: 40,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: _pinned
+                    .map(
+                      (s) => Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                        child: ActionChip(
+                          label: Text(s.name),
+                          onPressed: () => _selectStop(s),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          if (_searchResults.isNotEmpty)
+            Expanded(
+              child: ListView(
+                children: _searchResults
+                    .map(
+                      (s) => ListTile(
+                        title: Text(s.name),
+                        trailing: IconButton(
+                          icon: Icon(_pinned.any((p) => p.id == s.id)
+                              ? Icons.star
+                              : Icons.star_border),
+                          onPressed: () => _togglePin(s),
+                        ),
+                        onTap: () => _selectStop(s),
+                      ),
+                    )
+                    .toList(),
+              ),
+            )
+          else if (_selected != null)
+            Expanded(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      'Departures from ${_selected!.name}',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Expanded(
+                    child: ListView(
+                      children: _departures
+                          .map(
+                            (d) => ListTile(
+                              title: Text('${d.line} → ${d.destination}'),
+                              trailing: Text(
+                                  '${d.time.hour.toString().padLeft(2, '0')}:${d.time.minute.toString().padLeft(2, '0')}'),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          else
+            const Expanded(child: SizedBox.shrink()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/transit_service.dart
+++ b/lib/services/transit_service.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/models.dart';
+
+class TransitService {
+  TransitService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+  static const _baseUrl = 'https://transport.opendata.ch/v1';
+
+  Uri _uri(String path, [Map<String, String>? params]) {
+    return Uri.parse('$_baseUrl$path').replace(queryParameters: params);
+  }
+
+  Future<List<TransitStop>> searchStops(String query) async {
+    final res = await _client.get(_uri('/locations', {'query': query}));
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['stations'] as List<dynamic>;
+      return list
+          .map((e) => TransitStop.fromMap(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+
+  Future<List<TransitDeparture>> fetchDepartures(String stopId, {int limit = 10}) async {
+    final res =
+        await _client.get(_uri('/stationboard', {'id': stopId, 'limit': '$limit'}));
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['stationboard'] as List<dynamic>;
+      return list.map((e) {
+        final map = e as Map<String, dynamic>;
+        final stop = map['stop'] as Map<String, dynamic>;
+        return TransitDeparture(
+          line: map['name'] as String,
+          destination: map['to'] as String,
+          time: DateTime.parse(stop['departure'] as String),
+        );
+      }).toList();
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+
+  Future<List<TransitStop>> loadPinnedStops() async {
+    final box = await Hive.openBox('transitBox');
+    final list = box.get('pinned', defaultValue: const <dynamic>[]) as List;
+    return list
+        .map((e) => TransitStop.fromMap(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  Future<void> pinStop(TransitStop stop) async {
+    final box = await Hive.openBox('transitBox');
+    final list = box.get('pinned', defaultValue: const <dynamic>[]) as List;
+    if (!list.any((e) => Map<String, dynamic>.from(e)['id'].toString() == stop.id)) {
+      list.add(stop.toMap());
+      await box.put('pinned', list);
+    }
+  }
+
+  Future<void> unpinStop(String id) async {
+    final box = await Hive.openBox('transitBox');
+    final list = box.get('pinned', defaultValue: const <dynamic>[]) as List;
+    list.removeWhere((e) => Map<String, dynamic>.from(e)['id'].toString() == id);
+    await box.put('pinned', list);
+  }
+}

--- a/test/services/transit_service_test.dart
+++ b/test/services/transit_service_test.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:oly_app/services/transit_service.dart';
+
+void main() {
+  group('TransitService', () {
+    test('searchStops parses results', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.path, '/v1/locations');
+        return http.Response(
+          jsonEncode({
+            'stations': [
+              {'id': '1', 'name': 'Stop'}
+            ]
+          }),
+          200,
+        );
+      });
+      final service = TransitService(client: mockClient);
+      final results = await service.searchStops('stop');
+      expect(results, hasLength(1));
+      expect(results.first.name, 'Stop');
+    });
+
+    test('fetchDepartures parses list', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.path, '/v1/stationboard');
+        return http.Response(
+          jsonEncode({
+            'stationboard': [
+              {
+                'name': 'U1',
+                'to': 'Downtown',
+                'stop': {'departure': '1970-01-01T00:00:00.000Z'}
+              }
+            ]
+          }),
+          200,
+        );
+      });
+      final service = TransitService(client: mockClient);
+      final deps = await service.fetchDepartures('1');
+      expect(deps, hasLength(1));
+      expect(deps.first.line, 'U1');
+    });
+
+    test('throws on non-success status', () async {
+      final mockClient = MockClient((_) async => http.Response('err', 500));
+      final service = TransitService(client: mockClient);
+      expect(service.searchStops('a'), throwsException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement TransitService using transport.opendata.ch
- display departures and favorite stops in new TransitPage
- hook TransitPage into MainPage navigation
- generate Hive adapter updates for new models
- document new Transit feature
- cover TransitService logic with tests

## Testing
- `flutter analyze`
- `flutter test`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432eae9e98832b8acd6e4e9cc7c018