### PR TITLE
Add clubs feature

### DIFF
--- a/lib/models/club.dart
+++ b/lib/models/club.dart
@@ -1,0 +1,38 @@
+part of 'models.dart';
+
+class Club {
+  final String? id;
+  final String name;
+  final String? description;
+  final List<String> members;
+  final String? channelId;
+
+  Club({
+    this.id,
+    required this.name,
+    this.description,
+    this.members = const [],
+    this.channelId,
+  });
+
+  factory Club.fromMap(Map<String, dynamic> map) => Club(
+    id: map['id']?.toString() ?? map['_id']?.toString(),
+    name: map['name'] as String? ?? '',
+    description: map['description'] as String?,
+    members: (map['members'] as List<dynamic>? ?? const [])
+        .map((e) => e.toString())
+        .toList(),
+    channelId: map['channelId']?.toString(),
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'name': name,
+    'description': description,
+    'members': members,
+    'channelId': channelId,
+  };
+
+  factory Club.fromJson(Map<String, dynamic> json) => Club.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -16,6 +16,7 @@ part 'transit.dart';
 part 'poll.dart';
 part 'lost_item.dart';
 part 'chat_channel.dart';
+part 'club.dart';
 part 'wiki_article.dart';
 
 DateTime _parseDate(dynamic value) {

--- a/lib/pages/club_detail_page.dart
+++ b/lib/pages/club_detail_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/club_service.dart';
+import '../services/chat_service.dart';
+import '../utils/user_helpers.dart';
+import 'group_chat_page.dart';
+
+class ClubDetailPage extends StatefulWidget {
+  final Club club;
+  final ClubService? service;
+  const ClubDetailPage({super.key, required this.club, this.service});
+
+  @override
+  State<ClubDetailPage> createState() => _ClubDetailPageState();
+}
+
+class _ClubDetailPageState extends State<ClubDetailPage> {
+  late Club _club;
+  late final ClubService _service;
+  final ChatService _chat = ChatService();
+
+  @override
+  void initState() {
+    super.initState();
+    _club = widget.club;
+    _service = widget.service ?? ClubService();
+  }
+
+  Future<void> _joinAndChat() async {
+    if (_club.id == null || _club.channelId == null) return;
+    final updated = await _service.joinClub(_club.id!);
+    if (mounted) setState(() => _club = updated);
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => GroupChatPage(
+          channel: ChatChannel(id: _club.channelId!, name: _club.name),
+        ),
+      ),
+    );
+  }
+
+  void _openChat() {
+    if (_club.channelId == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => GroupChatPage(
+          channel: ChatChannel(id: _club.channelId!, name: _club.name),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isMember = _club.members.contains(currentUserId());
+    return Scaffold(
+      appBar: AppBar(title: Text(_club.name)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_club.description != null) Text(_club.description!),
+            const SizedBox(height: 12),
+            Text('Members: ${_club.members.length}'),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _club.channelId == null
+                  ? null
+                  : (isMember ? _openChat : _joinAndChat),
+              child: Text(isMember ? 'Open Chat' : 'Join & Chat'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/clubs_page.dart
+++ b/lib/pages/clubs_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/club_service.dart';
+import 'club_detail_page.dart';
+
+class ClubsPage extends StatefulWidget {
+  final ClubService? service;
+  const ClubsPage({super.key, this.service});
+
+  @override
+  State<ClubsPage> createState() => _ClubsPageState();
+}
+
+class _ClubsPageState extends State<ClubsPage> {
+  late final ClubService _service;
+  List<Club> _clubs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? ClubService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final list = await _service.fetchClubs();
+    if (mounted) setState(() => _clubs = list);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView.builder(
+        itemCount: _clubs.length,
+        itemBuilder: (context, index) {
+          final club = _clubs[index];
+          return ListTile(
+            title: Text(club.name),
+            subtitle: Text(club.description ?? ''),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => ClubDetailPage(club: club, service: _service),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -18,6 +18,7 @@ import 'lost_found_page.dart';
 import 'create_channel_page.dart';
 import 'group_chat_page.dart';
 import 'wiki_page.dart';
+import 'clubs_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -188,8 +189,14 @@ class _MainPageState extends State<MainPage> {
       case 2:
         if (!widget.isAdmin) return null;
         return () async {
-          await showAddEventDialog(context,
-              (title, date, location, interval, until, category) async {
+          await showAddEventDialog(context, (
+            title,
+            date,
+            location,
+            interval,
+            until,
+            category,
+          ) async {
             final service = EventService();
             await service.createEvent(
               CalendarEvent(
@@ -357,8 +364,17 @@ class DashboardPage extends StatelessWidget {
                       );
                     }
                   },
-                ), 
-                DashboardCard( 
+                ),
+                DashboardCard(
+                  icon: Icons.group,
+                  label: 'Clubs',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ClubsPage()),
+                  ),
+                ),
+                DashboardCard(
                   icon: Icons.menu_book,
                   label: 'Wiki',
                   colorScheme: colorScheme,

--- a/lib/services/club_service.dart
+++ b/lib/services/club_service.dart
@@ -1,0 +1,25 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class ClubService extends ApiService {
+  ClubService({super.client});
+
+  Future<List<Club>> fetchClubs() async {
+    return get('/clubs', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list.map((e) => Club.fromJson(e as Map<String, dynamic>)).toList();
+    });
+  }
+
+  Future<Club> createClub(Club club) async {
+    return post('/clubs', club.toJson(), (json) {
+      return Club.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+
+  Future<Club> joinClub(String clubId) async {
+    return post('/clubs/$clubId/join', const {}, (json) {
+      return Club.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -16,6 +16,7 @@ const pollsRouter = require('../routes/polls');
 const statsRouter = require('../routes/stats');
 const channelsRouter = require('../routes/channels');
 const wikiRouter = require('../routes/wiki');
+const clubsRouter = require('../routes/clubs');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -37,4 +38,5 @@ router.use('/polls', pollsRouter);
 router.use('/stats', statsRouter);
 router.use('/channels', channelsRouter);
 router.use('/wiki', wikiRouter);
+router.use('/clubs', clubsRouter);
 module.exports = router;

--- a/server/models/Club.js
+++ b/server/models/Club.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const ClubSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: String,
+  members: { type: [String], default: [] },
+  channelId: String,
+}, { timestamps: true });
+
+module.exports = mongoose.model('Club', ClubSchema);

--- a/server/routes/clubs.js
+++ b/server/routes/clubs.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const Club = require('../models/Club');
+const Conversation = require('../models/Conversation');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /clubs - list clubs
+router.get('/', async (req, res) => {
+  try {
+    const clubs = await Club.find();
+    res.json({ data: clubs });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /clubs - create club and chat channel
+router.post('/', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    if (!name) return res.status(400).json({ error: 'Name required' });
+    const convo = await Conversation.create({
+      name,
+      participants: [String(req.userId)],
+      isGroup: true,
+    });
+    const club = await Club.create({
+      name,
+      description,
+      members: [String(req.userId)],
+      channelId: convo._id.toString(),
+    });
+    res.status(201).json({ data: club });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// GET /clubs/:id - get club
+router.get('/:id', async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    if (!club) return res.status(404).json({ error: 'Club not found' });
+    res.json({ data: club });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /clubs/:id - update club
+router.put('/:id', async (req, res) => {
+  try {
+    const club = await Club.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!club) return res.status(404).json({ error: 'Club not found' });
+    res.json({ data: club });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /clubs/:id - delete club
+router.delete('/:id', async (req, res) => {
+  try {
+    const club = await Club.findByIdAndDelete(req.params.id);
+    if (!club) return res.status(404).json({ error: 'Club not found' });
+    res.json({ data: club });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /clubs/:id/join - join club and channel
+router.post('/:id/join', async (req, res) => {
+  try {
+    const club = await Club.findById(req.params.id);
+    if (!club) return res.status(404).json({ error: 'Club not found' });
+    const userId = String(req.userId);
+    if (!club.members.includes(userId)) {
+      club.members.push(userId);
+      await club.save();
+      if (club.channelId) {
+        await Conversation.findByIdAndUpdate(
+          club.channelId,
+          { $addToSet: { participants: userId } },
+          { new: true }
+        );
+      }
+    }
+    res.json({ data: club });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create Club model and routes on server
- register /clubs API endpoint
- add Club model, service and pages in Flutter app
- link Clubs page from dashboard

## Testing
- `npm test`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6843f3916de0832bb43337acca3c6717