### PR TITLE
Add analytics endpoint and admin chart page

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -6,6 +6,7 @@ import 'bulletin_admin_page.dart';
 import 'booking_admin_page.dart';
 import 'map_admin_page.dart';
 import 'poll_admin_page.dart';
+import 'analytics_page.dart';
 import '../../utils/user_helpers.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -100,6 +101,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Create Poll'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AnalyticsPage()),
+                );
+              },
+              child: const Text('Analytics'),
             ),
           ],
         ),

--- a/lib/pages/admin/analytics_page.dart
+++ b/lib/pages/admin/analytics_page.dart
@@ -1,0 +1,95 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../services/stats_service.dart';
+import '../../utils/user_helpers.dart';
+
+class AnalyticsPage extends StatefulWidget {
+  final StatsService? service;
+  const AnalyticsPage({super.key, this.service});
+
+  @override
+  State<AnalyticsPage> createState() => _AnalyticsPageState();
+}
+
+class _AnalyticsPageState extends State<AnalyticsPage> {
+  late final StatsService _service;
+  Map<String, int> _stats = {};
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Admin access required')));
+      });
+    } else {
+      _service = widget.service ?? StatsService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final data = await _service.fetchStats();
+    setState(() {
+      _stats = data.map((k, v) => MapEntry(k, v as int));
+      _loaded = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    if (!_loaded) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Analytics')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final entries = _stats.entries.toList();
+    final groups = List.generate(entries.length, (i) {
+      return BarChartGroupData(
+        x: i,
+        barRods: [BarChartRodData(toY: entries[i].value.toDouble(), width: 16)],
+      );
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Analytics')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: BarChart(
+          BarChartData(
+            barGroups: groups,
+            titlesData: FlTitlesData(
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, meta) {
+                    final label = entries[value.toInt()].key;
+                    return SideTitleWidget(
+                      meta: meta,
+                      space: 4,
+                      child: Text(label, style: const TextStyle(fontSize: 10)),
+                    );
+                  },
+                ),
+              ),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(showTitles: true),
+              ),
+              rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            ),
+            gridData: FlGridData(show: true),
+            borderData: FlBorderData(show: false),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -1,0 +1,12 @@
+import 'api_service.dart';
+
+class StatsService extends ApiService {
+  StatsService({super.client});
+
+  Future<Map<String, dynamic>> fetchStats() async {
+    return get('/stats', (json) {
+      final map = Map<String, dynamic>.from(json['data'] as Map);
+      return map;
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   mobile_scanner: ^3.5.0
   share_plus: ^7.2.1
   path_provider: ^2.1.5
+  fl_chart: ^1.0.0
 dev_dependencies:
   test: any
   flutter_test:

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -13,6 +13,7 @@ const directoryRouter = require('../routes/directory');
 const lostFoundRouter = require('../routes/lostfound');
 const servicesRouter = require('../routes/services');
 const pollsRouter = require('../routes/polls');
+const statsRouter = require('../routes/stats');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -31,4 +32,5 @@ router.use('/directory', directoryRouter);
 router.use('/lostfound', lostFoundRouter);
 router.use('/services', servicesRouter);
 router.use('/polls', pollsRouter);
+router.use('/stats', statsRouter);
 module.exports = router;

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
+const User = require('../models/User');
+const Event = require('../models/Event');
+const Item = require('../models/Item');
+const ServiceListing = require('../models/ServiceListing');
+const MaintenanceRequest = require('../models/MaintenanceRequest');
+const MapPin = require('../models/MapPin');
+const LostItem = require('../models/LostItem');
+const BookingSlot = require('../models/BookingSlot');
+const BulletinPost = require('../models/BulletinPost');
+const Poll = require('../models/Poll');
+
+const router = express.Router();
+router.use(auth);
+router.use(requireAdmin);
+
+router.get('/', async (req, res) => {
+  try {
+    const [users, events, items, listings, maintenance, pins, lostItems, bookings, bulletinPosts, polls] = await Promise.all([
+      User.countDocuments(),
+      Event.countDocuments(),
+      Item.countDocuments(),
+      ServiceListing.countDocuments(),
+      MaintenanceRequest.countDocuments(),
+      MapPin.countDocuments(),
+      LostItem.countDocuments(),
+      BookingSlot.countDocuments(),
+      BulletinPost.countDocuments(),
+      Poll.countDocuments(),
+    ]);
+    res.json({
+      data: {
+        users,
+        events,
+        items,
+        listings,
+        maintenance,
+        pins,
+        lostItems,
+        bookings,
+        bulletinPosts,
+        polls,
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/stats.test.js
+++ b/server/tests/stats.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const apiRouter = require('../api');
+const User = require('../models/User');
+const Event = require('../models/Event');
+const Item = require('../models/Item');
+const ServiceListing = require('../models/ServiceListing');
+
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('Stats API', () => {
+  test('GET /stats returns counts', async () => {
+    await User.create({ name: 'u', email: 'u@a.b', passwordHash: 'x' });
+    await Event.create({ title: 'e', date: new Date(0) });
+    await Item.create({ ownerId: '1', title: 'i' });
+    await ServiceListing.create({ userId: '1', title: 's', description: '' });
+    const admin = await User.create({ name: 'a', email: 'a@b.c', passwordHash: 'x', isAdmin: true });
+    const token = jwt.sign({ userId: admin._id }, SECRET);
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.users).toBe(2);
+    expect(res.body.data.events).toBe(1);
+    expect(res.body.data.items).toBe(1);
+    expect(res.body.data.listings).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add statistics route for server showing counts of objects
- mount the stats API in Express router
- fetch stats data from Flutter via `StatsService`
- visualize analytics with a bar chart using `fl_chart`
- link analytics page from admin home
- add dependency for `fl_chart`
- test stats endpoint

## Testing
- `npm test`
- `flutter test` *(fails to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6843e972a138832baa3b9a47de645365