### PR TITLE
Add recurring events

### DIFF
--- a/lib/models/calendar_event.dart
+++ b/lib/models/calendar_event.dart
@@ -13,6 +13,10 @@ class CalendarEvent {
   final List<String> attendees;
   @HiveField(5)
   final String? location;
+  @HiveField(6)
+  final String? repeatInterval;
+  @HiveField(7)
+  final DateTime? repeatUntil;
 
   CalendarEvent({
     this.id,
@@ -21,6 +25,8 @@ class CalendarEvent {
     this.description,
     this.attendees = const [],
     this.location,
+    this.repeatInterval,
+    this.repeatUntil,
   });
 
   factory CalendarEvent.fromMap(Map<String, dynamic> map) => CalendarEvent(
@@ -31,6 +37,8 @@ class CalendarEvent {
     attendees:
         (map['attendees'] as List<dynamic>? ?? const []).map((e) => e.toString()).toList(),
     location: map['location'] as String?,
+    repeatInterval: map['repeatInterval'] as String?,
+    repeatUntil: map['repeatUntil'] != null ? _parseDate(map['repeatUntil']) : null,
   );
 
   Map<String, dynamic> toMap() => {
@@ -40,6 +48,8 @@ class CalendarEvent {
     'description': description,
     'attendees': attendees,
     'location': location,
+    if (repeatInterval != null) 'repeatInterval': repeatInterval,
+    if (repeatUntil != null) 'repeatUntil': repeatUntil!.toIso8601String(),
   };
 
   factory CalendarEvent.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -168,13 +168,15 @@ class CalendarEventAdapter extends TypeAdapter<CalendarEvent> {
       description: fields[3] as String?,
       attendees: (fields[4] as List).cast<String>(),
       location: fields[5] as String?,
+      repeatInterval: fields[6] as String?,
+      repeatUntil: fields[7] as DateTime?,
     );
   }
 
   @override
   void write(BinaryWriter writer, CalendarEvent obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -186,7 +188,11 @@ class CalendarEventAdapter extends TypeAdapter<CalendarEvent> {
       ..writeByte(4)
       ..write(obj.attendees)
       ..writeByte(5)
-      ..write(obj.location);
+      ..write(obj.location)
+      ..writeByte(6)
+      ..write(obj.repeatInterval)
+      ..writeByte(7)
+      ..write(obj.repeatUntil);
   }
 
   @override

--- a/lib/pages/admin/event_admin_page.dart
+++ b/lib/pages/admin/event_admin_page.dart
@@ -80,9 +80,16 @@ class _EventAdminPageState extends State<EventAdminPage> {
       appBar: AppBar(title: const Text('Manage Events')),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
-          await showAddEventDialog(context, (title, date, location) async {
+          await showAddEventDialog(context,
+              (title, date, location, interval, until) async {
             await _service.createEvent(
-              CalendarEvent(title: title, date: date, location: location),
+              CalendarEvent(
+                title: title,
+                date: date,
+                location: location,
+                repeatInterval: interval,
+                repeatUntil: until,
+              ),
             );
             _load();
           });

--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -86,12 +86,14 @@ class _CalendarPageState extends State<CalendarPage> {
   }
 
   void _addEvent() async {
-    await showAddEventDialog(context, (title, date, location) async {
+    await showAddEventDialog(context, (title, date, location, interval, until) async {
       final event = await _service.createEvent(
         CalendarEvent(
           title: title,
           date: date,
           location: location.isNotEmpty ? location : null,
+          repeatInterval: interval,
+          repeatUntil: until,
         ),
       );
       final dayKey = DateTime(
@@ -412,11 +414,20 @@ class _CalendarPageState extends State<CalendarPage> {
 
 Future<void> showAddEventDialog(
   BuildContext context,
-  void Function(String title, DateTime date, String location) onConfirm,
+  void Function(
+    String title,
+    DateTime date,
+    String location,
+    String? repeatInterval,
+    DateTime? repeatUntil,
+  )
+      onConfirm,
 ) async {
   final textCtrl = TextEditingController();
   final locCtrl = TextEditingController();
   DateTime selectedDate = DateTime.now();
+  String interval = 'none';
+  DateTime? until;
   await showDialog(
     context: context,
     builder:
@@ -450,6 +461,36 @@ Future<void> showAddEventDialog(
                   if (picked != null) selectedDate = picked;
                 },
               ),
+              const SizedBox(height: 8),
+              DropdownButton<String>(
+                value: interval,
+                items: const [
+                  DropdownMenuItem(value: 'none', child: Text('No Repeat')),
+                  DropdownMenuItem(value: 'daily', child: Text('Daily')),
+                  DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
+                  DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
+                  DropdownMenuItem(value: 'yearly', child: Text('Yearly')),
+                ],
+                onChanged: (val) => interval = val ?? 'none',
+              ),
+              if (interval != 'none')
+                TextButton.icon(
+                  icon: const Icon(Icons.repeat),
+                  label: Text(
+                    until == null
+                        ? 'Repeat Until'
+                        : '${until!.day}/${until!.month}/${until!.year}',
+                  ),
+                  onPressed: () async {
+                    final picked = await showDatePicker(
+                      context: ctx,
+                      initialDate: selectedDate,
+                      firstDate: selectedDate,
+                      lastDate: DateTime.utc(2035),
+                    );
+                    if (picked != null) until = picked;
+                  },
+                ),
             ],
           ),
           actions: [
@@ -460,7 +501,13 @@ Future<void> showAddEventDialog(
             ElevatedButton(
               onPressed: () {
                 if (textCtrl.text.isNotEmpty) {
-                  onConfirm(textCtrl.text, selectedDate, locCtrl.text);
+                  onConfirm(
+                    textCtrl.text,
+                    selectedDate,
+                    locCtrl.text,
+                    interval == 'none' ? null : interval,
+                    until,
+                  );
                   Navigator.pop(ctx);
                 }
               },

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -175,10 +175,17 @@ class _MainPageState extends State<MainPage> {
       case 2:
         if (!widget.isAdmin) return null;
         return () async {
-          await showAddEventDialog(context, (title, date, location) async {
+          await showAddEventDialog(context,
+              (title, date, location, interval, until) async {
             final service = EventService();
             await service.createEvent(
-              CalendarEvent(title: title, date: date, location: location),
+              CalendarEvent(
+                title: title,
+                date: date,
+                location: location,
+                repeatInterval: interval,
+                repeatUntil: until,
+              ),
             );
           });
         };

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -10,6 +10,11 @@ const EventSchema = new mongoose.Schema({
   checkIns: { type: [Number], default: [] },
   reminderSent: { type: Boolean, default: false },
   location: String,
+  repeatInterval: {
+    type: String,
+    enum: ['daily', 'weekly', 'monthly', 'yearly'],
+  },
+  repeatUntil: Date,
 }, { timestamps: true });
 
 module.exports = mongoose.model('Event', EventSchema);

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -13,7 +13,40 @@ router.use(auth);
 router.get('/', async (req, res) => {
   try {
     const events = await Event.find();
-    res.json({ data: events });
+    const result = [];
+    const addInterval = (date, interval) => {
+      const d = new Date(date);
+      switch (interval) {
+        case 'daily':
+          d.setDate(d.getDate() + 1);
+          break;
+        case 'weekly':
+          d.setDate(d.getDate() + 7);
+          break;
+        case 'monthly':
+          d.setMonth(d.getMonth() + 1);
+          break;
+        case 'yearly':
+          d.setFullYear(d.getFullYear() + 1);
+          break;
+        default:
+          return null;
+      }
+      return d;
+    };
+
+    for (const e of events) {
+      result.push(e);
+      if (e.repeatInterval && e.repeatUntil) {
+        let next = addInterval(e.date, e.repeatInterval);
+        while (next && next <= e.repeatUntil) {
+          const obj = { ...e.toObject(), date: next };
+          result.push(obj);
+          next = addInterval(next, e.repeatInterval);
+        }
+      }
+    }
+    res.json({ data: result });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- support recurring events on the server via `repeatInterval` and `repeatUntil`
- expand `/events` to generate future occurrences
- include recurrence fields in `CalendarEvent`
- wire recurrence options through event creation dialogs

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684372f62404832bbe6b0cb15bab583f