### PR TITLE
Add services listing feature

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -184,8 +184,9 @@ class CalendarEvent {
     title: map['title'] as String,
     date: _parseDate(map['date']),
     description: map['description'] as String?,
-    attendees:
-        (map['attendees'] as List<dynamic>? ?? const []).map((e) => e.toString()).toList(),
+    attendees: (map['attendees'] as List<dynamic>? ?? const [])
+        .map((e) => e.toString())
+        .toList(),
     location: map['location'] as String?,
   );
 
@@ -262,16 +263,14 @@ class Item {
     description: map['description'] as String?,
     imageUrl: map['imageUrl'] as String?,
     price: map['price'] != null ? (map['price'] as num).toDouble() : null,
-    isFree:
-        map['isFree'] is bool
-            ? map['isFree'] as bool
-            : (map['isFree'] as int) == 1,
-    category:
-        map['category'] is int
-            ? ItemCategory.values[map['category'] as int]
-            : ItemCategory.values.firstWhere(
-              (e) => e.name == map['category'] as String,
-            ),
+    isFree: map['isFree'] is bool
+        ? map['isFree'] as bool
+        : (map['isFree'] as int) == 1,
+    category: map['category'] is int
+        ? ItemCategory.values[map['category'] as int]
+        : ItemCategory.values.firstWhere(
+            (e) => e.name == map['category'] as String,
+          ),
     createdAt: _parseDate(map['createdAt']),
   );
 
@@ -294,14 +293,58 @@ class Item {
       Item.fromMap(jsonDecode(source));
 }
 
