### PR TITLE
Add calendar event ICS export

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -3,6 +3,10 @@ import 'package:table_calendar/table_calendar.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 import '../services/map_service.dart';
+import '../utils/ics_generator.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:path_provider/path_provider.dart';
+import 'dart:io';
 import 'map_page.dart';
 import '../models/map_pin.dart';
 import 'package:latlong2/latlong.dart';
@@ -233,6 +237,20 @@ class _CalendarPageState extends State<CalendarPage> {
                       ),
                     ),
                     actions: [
+                      TextButton(
+                        onPressed: () async {
+                          final ics = calendarEventToIcs(event);
+                          final dir = await getTemporaryDirectory();
+                          final file = File(
+                            '${dir.path}/event_${event.id ?? event.title}.ics',
+                          );
+                          await file.writeAsString(ics);
+                          await Share.shareXFiles([
+                            XFile(file.path),
+                          ], text: event.title);
+                        },
+                        child: const Text('Share'),
+                      ),
                       TextButton(
                         onPressed: () => Navigator.pop(ctx),
                         child: const Text('Close'),

--- a/lib/utils/ics_generator.dart
+++ b/lib/utils/ics_generator.dart
@@ -1,0 +1,39 @@
+import '../models/models.dart';
+
+String _formatDate(DateTime date) {
+  final utc = date.toUtc();
+  final y = utc.year.toString().padLeft(4, '0');
+  final m = utc.month.toString().padLeft(2, '0');
+  final d = utc.day.toString().padLeft(2, '0');
+  final h = utc.hour.toString().padLeft(2, '0');
+  final min = utc.minute.toString().padLeft(2, '0');
+  final s = utc.second.toString().padLeft(2, '0');
+  return '${y}${m}${d}T$h$min${s}Z';
+}
+
+/// Returns an ICS formatted string representing [event].
+String calendarEventToIcs(CalendarEvent event) {
+  final start = event.date;
+  final end = start.add(const Duration(hours: 1));
+  final buffer =
+      StringBuffer()
+        ..writeln('BEGIN:VCALENDAR')
+        ..writeln('VERSION:2.0')
+        ..writeln('PRODID:-//OlyApp//EN')
+        ..writeln('BEGIN:VEVENT')
+        ..writeln('UID:${event.id ?? event.hashCode}@olyapp')
+        ..writeln('DTSTAMP:${_formatDate(DateTime.now())}')
+        ..writeln('DTSTART:${_formatDate(start)}')
+        ..writeln('DTEND:${_formatDate(end)}')
+        ..writeln('SUMMARY:${event.title}');
+  if (event.description != null) {
+    buffer.writeln('DESCRIPTION:${event.description}');
+  }
+  if (event.location != null) {
+    buffer.writeln('LOCATION:${event.location}');
+  }
+  buffer
+    ..writeln('END:VEVENT')
+    ..writeln('END:VCALENDAR');
+  return buffer.toString();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -769,10 +769,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.6"
   mobile_scanner:
     dependency: "direct main"
     description:
@@ -838,7 +838,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -941,6 +941,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "3ef39599b00059db0990ca2e30fca0a29d8b37aae924d60063f8e0184cf20900"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "251eb156a8b5fa9ce033747d73535bf53911071f8d3b6f4f0b578505ce0d4496"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   shelf:
     dependency: transitive
     description:
@@ -1154,6 +1170,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:
@@ -1218,6 +1266,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.13.0"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   image_picker: ^1.1.2
   geolocator: ^11.0.0
   mobile_scanner: ^3.5.0
+  share_plus: ^7.2.1
+  path_provider: ^2.1.5
 dev_dependencies:
   test: any
   flutter_test:

--- a/test/ics_generator_test.dart
+++ b/test/ics_generator_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/utils/ics_generator.dart';
+
+void main() {
+  test('calendarEventToIcs outputs valid lines', () {
+    final event = CalendarEvent(
+      id: 1,
+      title: 'Meeting',
+      date: DateTime.utc(2024, 1, 1, 12, 0),
+      description: 'Discuss plans',
+      location: 'Room 1',
+    );
+    final ics = calendarEventToIcs(event);
+    expect(ics, contains('BEGIN:VEVENT'));
+    expect(ics, contains('SUMMARY:Meeting'));
+    expect(ics, contains('DESCRIPTION:Discuss plans'));
+    expect(ics, contains('LOCATION:Room 1'));
+    expect(ics, contains('END:VEVENT'));
+  });
+}


### PR DESCRIPTION
## Summary
- allow exporting events by adding a new helper to create ICS strings
- integrate sharing/export option in event details
- include `share_plus` and `path_provider` dependencies
- test ICS generation

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68435153c5c4832bb768e1a493f26881