### PR TITLE
Add poll admin page

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -5,6 +5,7 @@ import 'notification_admin_page.dart';
 import 'bulletin_admin_page.dart';
 import 'booking_admin_page.dart';
 import 'map_admin_page.dart';
+import 'poll_admin_page.dart';
 import '../../utils/user_helpers.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -15,9 +16,9 @@ class AdminHomePage extends StatelessWidget {
     if (!currentUserIsAdmin()) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.pop(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Admin access required')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Admin access required')));
       });
       return const SizedBox.shrink();
     }
@@ -89,6 +90,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Map Pins'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const PollAdminPage()),
+                );
+              },
+              child: const Text('Create Poll'),
             ),
           ],
         ),

--- a/lib/pages/admin/poll_admin_page.dart
+++ b/lib/pages/admin/poll_admin_page.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import '../../models/models.dart';
+import '../../services/poll_service.dart';
+import '../../utils/user_helpers.dart';
+
+class PollAdminPage extends StatefulWidget {
+  final PollService? service;
+  const PollAdminPage({super.key, this.service});
+
+  @override
+  State<PollAdminPage> createState() => _PollAdminPageState();
+}
+
+class _PollAdminPageState extends State<PollAdminPage> {
+  late final PollService _service;
+  final TextEditingController _questionCtrl = TextEditingController();
+  final List<TextEditingController> _optionCtrls = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Admin access required')));
+      });
+    } else {
+      _service = widget.service ?? PollService();
+      _optionCtrls.add(TextEditingController());
+      _optionCtrls.add(TextEditingController());
+    }
+  }
+
+  @override
+  void dispose() {
+    _questionCtrl.dispose();
+    for (final c in _optionCtrls) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final question = _questionCtrl.text.trim();
+    final options = _optionCtrls
+        .map((c) => c.text.trim())
+        .where((o) => o.isNotEmpty)
+        .toList();
+    if (question.isEmpty || options.length < 2) return;
+    try {
+      await _service.createPoll(Poll(question: question, options: options));
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Poll created')));
+      Navigator.pop(context);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to create poll')));
+    }
+  }
+
+  void _addOption() {
+    setState(() {
+      _optionCtrls.add(TextEditingController());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Poll')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _questionCtrl,
+                decoration: const InputDecoration(labelText: 'Question'),
+              ),
+              const SizedBox(height: 16),
+              const Text('Options'),
+              const SizedBox(height: 8),
+              for (var i = 0; i < _optionCtrls.length; i++)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: TextField(
+                    controller: _optionCtrls[i],
+                    decoration: InputDecoration(labelText: 'Option ${i + 1}'),
+                  ),
+                ),
+              TextButton.icon(
+                onPressed: _addOption,
+                icon: const Icon(Icons.add),
+                label: const Text('Add Option'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Create Poll'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create new `PollAdminPage` to submit polls
- link to the poll page from admin home
- show success message and return to admin page after creation

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684367879490832b9f32639b0ce23dad