+class ServiceListing {
+  final int? id;
+  final String userId;
+  final String title;
+  final String description;
+  final String? contact;
+  final DateTime createdAt;
+
+  ServiceListing({
+    this.id,
+    required this.userId,
+    required this.title,
+    required this.description,
+    this.contact,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  factory ServiceListing.fromMap(Map<String, dynamic> map) => ServiceListing(
+    id: map['id'] as int?,
+    userId: map['userId'] as String,
+    title: map['title'] as String,
+    description: map['description'] as String,
+    contact: map['contact'] as String?,
+    createdAt: _parseDate(map['createdAt']),
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'userId': userId,
+    'title': title,
+    'description': description,
+    'contact': contact,
+    'createdAt': createdAt.toIso8601String(),
+  };
+
+  factory ServiceListing.fromJson(Map<String, dynamic> json) =>
+      ServiceListing.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}
+
 class BulletinPost {
   final int? id;
   final String userId;
   final String content;
   final DateTime date;
 
-  BulletinPost({this.id, required this.userId, required this.content, DateTime? date})
-    : date = date ?? DateTime.now();
+  BulletinPost({
+    this.id,
+    required this.userId,
+    required this.content,
+    DateTime? date,
+  }) : date = date ?? DateTime.now();
 
   factory BulletinPost.fromMap(Map<String, dynamic> map) => BulletinPost(
     id: map['id'] as int?,
@@ -372,20 +415,20 @@ class EventComment {
   }) : date = date ?? DateTime.now();
 
   factory EventComment.fromMap(Map<String, dynamic> map) => EventComment(
-        id: map['id'] as String?,
-        eventId: map['eventId'] is int
-            ? map['eventId'] as int
-            : int.parse(map['eventId'].toString()),
-        content: map['content'] as String,
-        date: _parseDate(map['date']),
-      );
+    id: map['id'] as String?,
+    eventId: map['eventId'] is int
+        ? map['eventId'] as int
+        : int.parse(map['eventId'].toString()),
+    content: map['content'] as String,
+    date: _parseDate(map['date']),
+  );
 
   Map<String, dynamic> toMap() => {
-        if (id != null) 'id': id,
-        'eventId': eventId,
-        'content': content,
-        'date': date.toIso8601String(),
-      };
+    if (id != null) 'id': id,
+    'eventId': eventId,
+    'content': content,
+    'date': date.toIso8601String(),
+  };
 
   factory EventComment.fromJson(Map<String, dynamic> json) =>
       EventComment.fromMap(json);
@@ -401,11 +444,8 @@ class NotificationRecord {
   @HiveField(2)
   final DateTime timestamp;
 
-  NotificationRecord({
-    this.title,
-    this.body,
-    DateTime? timestamp,
-  }) : timestamp = timestamp ?? DateTime.now();
+  NotificationRecord({this.title, this.body, DateTime? timestamp})
+    : timestamp = timestamp ?? DateTime.now();
 
   factory NotificationRecord.fromMap(Map<String, dynamic> map) =>
       NotificationRecord(
@@ -415,10 +455,10 @@ class NotificationRecord {
       );
 
   Map<String, dynamic> toMap() => {
-        'title': title,
-        'body': body,
-        'timestamp': timestamp.toIso8601String(),
-      };
+    'title': title,
+    'body': body,
+    'timestamp': timestamp.toIso8601String(),
+  };
 
   factory NotificationRecord.fromJson(Map<String, dynamic> json) =>
       NotificationRecord.fromMap(json);
@@ -427,6 +467,7 @@ class NotificationRecord {
   factory NotificationRecord.fromJsonString(String source) =>
       NotificationRecord.fromMap(jsonDecode(source));
 }
+
 @HiveType(typeId: 7)
 class TransitStop {
   @HiveField(0)
@@ -436,10 +477,8 @@ class TransitStop {
 
   TransitStop({required this.id, required this.name});
 
-  factory TransitStop.fromMap(Map<String, dynamic> map) => TransitStop(
-        id: map['id'].toString(),
-        name: map['name'] as String,
-      );
+  factory TransitStop.fromMap(Map<String, dynamic> map) =>
+      TransitStop(id: map['id'].toString(), name: map['name'] as String);
 
   Map<String, dynamic> toMap() => {'id': id, 'name': name};
 
@@ -459,15 +498,16 @@ class TransitDeparture {
     required this.time,
   });
 
-  factory TransitDeparture.fromMap(Map<String, dynamic> map) => TransitDeparture(
+  factory TransitDeparture.fromMap(Map<String, dynamic> map) =>
+      TransitDeparture(
         line: map['line'] as String,
         destination: map['destination'] as String,
         time: _parseDate(map['time']),
       );
 
   Map<String, dynamic> toMap() => {
-        'line': line,
-        'destination': destination,
-        'time': time.toIso8601String(),
-      };
+    'line': line,
+    'destination': destination,
+    'time': time.toIso8601String(),
+  };
 }

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -8,9 +8,10 @@ import 'map_page.dart';
 import 'profile_page.dart';
 import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
-import 'notifications_page.dart'; 
-import 'transit_page.dart'; 
-import 'directory_page.dart'; 
+import 'services_page.dart';
+import 'notifications_page.dart';
+import 'transit_page.dart';
+import 'directory_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -44,8 +45,8 @@ class _MainPageState extends State<MainPage> {
     'Calendar',
     'Booking',
     'Item Exchange',
-    'Maintenance', 
-    'Transit', 
+    'Maintenance',
+    'Transit',
     'Directory',
   ];
 
@@ -121,7 +122,10 @@ class _MainPageState extends State<MainPage> {
             label: 'Exchange',
           ),
           NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
-          NavigationDestination(icon: Icon(Icons.directions_bus), label: 'Transit'),
+          NavigationDestination(
+            icon: Icon(Icons.directions_bus),
+            label: 'Transit',
+          ),
           NavigationDestination(icon: Icon(Icons.people), label: 'Directory'),
         ],
       ),
