### PR TITLE
Add emergency contacts module

### DIFF
--- a/lib/models/emergency_contact.dart
+++ b/lib/models/emergency_contact.dart
@@ -1,0 +1,34 @@
+part of 'models.dart';
+
+class EmergencyContact {
+  final String? id;
+  final String name;
+  final String phone;
+  final String? description;
+
+  EmergencyContact({
+    this.id,
+    required this.name,
+    required this.phone,
+    this.description,
+  });
+
+  factory EmergencyContact.fromMap(Map<String, dynamic> map) =>
+      EmergencyContact(
+        id: map['id']?.toString() ?? map['_id']?.toString(),
+        name: map['name'] as String,
+        phone: map['phone'] as String,
+        description: map['description'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'name': name,
+    'phone': phone,
+    'description': description,
+  };
+
+  factory EmergencyContact.fromJson(Map<String, dynamic> json) =>
+      EmergencyContact.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -17,6 +17,7 @@ part 'poll.dart';
 part 'lost_item.dart';
 part 'chat_channel.dart';
 part 'wiki_article.dart';
+part 'emergency_contact.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/pages/emergency_contacts_page.dart
+++ b/lib/pages/emergency_contacts_page.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/models.dart';
+import '../services/emergency_contact_service.dart';
+
+class EmergencyContactsPage extends StatefulWidget {
+  final EmergencyContactService? service;
+  const EmergencyContactsPage({super.key, this.service});
+
+  @override
+  State<EmergencyContactsPage> createState() => _EmergencyContactsPageState();
+}
+
+class _EmergencyContactsPageState extends State<EmergencyContactsPage> {
+  late final EmergencyContactService _service;
+  List<EmergencyContact> _contacts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? EmergencyContactService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final list = await _service.fetchContacts();
+      if (mounted) setState(() => _contacts = list);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to load contacts')));
+    }
+  }
+
+  Future<void> _call(String phone) async {
+    final uri = Uri.parse('tel:$phone');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Emergency Contacts')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView.builder(
+          itemCount: _contacts.length,
+          itemBuilder: (context, index) {
+            final c = _contacts[index];
+            return Card(
+              margin: const EdgeInsets.all(12),
+              child: ListTile(
+                title: Text(c.name),
+                subtitle: Text(c.description ?? c.phone),
+                trailing: IconButton(
+                  icon: const Icon(Icons.call),
+                  onPressed: () => _call(c.phone),
+                ),
+                onTap: () => _call(c.phone),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../models/models.dart';
 import '../main.dart';
 import '../services/user_service.dart';
+import 'emergency_contacts_page.dart';
 
 class SettingsPage extends StatefulWidget {
   final UserService? service;
@@ -71,6 +72,18 @@ class _SettingsPageState extends State<SettingsPage> {
             title: const Text('Appear in Directory'),
             value: _listed,
             onChanged: _updateListed,
+          ),
+          ListTile(
+            title: const Text('Emergency Contacts'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const EmergencyContactsPage(),
+                ),
+              );
+            },
           ),
         ],
       ),

--- a/lib/services/emergency_contact_service.dart
+++ b/lib/services/emergency_contact_service.dart
@@ -1,0 +1,36 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class EmergencyContactService extends ApiService {
+  EmergencyContactService({super.client});
+
+  Future<List<EmergencyContact>> fetchContacts() async {
+    return get('/emergency_contacts', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => EmergencyContact.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<EmergencyContact> createContact(EmergencyContact contact) async {
+    return post(
+      '/emergency_contacts',
+      contact.toJson(),
+      (json) => EmergencyContact.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<EmergencyContact> updateContact(EmergencyContact contact) async {
+    if (contact.id == null) throw ArgumentError('id required');
+    return put(
+      '/emergency_contacts/${contact.id}',
+      contact.toJson(),
+      (json) => EmergencyContact.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deleteContact(String id) async {
+    await delete('/emergency_contacts/$id', (_) => null);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -222,6 +222,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -334,6 +342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "577aeac8ca414c25333334d7c4bb246775234c0e44b38b10a82b559dd4d764e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flat_buffers:
     dependency: transitive
     description:
@@ -1170,6 +1186,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1178,6 +1218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1300,4 +1348,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.2 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.27.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   geolocator: ^11.0.0
   mobile_scanner: ^3.5.0
   share_plus: ^7.2.1
+  url_launcher: ^6.2.6
   path_provider: ^2.1.5
   fl_chart: ^1.0.0
 dev_dependencies:

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -16,6 +16,7 @@ const pollsRouter = require('../routes/polls');
 const statsRouter = require('../routes/stats');
 const channelsRouter = require('../routes/channels');
 const wikiRouter = require('../routes/wiki');
+const emergencyContactsRouter = require('../routes/emergency_contacts');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -37,4 +38,5 @@ router.use('/polls', pollsRouter);
 router.use('/stats', statsRouter);
 router.use('/channels', channelsRouter);
 router.use('/wiki', wikiRouter);
+router.use('/emergency_contacts', emergencyContactsRouter);
 module.exports = router;

--- a/server/models/EmergencyContact.js
+++ b/server/models/EmergencyContact.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const EmergencyContactSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  phone: { type: String, required: true },
+  description: String,
+});
+
+module.exports = mongoose.model('EmergencyContact', EmergencyContactSchema);

--- a/server/routes/emergency_contacts.js
+++ b/server/routes/emergency_contacts.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const EmergencyContact = require('../models/EmergencyContact');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /emergency_contacts - list contacts
+router.get('/', async (req, res) => {
+  try {
+    const contacts = await EmergencyContact.find();
+    res.json({ data: contacts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /emergency_contacts - create contact
+router.post('/', async (req, res) => {
+  try {
+    const contact = await EmergencyContact.create(req.body);
+    res.status(201).json({ data: contact });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /emergency_contacts/:id - update contact
+router.put('/:id', async (req, res) => {
+  try {
+    const contact = await EmergencyContact.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!contact) return res.status(404).json({ error: 'Contact not found' });
+    res.json({ data: contact });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /emergency_contacts/:id - remove contact
+router.delete('/:id', async (req, res) => {
+  try {
+    const contact = await EmergencyContact.findByIdAndDelete(req.params.id);
+    if (!contact) return res.status(404).json({ error: 'Contact not found' });
+    res.json({ data: contact });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add EmergencyContact model and CRUD API endpoints
- expose `/emergency_contacts` through API router
- add Flutter model, service and page for emergency contacts
- link emergency contacts from Settings page
- include url_launcher dependency

## Testing
- `npm test`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6843f3878e98832bb5b31ed942c04145