### PR TITLE
Implement polls feature

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -471,3 +471,73 @@ class TransitDeparture {
         'time': time.toIso8601String(),
       };
 }
+
+class Poll {
+  final String? id;
+  final String question;
+  final List<String> options;
+  final List<int> counts;
+
+  Poll({
+    this.id,
+    required this.question,
+    required List<String> options,
+    List<int>? counts,
+  })  : options = List.unmodifiable(options),
+        counts = counts != null
+            ? List<int>.from(counts)
+            : List<int>.filled(options.length, 0);
+
+  factory Poll.fromMap(Map<String, dynamic> map) => Poll(
+        id: map['_id']?.toString() ?? map['id']?.toString(),
+        question: map['question'] as String,
+        options:
+            (map['options'] as List<dynamic>).map((e) => e.toString()).toList(),
+        counts: (map['counts'] as List<dynamic>? ?? const [])
+            .map((e) => (e as num).toInt())
+            .toList(),
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'question': question,
+        'options': options,
+        'counts': counts,
+      };
+
+  factory Poll.fromJson(Map<String, dynamic> json) => Poll.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}
+
+class PollVote {
+  final String? id;
+  final String pollId;
+  final String userId;
+  final int option;
+
+  PollVote({
+    this.id,
+    required this.pollId,
+    required this.userId,
+    required this.option,
+  });
+
+  factory PollVote.fromMap(Map<String, dynamic> map) => PollVote(
+        id: map['_id']?.toString() ?? map['id']?.toString(),
+        pollId: map['pollId'].toString(),
+        userId: map['userId'].toString(),
+        option: map['option'] is int
+            ? map['option'] as int
+            : int.parse(map['option'].toString()),
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'pollId': pollId,
+        'userId': userId,
+        'option': option,
+      };
+
+  factory PollVote.fromJson(Map<String, dynamic> json) => PollVote.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -10,7 +10,8 @@ import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
 import 'notifications_page.dart'; 
 import 'transit_page.dart'; 
-import 'directory_page.dart'; 
+import 'directory_page.dart';
+import 'polls_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -44,9 +45,10 @@ class _MainPageState extends State<MainPage> {
     'Calendar',
     'Booking',
     'Item Exchange',
-    'Maintenance', 
-    'Transit', 
+    'Maintenance',
+    'Transit',
     'Directory',
+    'Polls',
   ];
 
   late final List<Widget> _pages;
@@ -63,6 +65,7 @@ class _MainPageState extends State<MainPage> {
       widget.maintenancePage ?? const MaintenancePage(),
       const TransitPage(),
       const DirectoryPage(),
+      const PollsPage(),
     ];
   }
 
@@ -123,6 +126,7 @@ class _MainPageState extends State<MainPage> {
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
           NavigationDestination(icon: Icon(Icons.directions_bus), label: 'Transit'),
           NavigationDestination(icon: Icon(Icons.people), label: 'Directory'),
+          NavigationDestination(icon: Icon(Icons.poll), label: 'Polls'),
         ],
       ),
     );

