### PR TITLE
Add event categories

### DIFF
--- a/lib/models/calendar_event.dart
+++ b/lib/models/calendar_event.dart
@@ -1,4 +1,5 @@
 part of 'models.dart';
+
 @HiveType(typeId: 3)
 class CalendarEvent {
   @HiveField(0)
@@ -13,6 +14,8 @@ class CalendarEvent {
   final List<String> attendees;
   @HiveField(5)
   final String? location;
+  @HiveField(6)
+  final String? category;
 
   CalendarEvent({
     this.id,
@@ -21,6 +24,7 @@ class CalendarEvent {
     this.description,
     this.attendees = const [],
     this.location,
+    this.category,
   });
 
   factory CalendarEvent.fromMap(Map<String, dynamic> map) => CalendarEvent(
@@ -28,9 +32,11 @@ class CalendarEvent {
     title: map['title'] as String,
     date: _parseDate(map['date']),
     description: map['description'] as String?,
-    attendees:
-        (map['attendees'] as List<dynamic>? ?? const []).map((e) => e.toString()).toList(),
+    attendees: (map['attendees'] as List<dynamic>? ?? const [])
+        .map((e) => e.toString())
+        .toList(),
     location: map['location'] as String?,
+    category: map['category'] as String?,
   );
 
   Map<String, dynamic> toMap() => {
@@ -40,6 +46,7 @@ class CalendarEvent {
     'description': description,
     'attendees': attendees,
     'location': location,
+    'category': category,
   };
 
   factory CalendarEvent.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -168,13 +168,14 @@ class CalendarEventAdapter extends TypeAdapter<CalendarEvent> {
       description: fields[3] as String?,
       attendees: (fields[4] as List).cast<String>(),
       location: fields[5] as String?,
+      category: fields[6] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, CalendarEvent obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(7)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -186,7 +187,9 @@ class CalendarEventAdapter extends TypeAdapter<CalendarEvent> {
       ..writeByte(4)
       ..write(obj.attendees)
       ..writeByte(5)
-      ..write(obj.location);
+      ..write(obj.location)
+      ..writeByte(6)
+      ..write(obj.category);
   }
 
   @override

--- a/lib/pages/admin/event_admin_page.dart
+++ b/lib/pages/admin/event_admin_page.dart
@@ -22,9 +22,9 @@ class _EventAdminPageState extends State<EventAdminPage> {
     if (!currentUserIsAdmin()) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.pop(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Admin access required')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Admin access required')));
       });
     } else {
       _service = widget.service ?? EventService();
@@ -80,9 +80,19 @@ class _EventAdminPageState extends State<EventAdminPage> {
       appBar: AppBar(title: const Text('Manage Events')),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
-          await showAddEventDialog(context, (title, date, location) async {
+          await showAddEventDialog(context, (
+            title,
+            date,
+            location,
+            category,
+          ) async {
             await _service.createEvent(
-              CalendarEvent(title: title, date: date, location: location),
+              CalendarEvent(
+                title: title,
+                date: date,
+                location: location,
+                category: category,
+              ),
             );
             _load();
           });

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -13,7 +13,7 @@ import 'notifications_page.dart';
 import 'transit_page.dart';
 import 'directory_page.dart';
 import 'polls_page.dart';
-import 'lost_found_page.dart'; 
+import 'lost_found_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -175,10 +175,20 @@ class _MainPageState extends State<MainPage> {
       case 2:
         if (!widget.isAdmin) return null;
         return () async {
-          await showAddEventDialog(context, (title, date, location) async {
+          await showAddEventDialog(context, (
+            title,
+            date,
+            location,
+            category,
+          ) async {
             final service = EventService();
             await service.createEvent(
-              CalendarEvent(title: title, date: date, location: location),
+              CalendarEvent(
+                title: title,
+                date: date,
+                location: location,
+                category: category,
+              ),
             );
           });
         };

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -10,6 +10,7 @@ const EventSchema = new mongoose.Schema({
   checkIns: { type: [Number], default: [] },
   reminderSent: { type: Boolean, default: false },
   location: String,
+  category: String,
 }, { timestamps: true });
 
 module.exports = mongoose.model('Event', EventSchema);

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -22,7 +22,18 @@ router.get('/', async (req, res) => {
 // POST /events - create event
 router.post('/', requireAdmin, async (req, res) => {
   try {
-    const event = await Event.create(req.body);
+    const data = {
+      title: req.body.title,
+      date: req.body.date,
+      description: req.body.description,
+      attendees: req.body.attendees,
+      deviceTokens: req.body.deviceTokens,
+      checkIns: req.body.checkIns,
+      reminderSent: req.body.reminderSent,
+      location: req.body.location,
+      category: req.body.category,
+    };
+    const event = await Event.create(data);
     res.json({ data: event });
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -32,7 +43,18 @@ router.post('/', requireAdmin, async (req, res) => {
 // PUT /events/:id - update event
 router.put('/:id', requireAdmin, async (req, res) => {
   try {
-    const event = await Event.findByIdAndUpdate(req.params.id, req.body, {
+    const data = {
+      title: req.body.title,
+      date: req.body.date,
+      description: req.body.description,
+      attendees: req.body.attendees,
+      deviceTokens: req.body.deviceTokens,
+      checkIns: req.body.checkIns,
+      reminderSent: req.body.reminderSent,
+      location: req.body.location,
+      category: req.body.category,
+    };
+    const event = await Event.findByIdAndUpdate(req.params.id, data, {
       new: true
     });
     if (!event) return res.status(404).json({ error: 'Event not found' });

--- a/test/calendar_page_test.dart
+++ b/test/calendar_page_test.dart
@@ -25,6 +25,7 @@ class FakeEventService extends EventService {
             description: event.description,
             attendees: event.attendees,
             location: event.location,
+            category: event.category,
           );
     events.add(newEvent);
     return newEvent;
@@ -42,6 +43,7 @@ class FakeEventService extends EventService {
         description: e.description,
         attendees: [...e.attendees, 'u1'],
         location: e.location,
+        category: e.category,
       );
     }
   }
@@ -73,6 +75,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField).at(0), 'Meeting');
     await tester.enterText(find.byType(TextField).at(1), 'building1');
+    await tester.enterText(find.byType(TextField).at(2), 'social');
     await tester.tap(find.text('Add'));
     await tester.pumpAndSettle();
 

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -111,6 +111,7 @@ void main() {
       description: 'Project discussion',
       attendees: const ['1', '2'],
       location: 'locA',
+      category: 'work',
     );
 
     final eventMap = {
@@ -120,6 +121,7 @@ void main() {
       'description': 'Project discussion',
       'attendees': const ['1', '2'],
       'location': 'locA',
+      'category': 'work',
     };
 
     test('toMap/fromMap round trip', () {
@@ -138,7 +140,7 @@ void main() {
 
   group('Item', () {
     final created = DateTime.utc(2023, 12, 31, 23, 59, 59);
-  final item = Item(
+    final item = Item(
       id: 5,
       ownerId: '6',
       title: 'Chair',


### PR DESCRIPTION
## Summary
- support categories in event schema
- handle category field in event routes
- extend CalendarEvent model with category
- allow event creation dialog to input category
- filter events by category on calendar page
- update tests for new category field

## Testing
- `npm test --prefix server` *(fails: jest not found)*
- `flutter test` *(fails during dependency fetch)*

------
https://chatgpt.com/codex/tasks/task_e_684372ef744c832b9199626412dd3bd3