### PR TITLE
Add Settings page with theme and directory options

### DIFF
--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -23,13 +23,14 @@ class UserAdapter extends TypeAdapter<User> {
       email: fields[2] as String,
       avatarUrl: fields[3] as String?,
       isAdmin: fields[4] as bool,
+      isListed: fields[5] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, User obj) {
     writer
-      ..writeByte(5)
+      ..writeByte(6)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -39,7 +40,9 @@ class UserAdapter extends TypeAdapter<User> {
       ..writeByte(3)
       ..write(obj.avatarUrl)
       ..writeByte(4)
-      ..write(obj.isAdmin);
+      ..write(obj.isAdmin)
+      ..writeByte(5)
+      ..write(obj.isListed);
   }
 
   @override

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,4 +1,5 @@
 part of 'models.dart';
+
 @HiveType(typeId: 0)
 class User {
   @HiveField(0)
@@ -12,6 +13,8 @@ class User {
   final String? avatarUrl;
   @HiveField(4)
   final bool isAdmin;
+  @HiveField(5)
+  final bool isListed;
 
   User({
     this.id,
@@ -19,6 +22,7 @@ class User {
     required this.email,
     this.avatarUrl,
     this.isAdmin = false,
+    this.isListed = false,
   });
 
   factory User.fromMap(Map<String, dynamic> map) => User(
@@ -27,6 +31,7 @@ class User {
     email: map['email'] as String,
     avatarUrl: map['avatarUrl'] as String?,
     isAdmin: (map['isAdmin'] ?? false) as bool,
+    isListed: (map['isListed'] ?? false) as bool,
   );
 
   Map<String, dynamic> toMap() => {
@@ -35,6 +40,7 @@ class User {
     'email': email,
     'avatarUrl': avatarUrl,
     'isAdmin': isAdmin,
+    'isListed': isListed,
   };
 
   factory User.fromJson(Map<String, dynamic> json) => User.fromMap(json);

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -72,6 +72,7 @@ class _LoginPageState extends State<LoginPage> {
         email: userMap['email'] as String,
         avatarUrl: userMap['avatarUrl'] as String?,
         isAdmin: (userMap['isAdmin'] ?? false) as bool,
+        isListed: (userMap['isListed'] ?? false) as bool,
       );
       final userBox = Hive.box<User>('userBox');
       await userBox.put('currentUser', user);
@@ -99,6 +100,7 @@ class _LoginPageState extends State<LoginPage> {
       name: account.displayName ?? account.email,
       email: account.email,
       avatarUrl: account.photoUrl,
+      isListed: false,
     );
 
     final authBox = Hive.box('authBox');
@@ -120,11 +122,16 @@ class _LoginPageState extends State<LoginPage> {
 
     final fullName =
         credential.givenName != null && credential.familyName != null
-            ? '${credential.givenName} ${credential.familyName}'
-            : 'Apple User';
+        ? '${credential.givenName} ${credential.familyName}'
+        : 'Apple User';
     final email = credential.email ?? '${credential.userIdentifier}@apple.com';
 
-    final user = User(name: fullName, email: email, avatarUrl: null);
+    final user = User(
+      name: fullName,
+      email: email,
+      avatarUrl: null,
+      isListed: false,
+    );
 
     final authBox = Hive.box('authBox');
     await authBox.put('token', credential.identityToken);
@@ -182,10 +189,8 @@ class _LoginPageState extends State<LoginPage> {
                             ? Icons.visibility
                             : Icons.visibility_off,
                       ),
-                      onPressed:
-                          () => setState(
-                            () => _passwordVisible = !_passwordVisible,
-                          ),
+                      onPressed: () =>
+                          setState(() => _passwordVisible = !_passwordVisible),
                     ),
                   ),
                   obscureText: !_passwordVisible,
@@ -196,14 +201,13 @@ class _LoginPageState extends State<LoginPage> {
                   width: double.infinity,
                   child: ElevatedButton(
                     onPressed: _isLoading ? null : _handleLogin,
-                    child:
-                        _isLoading
-                            ? const SizedBox(
-                              height: 16,
-                              width: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                            : const Text('Login'),
+                    child: _isLoading
+                        ? const SizedBox(
+                            height: 16,
+                            width: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Login'),
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -213,32 +217,31 @@ class _LoginPageState extends State<LoginPage> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     ElevatedButton.icon(
-                      onPressed:
-                          _isLoading
-                              ? null
-                              : () async {
-                                setState(() => _isLoading = true);
-                                try {
-                                  final user = await _handleGoogleSignIn();
-                                  if (!context.mounted) return;
-                                  if (user != null) {
-                                    final userBox = Hive.box<User>('userBox');
-                                    await userBox.put('currentUser', user);
-                                    widget.onLoginSuccess();
-                                  }
-                                } catch (e) {
-                                  if (!context.mounted) return;
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text('Google sign-in failed: $e'),
-                                    ),
-                                  );
-                                } finally {
-                                  if (mounted) {
-                                    setState(() => _isLoading = false);
-                                  }
+                      onPressed: _isLoading
+                          ? null
+                          : () async {
+                              setState(() => _isLoading = true);
+                              try {
+                                final user = await _handleGoogleSignIn();
+                                if (!context.mounted) return;
+                                if (user != null) {
+                                  final userBox = Hive.box<User>('userBox');
+                                  await userBox.put('currentUser', user);
+                                  widget.onLoginSuccess();
                                 }
-                              },
+                              } catch (e) {
+                                if (!context.mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text('Google sign-in failed: $e'),
+                                  ),
+                                );
+                              } finally {
+                                if (mounted) {
+                                  setState(() => _isLoading = false);
+                                }
+                              }
+                            },
                       icon: const Icon(Icons.login),
                       label: const Text('Google'),
                       style: ElevatedButton.styleFrom(
@@ -248,56 +251,53 @@ class _LoginPageState extends State<LoginPage> {
                     ),
                     const SizedBox(width: 12),
                     ElevatedButton.icon(
-                      onPressed:
-                          _isLoading
-                              ? null
-                              : () async {
-                                setState(() => _isLoading = true);
-                                try {
-                                  final user = await _handleAppleSignIn();
-                                  if (!context.mounted) return;
-                                  if (user != null) {
-                                    final userBox = Hive.box<User>('userBox');
-                                    await userBox.put('currentUser', user);
-                                    widget.onLoginSuccess();
-                                  }
-                                } catch (e) {
-                                  if (!context.mounted) return;
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                        content: Text(
-                                          'Apple sign-in failed: $e',
-                                        ),
-                                      ),
-                                    );
-                                  } finally {
-                                  if (mounted) {
-                                    setState(() => _isLoading = false);
-                                  }
+                      onPressed: _isLoading
+                          ? null
+                          : () async {
+                              setState(() => _isLoading = true);
+                              try {
+                                final user = await _handleAppleSignIn();
+                                if (!context.mounted) return;
+                                if (user != null) {
+                                  final userBox = Hive.box<User>('userBox');
+                                  await userBox.put('currentUser', user);
+                                  widget.onLoginSuccess();
                                 }
-                              },
+                              } catch (e) {
+                                if (!context.mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text('Apple sign-in failed: $e'),
+                                  ),
+                                );
+                              } finally {
+                                if (mounted) {
+                                  setState(() => _isLoading = false);
+                                }
+                              }
+                            },
                       icon: const Icon(Icons.apple),
                       label: const Text('Apple'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: cs.primaryContainer,
-                      foregroundColor: cs.onPrimaryContainer,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: cs.primaryContainer,
+                        foregroundColor: cs.onPrimaryContainer,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
-              TextButton(
-                onPressed: _isLoading
-                    ? null
-                    : () => Navigator.pushNamed(context, '/register'),
-                child: const Text('Create an account'),
-              ),
-              TextButton(
-                onPressed: _isLoading
-                    ? null
-                    : () => Navigator.pushNamed(context, '/forgot'),
-                child: const Text('Forgot password?'),
-              ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                TextButton(
+                  onPressed: _isLoading
+                      ? null
+                      : () => Navigator.pushNamed(context, '/register'),
+                  child: const Text('Create an account'),
+                ),
+                TextButton(
+                  onPressed: _isLoading
+                      ? null
+                      : () => Navigator.pushNamed(context, '/forgot'),
+                  child: const Text('Forgot password?'),
+                ),
               ],
             ),
           ),

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -6,6 +6,7 @@ import 'booking_page.dart';
 import 'admin/admin_home_page.dart';
 import 'map_page.dart';
 import 'profile_page.dart';
+import 'settings_page.dart';
 import 'post_item_page.dart';
 import 'bulletin_board_page.dart';
 import 'services_page.dart';
@@ -13,7 +14,7 @@ import 'notifications_page.dart';
 import 'transit_page.dart';
 import 'directory_page.dart';
 import 'polls_page.dart';
-import 'lost_found_page.dart'; 
+import 'lost_found_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -85,7 +86,12 @@ class _MainPageState extends State<MainPage> {
         actions: [
           PopupMenuButton<String>(
             onSelected: (val) async {
-              if (val == 'profile') {
+              if (val == 'settings') {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const SettingsPage()),
+                );
+              } else if (val == 'profile') {
                 await Navigator.push(
                   context,
                   MaterialPageRoute(builder: (_) => const ProfilePage()),
@@ -95,6 +101,7 @@ class _MainPageState extends State<MainPage> {
               }
             },
             itemBuilder: (context) => [
+              const PopupMenuItem(value: 'settings', child: Text('Settings')),
               const PopupMenuItem(value: 'profile', child: Text('Profile')),
               if (widget.onLogout != null)
                 const PopupMenuItem(value: 'logout', child: Text('Logout')),

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -18,7 +18,6 @@ class ProfilePage extends StatefulWidget {
 class _ProfilePageState extends State<ProfilePage> {
   late final Box<User> _userBox;
   late User _user;
-  bool _darkMode = false;
   late final UserService _service;
 
   final _formKey = GlobalKey<FormState>();
@@ -37,8 +36,6 @@ class _ProfilePageState extends State<ProfilePage> {
     _emailCtrl = TextEditingController(text: _user.email);
     _avatarCtrl = TextEditingController(text: _user.avatarUrl ?? '');
     _avatarCtrl.addListener(() => setState(() {}));
-    final settingsBox = Hive.box('settingsBox');
-    _darkMode = settingsBox.get('themeMode', defaultValue: 'light') == 'dark';
   }
 
   @override
@@ -80,6 +77,7 @@ class _ProfilePageState extends State<ProfilePage> {
           ? null
           : _avatarCtrl.text.trim(),
       isAdmin: _user.isAdmin,
+      isListed: _user.isListed,
     );
     try {
       final user = await _service.updateProfile(updated);
@@ -190,15 +188,6 @@ class _ProfilePageState extends State<ProfilePage> {
                 const SizedBox(height: 12),
                 Image.file(File(_avatarFile!.path), height: 120),
               ],
-              SwitchListTile(
-                title: const Text('Dark Mode'),
-                value: _darkMode,
-                onChanged: (val) {
-                  setState(() => _darkMode = val);
-                  final mode = val ? ThemeMode.dark : ThemeMode.light;
-                  OlyApp.of(context)?.updateThemeMode(mode);
-                },
-              ),
               const SizedBox(height: 20),
               ElevatedButton(onPressed: _save, child: const Text('Save')),
               const SizedBox(height: 12),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/models.dart';
+import '../main.dart';
+import '../services/user_service.dart';
+
+class SettingsPage extends StatefulWidget {
+  final UserService? service;
+  const SettingsPage({super.key, this.service});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  bool _darkMode = false;
+  bool _listed = false;
+  late final UserService _service;
+  late User _user;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? UserService();
+    final settingsBox = Hive.box('settingsBox');
+    _darkMode = settingsBox.get('themeMode', defaultValue: 'light') == 'dark';
+    final userBox = Hive.box<User>('userBox');
+    _user = userBox.get('currentUser')!;
+    _listed = _user.isListed;
+  }
+
+  Future<void> _updateListed(bool val) async {
+    setState(() => _listed = val);
+    final updated = User(
+      id: _user.id,
+      name: _user.name,
+      email: _user.email,
+      avatarUrl: _user.avatarUrl,
+      isAdmin: _user.isAdmin,
+      isListed: val,
+    );
+    try {
+      final user = await _service.updateProfile(updated);
+      await Hive.box<User>('userBox').put('currentUser', user);
+      if (mounted) setState(() => _user = user);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('Dark Mode'),
+            value: _darkMode,
+            onChanged: (val) {
+              setState(() => _darkMode = val);
+              final mode = val ? ThemeMode.dark : ThemeMode.light;
+              OlyApp.of(context)?.updateThemeMode(mode);
+            },
+          ),
+          SwitchListTile(
+            title: const Text('Appear in Directory'),
+            value: _listed,
+            onChanged: _updateListed,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -136,9 +136,10 @@ void main() {
 
   testWidgets('Owner can edit an item', (tester) async {
     await tester.runAsync(() async {
-      await Hive.box<User>(
-        'userBox',
-      ).put('currentUser', User(id: '1', name: 'Owner', email: 'o@test.com'));
+      await Hive.box<User>('userBox').put(
+        'currentUser',
+        User(id: '1', name: 'Owner', email: 'o@test.com', isListed: false),
+      );
 
       final item = Item(
         id: 1,
@@ -149,7 +150,9 @@ void main() {
       final service = FakeItemService([item]);
 
       await tester.pumpWidget(
-        MaterialApp(home: ItemDetailPage(item: item, service: service)),
+        MaterialApp(
+          home: ItemDetailPage(item: item, service: service),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -176,9 +179,10 @@ void main() {
 
   testWidgets('Owner can delete an item', (tester) async {
     await tester.runAsync(() async {
-      await Hive.box<User>(
-        'userBox',
-      ).put('currentUser', User(id: '1', name: 'Owner', email: 'o@test.com'));
+      await Hive.box<User>('userBox').put(
+        'currentUser',
+        User(id: '1', name: 'Owner', email: 'o@test.com', isListed: false),
+      );
 
       final item = Item(
         id: 1,
@@ -189,7 +193,9 @@ void main() {
       final service = FakeItemService([item]);
 
       await tester.pumpWidget(
-        MaterialApp(home: ItemDetailPage(item: item, service: service)),
+        MaterialApp(
+          home: ItemDetailPage(item: item, service: service),
+        ),
       );
       await tester.pumpAndSettle();
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -10,6 +10,7 @@ void main() {
       email: 'john@example.com',
       avatarUrl: 'https://example.com/avatar.png',
       isAdmin: true,
+      isListed: false,
     );
 
     final userMap = {
@@ -18,6 +19,7 @@ void main() {
       'email': 'john@example.com',
       'avatarUrl': 'https://example.com/avatar.png',
       'isAdmin': true,
+      'isListed': false,
     };
 
     test('toMap/fromMap round trip', () {
@@ -138,7 +140,7 @@ void main() {
 
   group('Item', () {
     final created = DateTime.utc(2023, 12, 31, 23, 59, 59);
-  final item = Item(
+    final item = Item(
       id: 5,
       ownerId: '6',
       title: 'Chair',

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -39,15 +39,20 @@ void main() {
       await tester.runAsync(() async {
         // 1) Insert the “Old” user into Hive on the real event loop:
         final box = Hive.box<User>('userBox');
-        await box.put('currentUser', User(name: 'Old', email: 'old@test.com'));
+        await box.put(
+          'currentUser',
+          User(name: 'Old', email: 'old@test.com', isListed: false),
+        );
 
         final service = FakeUserService();
 
         // 2) Pump ProfilePage:
-        await tester.pumpWidget(MaterialApp(home: ProfilePage(service: service)));
+        await tester.pumpWidget(
+          MaterialApp(home: ProfilePage(service: service)),
+        );
         // Give 300ms for any images/animations to complete (instead of pumpAndSettle):
         await tester.pump(const Duration(milliseconds: 300));
- 
+
         final nameFieldTf = find.byType(TextFormField).at(0);
         final emailFieldTf = find.byType(TextFormField).at(1);
 
@@ -76,20 +81,24 @@ void main() {
         // 7) Verify that service was called and Hive wrote the updated user:
         expect(service.updated!.name, 'New Name');
         expect(service.updated!.email, 'new@example.com');
-        
+
         final saved = Hive.box<User>('userBox').get('currentUser')!;
         expect(saved.name, 'New Name');
         expect(saved.email, 'new@example.com');
 
         // 8) Re‐pump the ProfilePage and give it time to rebuild:
-        await tester.pumpWidget(MaterialApp(home: ProfilePage(service: service)));
+        await tester.pumpWidget(
+          MaterialApp(home: ProfilePage(service: service)),
+        );
         await tester.pump(const Duration(milliseconds: 300));
 
         // 9) Finally, confirm that the text fields now show “New Name” / “new@example.com”:
         final reloadedNameEditable = tester.widget<EditableText>(
-            nameEditableFinder);
+          nameEditableFinder,
+        );
         final reloadedEmailEditable = tester.widget<EditableText>(
-            emailEditableFinder);
+          emailEditableFinder,
+        );
         expect(reloadedNameEditable.controller.text, 'New Name');
         expect(reloadedEmailEditable.controller.text, 'new@example.com');
       });


### PR DESCRIPTION
## Summary
- add SettingsPage with dark mode and directory listing toggles
- move theme toggle from ProfilePage to SettingsPage
- open SettingsPage from MainPage menu
- persist directory listing with UserService and theme with settingsBox
- extend User model with `isListed` field
- update tests for new field

## Testing
- `flutter analyze`
- `flutter test`
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684372c4345c832b9a4fde7e6a2ab12f