### PR TITLE
Add service ratings

### DIFF
--- a/lib/models/service_listing.dart
+++ b/lib/models/service_listing.dart
@@ -1,5 +1,26 @@
 part of 'models.dart';
 
+class ServiceRating {
+  final int rating;
+  final String? review;
+
+  ServiceRating({required this.rating, this.review});
+
+  factory ServiceRating.fromMap(Map<String, dynamic> map) => ServiceRating(
+        rating: (map['rating'] as num).toInt(),
+        review: map['review'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'rating': rating,
+        if (review != null) 'review': review,
+      };
+
+  factory ServiceRating.fromJson(Map<String, dynamic> json) =>
+      ServiceRating.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}
+
 class ServiceListing {
   final int? id;
   final String userId;
@@ -7,6 +28,7 @@ class ServiceListing {
   final String description;
   final String? contact;
   final DateTime createdAt;
+  final List<ServiceRating> ratings;
 
   ServiceListing({
     this.id,
@@ -15,6 +37,7 @@ class ServiceListing {
     required this.description,
     this.contact,
     DateTime? createdAt,
+    this.ratings = const [],
   }) : createdAt = createdAt ?? DateTime.now();
 
   factory ServiceListing.fromMap(Map<String, dynamic> map) => ServiceListing(
@@ -24,6 +47,9 @@ class ServiceListing {
         description: map['description'] as String,
         contact: map['contact'] as String?,
         createdAt: _parseDate(map['createdAt']),
+        ratings: (map['ratings'] as List<dynamic>? ?? const [])
+            .map((e) => ServiceRating.fromMap(Map<String, dynamic>.from(e)))
+            .toList(),
       );
 
   Map<String, dynamic> toMap() => {
@@ -33,9 +59,16 @@ class ServiceListing {
         'description': description,
         'contact': contact,
         'createdAt': createdAt.toIso8601String(),
+        'ratings': ratings.map((e) => e.toMap()).toList(),
       };
 
   factory ServiceListing.fromJson(Map<String, dynamic> json) =>
       ServiceListing.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
+
+  double get averageRating {
+    if (ratings.isEmpty) return 0;
+    final total = ratings.fold<int>(0, (sum, r) => sum + r.rating);
+    return total / ratings.length;
+  }
 }

--- a/lib/pages/service_detail_page.dart
+++ b/lib/pages/service_detail_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import '../models/models.dart';
+import '../services/service_list_service.dart';
+import '../utils/user_helpers.dart';
+
+class ServiceDetailPage extends StatefulWidget {
+  final ServiceListing listing;
+  final ServiceListService? service;
+
+  const ServiceDetailPage({super.key, required this.listing, this.service});
+
+  @override
+  State<ServiceDetailPage> createState() => _ServiceDetailPageState();
+}
+
+class _ServiceDetailPageState extends State<ServiceDetailPage> {
+  late ServiceListing _listing;
+  late ServiceListService _service;
+  List<ServiceRating> _ratings = [];
+  final _ratingCtrl = TextEditingController();
+  final _reviewCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _listing = widget.listing;
+    _service = widget.service ?? ServiceListService();
+    _ratings = _listing.ratings;
+    _loadRatings();
+  }
+
+  Future<void> _loadRatings() async {
+    if (_listing.id == null) return;
+    final list = await _service.fetchRatings(_listing.id!);
+    if (mounted) setState(() => _ratings = list);
+  }
+
+  Future<void> _submitRating() async {
+    if (_listing.id == null) return;
+    final rating = int.tryParse(_ratingCtrl.text) ?? 0;
+    await _service.submitRating(
+      _listing.id!,
+      rating,
+      review: _reviewCtrl.text,
+    );
+    if (!mounted) return;
+    _ratingCtrl.clear();
+    _reviewCtrl.clear();
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Rating submitted')));
+    _loadRatings();
+  }
+
+  @override
+  void dispose() {
+    _ratingCtrl.dispose();
+    _reviewCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isOwner = currentUserId() == _listing.userId;
+    return Scaffold(
+      appBar: AppBar(title: Text(_listing.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(_listing.description),
+            const SizedBox(height: 12),
+            if (_listing.contact != null)
+              Row(
+                children: [
+                  const Text('Contact: '),
+                  Text(_listing.contact!),
+                ],
+              ),
+            const SizedBox(height: 12),
+            if (_ratings.isNotEmpty)
+              Row(
+                children: [
+                  const Icon(Icons.star, color: Colors.amber),
+                  const SizedBox(width: 4),
+                  Text(_listing.averageRating.toStringAsFixed(1)),
+                ],
+              )
+            else
+              const Text('No ratings yet'),
+            if (!isOwner) ...[
+              const SizedBox(height: 24),
+              TextField(
+                controller: _ratingCtrl,
+                decoration: const InputDecoration(labelText: 'Rating (1-5)'),
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: false),
+              ),
+              TextField(
+                controller: _reviewCtrl,
+                decoration: const InputDecoration(labelText: 'Review'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _submitRating,
+                child: const Text('Submit Rating'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/services_page.dart
+++ b/lib/pages/services_page.dart
@@ -5,6 +5,7 @@ import '../models/models.dart';
 import '../services/service_list_service.dart';
 import '../utils/user_helpers.dart';
 import 'post_service_listing_page.dart';
+import 'service_detail_page.dart';
 
 class ServicesPage extends StatefulWidget {
   final ServiceListService? service;
@@ -71,11 +72,28 @@ class _ServicesPageState extends State<ServicesPage> {
                   return ListTile(
                     onTap: listing.userId == currentUserId()
                         ? () => _openForm(listing)
-                        : null,
+                        : () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => ServiceDetailPage(
+                                  listing: listing,
+                                  service: _service,
+                                ),
+                              ),
+                            ),
                     title: Text(listing.title),
                     subtitle: Text(listing.description),
-                    trailing: listing.contact != null
-                        ? Row(
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (listing.ratings.isNotEmpty) ...[
+                          const Icon(Icons.star, size: 16, color: Colors.amber),
+                          const SizedBox(width: 4),
+                          Text(listing.averageRating.toStringAsFixed(1)),
+                          const SizedBox(width: 8),
+                        ],
+                        if (listing.contact != null)
+                          Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               Text(listing.contact!),
@@ -94,8 +112,9 @@ class _ServicesPageState extends State<ServicesPage> {
                                 },
                               ),
                             ],
-                          )
-                        : null,
+                          ),
+                      ],
+                    ),
                   );
                 },
               ),

--- a/lib/services/service_list_service.dart
+++ b/lib/services/service_list_service.dart
@@ -33,4 +33,18 @@ class ServiceListService extends ApiService {
   Future<void> deleteListing(int id) async {
     await delete('/services/$id', (_) => null);
   }
+
+  Future<void> submitRating(int listingId, int rating, {String? review}) async {
+    await post('/services/$listingId/ratings',
+        {'rating': rating, 'review': review}, (_) => null);
+  }
+
+  Future<List<ServiceRating>> fetchRatings(int listingId) async {
+    return get('/services/$listingId/ratings', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => ServiceRating.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
 }

--- a/server/models/ServiceListing.js
+++ b/server/models/ServiceListing.js
@@ -5,6 +5,12 @@ const ServiceListingSchema = new mongoose.Schema({
   title: { type: String, required: true },
   description: String,
   contact: String,
+  ratings: [
+    {
+      rating: { type: Number, required: true },
+      review: String,
+    },
+  ],
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -52,4 +52,31 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
+// POST /services/:id/ratings - submit rating
+router.post('/:id/ratings', async (req, res) => {
+  try {
+    const { rating, review } = req.body;
+    const listing = await ServiceListing.findByIdAndUpdate(
+      req.params.id,
+      { $push: { ratings: { rating, review } } },
+      { new: true }
+    );
+    if (!listing) return res.status(404).json({ error: 'Listing not found' });
+    res.status(201).json({ data: listing });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /services/:id/ratings - list ratings
+router.get('/:id/ratings', async (req, res) => {
+  try {
+    const listing = await ServiceListing.findById(req.params.id);
+    if (!listing) return res.status(404).json({ error: 'Listing not found' });
+    res.json({ data: listing.ratings });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- support ratings for service listings on backend and frontend
- expose POST and GET rating APIs
- extend `ServiceListing` model with ratings
- allow submitting ratings in a new details page
- show average rating in services list

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684372d04d0c832bb7e278ca1eb3e418