### PR TITLE
Add group chat support

### DIFF
--- a/lib/models/chat_channel.dart
+++ b/lib/models/chat_channel.dart
@@ -1,0 +1,35 @@
+part of 'models.dart';
+
+class ChatChannel {
+  final String? id;
+  final String name;
+  final List<String> participants;
+  final bool isGroup;
+
+  ChatChannel({
+    this.id,
+    required this.name,
+    this.participants = const [],
+    this.isGroup = true,
+  });
+
+  factory ChatChannel.fromMap(Map<String, dynamic> map) => ChatChannel(
+        id: map['id']?.toString() ?? map['_id']?.toString(),
+        name: map['name'] as String? ?? '',
+        participants:
+            (map['participants'] as List<dynamic>? ?? const []).map((e) => e.toString()).toList(),
+        isGroup: map['isGroup'] as bool? ?? true,
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'name': name,
+        'participants': participants,
+        'isGroup': isGroup,
+      };
+
+  factory ChatChannel.fromJson(Map<String, dynamic> json) => ChatChannel.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+  String toJsonString() => jsonEncode(toJson());
+  factory ChatChannel.fromJsonString(String source) => ChatChannel.fromMap(jsonDecode(source));
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -14,7 +14,8 @@ part 'event_comment.dart';
 part 'notification_record.dart';
 part 'transit.dart';
 part 'poll.dart';
-part 'lost_item.dart'; 
+part 'lost_item.dart';
+part 'chat_channel.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/pages/create_channel_page.dart
+++ b/lib/pages/create_channel_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/chat_service.dart';
+
+class CreateChannelPage extends StatefulWidget {
+  const CreateChannelPage({super.key});
+
+  @override
+  State<CreateChannelPage> createState() => _CreateChannelPageState();
+}
+
+class _CreateChannelPageState extends State<CreateChannelPage> {
+  final TextEditingController _nameCtrl = TextEditingController();
+  final ChatService _service = ChatService();
+  bool _creating = false;
+
+  Future<void> _create() async {
+    final name = _nameCtrl.text.trim();
+    if (name.isEmpty) return;
+    setState(() => _creating = true);
+    try {
+      final channel = await _service.createChannel(name);
+      if (!mounted) return;
+      Navigator.pop(context, channel);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _creating = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Channel')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameCtrl,
+              decoration: const InputDecoration(labelText: 'Channel name'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _creating ? null : _create,
+              child: const Text('Create'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/group_chat_page.dart
+++ b/lib/pages/group_chat_page.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/chat_service.dart';
+import '../utils/user_helpers.dart';
+
+class GroupChatPage extends StatefulWidget {
+  final ChatChannel channel;
+  const GroupChatPage({super.key, required this.channel});
+
+  @override
+  State<GroupChatPage> createState() => _GroupChatPageState();
+}
+
+class _GroupChatPageState extends State<GroupChatPage> {
+  final ChatService _service = ChatService();
+  final TextEditingController _messageCtrl = TextEditingController();
+  List<Message> _messages = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMessages();
+  }
+
+  Future<void> _loadMessages() async {
+    if (widget.channel.id == null) return;
+    final msgs = await _service.fetchMessages(widget.channel.id!);
+    if (!mounted) return;
+    setState(() => _messages = msgs);
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _messageCtrl.text.trim();
+    if (text.isEmpty || widget.channel.id == null) return;
+    final msg = await _service.sendMessage(widget.channel.id!, text);
+    if (!mounted) return;
+    setState(() => _messages.add(msg));
+    _messageCtrl.clear();
+  }
+
+  @override
+  void dispose() {
+    _messageCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.channel.name),
+        backgroundColor: colorScheme.primaryContainer,
+        foregroundColor: colorScheme.onPrimaryContainer,
+        elevation: 1,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final msg = _messages[index];
+                final isMe = msg.senderId == currentUserId();
+                return Align(
+                  alignment: isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: isMe
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(msg.content),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _messageCtrl,
+                    decoration: const InputDecoration(hintText: 'Type a message'),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: _sendMessage,
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -15,6 +15,8 @@ import 'transit_page.dart';
 import 'directory_page.dart';
 import 'polls_page.dart';
 import 'lost_found_page.dart';
+import 'create_channel_page.dart';
+import 'group_chat_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -329,6 +331,28 @@ class DashboardPage extends StatelessWidget {
                     context,
                     MaterialPageRoute(builder: (_) => const ServicesPage()),
                   ),
+                ),
+                DashboardCard(
+                  icon: Icons.forum,
+                  label: 'Channels',
+                  colorScheme: colorScheme,
+                  onTap: () async {
+                    final channel = await Navigator.push<ChatChannel>(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const CreateChannelPage(),
+                      ),
+                    );
+                    if (channel != null) {
+                      // ignore: use_build_context_synchronously
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => GroupChatPage(channel: channel),
+                        ),
+                      );
+                    }
+                  },
                 ),
                 DashboardCard(
                   icon: Icons.miscellaneous_services,

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,0 +1,42 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class ChatService extends ApiService {
+  ChatService({super.client});
+
+  Future<ChatChannel> createChannel(String name, {List<String> participants = const []}) async {
+    return post('/channels', {
+      'name': name,
+      'participants': participants,
+    }, (json) {
+      return ChatChannel.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Future<ChatChannel> addParticipant(String channelId, String userId) async {
+    return post('/channels/$channelId/participants', {'userId': userId}, (json) {
+      return ChatChannel.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Future<ChatChannel> removeParticipant(String channelId, String userId) async {
+    return delete('/channels/$channelId/participants/$userId', (json) {
+      return ChatChannel.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Future<List<Message>> fetchMessages(String channelId) async {
+    return get('/channels/$channelId/messages', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list.map((e) => Message.fromJson(e as Map<String, dynamic>)).toList();
+    });
+  }
+
+  Future<Message> sendMessage(String channelId, String content) async {
+    return post('/channels/$channelId/messages', {
+      'content': content,
+    }, (json) {
+      return Message.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -13,6 +13,7 @@ const directoryRouter = require('../routes/directory');
 const lostFoundRouter = require('../routes/lostfound');
 const servicesRouter = require('../routes/services');
 const pollsRouter = require('../routes/polls');
+const channelsRouter = require('../routes/channels');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -31,4 +32,5 @@ router.use('/directory', directoryRouter);
 router.use('/lostfound', lostFoundRouter);
 router.use('/services', servicesRouter);
 router.use('/polls', pollsRouter);
+router.use('/channels', channelsRouter);
 module.exports = router;

--- a/server/models/Conversation.js
+++ b/server/models/Conversation.js
@@ -4,6 +4,11 @@ const ConversationSchema = new mongoose.Schema({
   participants: {
     type: [String],
     required: true
+  },
+  name: String,
+  isGroup: {
+    type: Boolean,
+    default: false
   }
 });
 

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const Conversation = require('../models/Conversation');
+const Message = require('../models/Message');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// POST /channels - create a new group channel
+router.post('/', async (req, res) => {
+  try {
+    const { name, participants = [] } = req.body;
+    if (!name) return res.status(400).json({ error: 'Name required' });
+    const ids = Array.from(new Set([...participants.map(String), String(req.userId)]));
+    const channel = await Conversation.create({
+      name,
+      participants: ids,
+      isGroup: true,
+    });
+    res.status(201).json({ data: channel });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /channels/:id/participants - add participant
+router.post('/:id/participants', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    const channel = await Conversation.findByIdAndUpdate(
+      req.params.id,
+      { $addToSet: { participants: String(userId) } },
+      { new: true }
+    );
+    if (!channel) return res.status(404).json({ error: 'Channel not found' });
+    res.json({ data: channel });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /channels/:id/participants/:userId - remove participant
+router.delete('/:id/participants/:userId', async (req, res) => {
+  try {
+    const channel = await Conversation.findByIdAndUpdate(
+      req.params.id,
+      { $pull: { participants: String(req.params.userId) } },
+      { new: true }
+    );
+    if (!channel) return res.status(404).json({ error: 'Channel not found' });
+    res.json({ data: channel });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /channels/:id/messages - fetch group messages
+router.get('/:id/messages', async (req, res) => {
+  try {
+    const messages = await Message.find({ conversationId: req.params.id });
+    res.json({ data: messages });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /channels/:id/messages - send message to channel
+router.post('/:id/messages', async (req, res) => {
+  try {
+    const message = await Message.create({
+      conversationId: req.params.id,
+      senderId: req.userId,
+      content: req.body.content,
+    });
+    res.status(201).json({ data: message });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- extend Conversation model with `name` and `isGroup`
- expose new `/channels` API for creating and managing chat channels
- register channels routes with API index
- add Dart `ChatChannel` model
- create `ChatService` to call new endpoints
- add group chat and create channel pages
- hook up channel creation from dashboard

## Testing
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6843e96fb984832b8995376250c5ed7d