@@ -151,9 +155,7 @@ class _MainPageState extends State<MainPage> {
         return () {
           Navigator.push(
             context,
-            MaterialPageRoute(
-              builder: (_) => const NotificationsPage(),
-            ),
+            MaterialPageRoute(builder: (_) => const NotificationsPage()),
           );
         };
       case 1:
@@ -289,6 +291,15 @@ class DashboardPage extends StatelessWidget {
                   label: 'Transit',
                   colorScheme: colorScheme,
                   onTap: () => _navigate(6),
+                ),
+                DashboardCard(
+                  icon: Icons.miscellaneous_services,
+                  label: 'Services',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ServicesPage()),
+                  ),
                 ),
                 if (isAdmin)
                   DashboardCard(

--- a/lib/pages/services_page.dart
+++ b/lib/pages/services_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/service_list_service.dart';
+
+class ServicesPage extends StatefulWidget {
+  final ServiceListService? service;
+  const ServicesPage({super.key, this.service});
+
+  @override
+  State<ServicesPage> createState() => _ServicesPageState();
+}
+
+class _ServicesPageState extends State<ServicesPage> {
+  late final ServiceListService _service;
+  List<ServiceListing> _listings = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? ServiceListService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final listings = await _service.fetchListings();
+    if (!mounted) return;
+    setState(() => _listings = listings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Services'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _listings.isEmpty
+            ? ListView(
+                children: const [
+                  SizedBox(
+                    height: 200,
+                    child: Center(child: Text('No services')),
+                  ),
+                ],
+              )
+            : ListView.separated(
+                padding: const EdgeInsets.all(16),
+                itemCount: _listings.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final listing = _listings[index];
+                  return ListTile(
+                    title: Text(listing.title),
+                    subtitle: Text(listing.description),
+                    trailing: listing.contact != null
+                        ? Text(listing.contact!)
+                        : null,
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/service_list_service.dart
+++ b/lib/services/service_list_service.dart
@@ -1,0 +1,36 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class ServiceListService extends ApiService {
+  ServiceListService({super.client});
+
+  Future<List<ServiceListing>> fetchListings() async {
+    return get('/services', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => ServiceListing.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<ServiceListing> addListing(ServiceListing listing) async {
+    return post(
+      '/services',
+      listing.toJson(),
+      (json) => ServiceListing.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<ServiceListing> updateListing(ServiceListing listing) async {
+    if (listing.id == null) throw ArgumentError('id required');
+    return put(
+      '/services/${listing.id}',
+      listing.toJson(),
+      (json) => ServiceListing.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deleteListing(int id) async {
+    await delete('/services/$id', (_) => null);
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -10,6 +10,7 @@ const pinsRouter = require('../routes/pins');
 const notificationsRouter = require('../routes/notifications');
 const usersRouter = require('../routes/users');
 const directoryRouter = require('../routes/directory');
+const servicesRouter = require('../routes/services');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -25,4 +26,5 @@ router.use('/pins', pinsRouter);
 router.use('/notifications', notificationsRouter);
 router.use('/users', usersRouter);
 router.use('/directory', directoryRouter);
+router.use('/services', servicesRouter);
 module.exports = router;

--- a/server/models/ServiceListing.js
+++ b/server/models/ServiceListing.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const ServiceListingSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  title: { type: String, required: true },
+  description: String,
+  contact: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('ServiceListing', ServiceListingSchema);

--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const ServiceListing = require('../models/ServiceListing');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /services - list service listings
+router.get('/', async (req, res) => {
+  try {
+    const listings = await ServiceListing.find();
+    res.json({ data: listings });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /services - create listing
+router.post('/', async (req, res) => {
+  try {
+    const data = { ...req.body, userId: req.userId };
+    const listing = await ServiceListing.create(data);
+    res.status(201).json({ data: listing });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /services/:id - update listing
+router.put('/:id', async (req, res) => {
+  try {
+    const listing = await ServiceListing.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!listing) return res.status(404).json({ error: 'Listing not found' });
+    res.json({ data: listing });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /services/:id - remove listing
+router.delete('/:id', async (req, res) => {
+  try {
+    const listing = await ServiceListing.findByIdAndDelete(req.params.id);
+    if (!listing) return res.status(404).json({ error: 'Listing not found' });
+    res.json({ data: listing });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create ServiceListing mongoose model
- add services routes with CRUD endpoints
- mount services routes in API router
- provide Dart model, service layer, and services page
- link new Services page from dashboard

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684353d964f4832b9bcb60b2bcaab2c5