### PR TITLE
Add search and filters for Lost & Found

### DIFF
--- a/server/routes/lostfound.js
+++ b/server/routes/lostfound.js
@@ -22,7 +22,18 @@ router.use(auth);
 // GET /lostfound - list lost & found posts
 router.get('/', async (req, res) => {
   try {
-    const items = await LostItem.find();
+    const query = {};
+    if (req.query.type) {
+      query.type = req.query.type;
+    }
+    if (typeof req.query.resolved !== 'undefined') {
+      query.resolved = req.query.resolved === 'true';
+    }
+    if (req.query.search) {
+      const regex = { $regex: req.query.search, $options: 'i' };
+      query.$or = [{ title: regex }, { description: regex }];
+    }
+    const items = await LostItem.find(query);
     res.json({ data: items });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/tests/lostfound.test.js
+++ b/server/tests/lostfound.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const apiRouter = require('../api');
+const LostItem = require('../models/LostItem');
+
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+function getToken(id = 1) {
+  return jwt.sign({ userId: id }, SECRET);
+}
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('LostFound API', () => {
+  test('GET /lostfound filters by query params', async () => {
+    await LostItem.create([
+      { ownerId: '1', title: 'Lost Phone', type: 'lost' },
+      { ownerId: '1', title: 'Found Keys', type: 'found' },
+      { ownerId: '1', title: 'Old Wallet', type: 'lost', resolved: true },
+    ]);
+    const token = getToken();
+    const res = await request(app)
+      .get('/api/lostfound?search=phone&type=lost&resolved=false')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].title).toBe('Lost Phone');
+  });
+});

--- a/test/services/lost_found_service_test.dart
+++ b/test/services/lost_found_service_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:oly_app/services/lost_found_service.dart';
+import 'package:oly_app/models/models.dart';
+
+const apiUrl = String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+
+void main() {
+  group('LostFoundService', () {
+    test('fetchItems passes params and parses list', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.method, equals('GET'));
+        expect(request.url.origin, Uri.parse(apiUrl).origin);
+        expect(request.url.path, '/api/lostfound');
+        expect(request.url.queryParameters['search'], 'phone');
+        expect(request.url.queryParameters['type'], 'lost');
+        expect(request.url.queryParameters['resolved'], 'false');
+        return http.Response(
+          jsonEncode({
+            'data': [
+              {
+                'id': 1,
+                'ownerId': '1',
+                'title': 'Phone',
+                'description': 'Black',
+                'type': 'lost',
+                'resolved': false,
+                'createdAt': '1970-01-01T00:00:00.000Z'
+              }
+            ]
+          }),
+          200,
+        );
+      });
+
+      final service = LostFoundService(client: mockClient);
+      final items = await service.fetchItems(search: 'phone', type: 'lost', resolved: false);
+      expect(items, hasLength(1));
+      expect(items.first.title, 'Phone');
+    });
+
+    test('throws on non-success status', () async {
+      final mockClient = MockClient((_) async => http.Response('err', 500));
+      final service = LostFoundService(client: mockClient);
+      expect(service.fetchItems(), throwsException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- filter lost & found posts in server API via query params
- add parameters in `LostFoundService.fetchItems`
- add search and filter UI to `LostFoundPage`
- test lost & found service and API

## Testing
- `npm test --prefix server` *(fails: spawn MongoMemoryServer)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684372fcaa74832b9f47288e9fe8b990