--- a/lib/pages/polls_page.dart
+++ b/lib/pages/polls_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import '../models/models.dart';
+import '../services/poll_service.dart';
+import '../utils/user_helpers.dart';
+
+class PollsPage extends StatefulWidget {
+  final PollService? service;
+  const PollsPage({super.key, this.service});
+
+  @override
+  State<PollsPage> createState() => _PollsPageState();
+}
+
+class _PollsPageState extends State<PollsPage> {
+  late final PollService _service;
+  List<Poll> _polls = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? PollService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final polls = await _service.fetchPolls();
+      if (!mounted) return;
+      setState(() => _polls = polls);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to load polls')),
+      );
+    }
+  }
+
+  Future<void> _vote(Poll poll, int index) async {
+    if (poll.id == null) return;
+    try {
+      await _service.vote(poll.id!, index);
+      await _load();
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to submit vote')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.builder(
+        itemCount: _polls.length,
+        itemBuilder: (context, index) {
+          final poll = _polls[index];
+          return Card(
+            margin: const EdgeInsets.all(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    poll.question,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  for (var i = 0; i < poll.options.length; i++)
+                    ListTile(
+                      title: Text(
+                        '${poll.options[i]} (${poll.counts.length > i ? poll.counts[i] : 0})',
+                      ),
+                      trailing: ElevatedButton(
+                        onPressed: () => _vote(poll, i),
+                        child: const Text('Vote'),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/poll_service.dart
+++ b/lib/services/poll_service.dart
@@ -1,0 +1,23 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class PollService extends ApiService {
+  PollService({super.client});
+
+  Future<List<Poll>> fetchPolls() async {
+    return get('/polls', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list.map((e) => Poll.fromJson(e as Map<String, dynamic>)).toList();
+    });
+  }
+
+  Future<Poll> createPoll(Poll poll) async {
+    return post('/polls', poll.toJson(), (json) {
+      return Poll.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Future<void> vote(String pollId, int option) async {
+    await post('/polls/$pollId/vote', {'option': option}, (_) => null);
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -10,6 +10,7 @@ const pinsRouter = require('../routes/pins');
 const notificationsRouter = require('../routes/notifications');
 const usersRouter = require('../routes/users');
 const directoryRouter = require('../routes/directory');
+const pollsRouter = require('../routes/polls');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -25,4 +26,5 @@ router.use('/pins', pinsRouter);
 router.use('/notifications', notificationsRouter);
 router.use('/users', usersRouter);
 router.use('/directory', directoryRouter);
+router.use('/polls', pollsRouter);
 module.exports = router;

--- a/server/models/Poll.js
+++ b/server/models/Poll.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const PollSchema = new mongoose.Schema({
+  question: { type: String, required: true },
+  options: { type: [String], required: true },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Poll', PollSchema);

--- a/server/models/PollVote.js
+++ b/server/models/PollVote.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const PollVoteSchema = new mongoose.Schema({
+  pollId: { type: mongoose.Schema.Types.ObjectId, ref: 'Poll', required: true },
+  userId: { type: String, required: true },
+  option: { type: Number, required: true },
+}, { timestamps: true });
+
+PollVoteSchema.index({ pollId: 1, userId: 1 }, { unique: true });
+
+module.exports = mongoose.model('PollVote', PollVoteSchema);

--- a/server/routes/polls.js
+++ b/server/routes/polls.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const Poll = require('../models/Poll');
+const PollVote = require('../models/PollVote');
+const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /polls - list polls with vote counts
+router.get('/', async (req, res) => {
+  try {
+    const polls = await Poll.find();
+    const pollIds = polls.map(p => p._id);
+    const agg = await PollVote.aggregate([
+      { $match: { pollId: { $in: pollIds } } },
+      { $group: { _id: { pollId: '$pollId', option: '$option' }, count: { $sum: 1 } } }
+    ]);
+    const countsMap = {};
+    for (const a of agg) {
+      const pid = a._id.pollId.toString();
+      const opt = a._id.option;
+      countsMap[pid] = countsMap[pid] || {};
+      countsMap[pid][opt] = a.count;
+    }
+    const result = polls.map(p => {
+      const map = countsMap[p._id.toString()] || {};
+      const counts = p.options.map((_, i) => map[i] || 0);
+      return { ...p.toObject(), counts };
+    });
+    res.json({ data: result });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /polls - create poll
+router.post('/', requireAdmin, async (req, res) => {
+  const { question, options } = req.body;
+  if (!question || !Array.isArray(options) || options.length < 2) {
+    return res.status(400).json({ error: 'question and options required' });
+  }
+  try {
+    const poll = await Poll.create({ question, options });
+    res.status(201).json({ data: poll });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /polls/:id/vote - submit vote
+router.post('/:id/vote', async (req, res) => {
+  const { option } = req.body;
+  try {
+    const poll = await Poll.findById(req.params.id);
+    if (!poll) return res.status(404).json({ error: 'Poll not found' });
+    if (typeof option !== 'number' || option < 0 || option >= poll.options.length) {
+      return res.status(400).json({ error: 'Invalid option' });
+    }
+    await PollVote.findOneAndUpdate(
+      { pollId: poll._id, userId: req.userId },
+      { pollId: poll._id, userId: req.userId, option },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    res.json({});
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Poll and PollVote schemas
- create polls routes and mount in API
- expose poll models on client
- create PollService and PollsPage
- add Polls page navigation entry

## Testing
- `npm --prefix server install` *(fails: jest not found; environment issue)*
- `npm --prefix server test` *(fails: Mongo server startup errors)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684352456b54832b900d967d435aab5a