### PR TITLE
Add bio and room fields to user profiles

### DIFF
--- a/lib/models/models.g.dart
+++ b/lib/models/models.g.dart
@@ -24,13 +24,15 @@ class UserAdapter extends TypeAdapter<User> {
       avatarUrl: fields[3] as String?,
       isAdmin: fields[4] as bool,
       isListed: fields[5] as bool,
+      bio: fields[6] as String?,
+      room: fields[7] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, User obj) {
     writer
-      ..writeByte(6)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -42,7 +44,11 @@ class UserAdapter extends TypeAdapter<User> {
       ..writeByte(4)
       ..write(obj.isAdmin)
       ..writeByte(5)
-      ..write(obj.isListed);
+      ..write(obj.isListed)
+      ..writeByte(6)
+      ..write(obj.bio)
+      ..writeByte(7)
+      ..write(obj.room);
   }
 
   @override

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -15,6 +15,10 @@ class User {
   final bool isAdmin;
   @HiveField(5)
   final bool isListed;
+  @HiveField(6)
+  final String? bio;
+  @HiveField(7)
+  final String? room;
 
   User({
     this.id,
@@ -23,6 +27,8 @@ class User {
     this.avatarUrl,
     this.isAdmin = false,
     this.isListed = false,
+    this.bio,
+    this.room,
   });
 
   factory User.fromMap(Map<String, dynamic> map) => User(
@@ -32,6 +38,8 @@ class User {
     avatarUrl: map['avatarUrl'] as String?,
     isAdmin: (map['isAdmin'] ?? false) as bool,
     isListed: (map['isListed'] ?? false) as bool,
+    bio: map['bio'] as String?,
+    room: map['room'] as String?,
   );
 
   Map<String, dynamic> toMap() => {
@@ -41,6 +49,8 @@ class User {
     'avatarUrl': avatarUrl,
     'isAdmin': isAdmin,
     'isListed': isListed,
+    'bio': bio,
+    'room': room,
   };
 
   factory User.fromJson(Map<String, dynamic> json) => User.fromMap(json);

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -73,6 +73,8 @@ class _LoginPageState extends State<LoginPage> {
         avatarUrl: userMap['avatarUrl'] as String?,
         isAdmin: (userMap['isAdmin'] ?? false) as bool,
         isListed: (userMap['isListed'] ?? false) as bool,
+        bio: userMap['bio'] as String?,
+        room: userMap['room'] as String?,
       );
       final userBox = Hive.box<User>('userBox');
       await userBox.put('currentUser', user);
@@ -122,8 +124,8 @@ class _LoginPageState extends State<LoginPage> {
 
     final fullName =
         credential.givenName != null && credential.familyName != null
-        ? '${credential.givenName} ${credential.familyName}'
-        : 'Apple User';
+            ? '${credential.givenName} ${credential.familyName}'
+            : 'Apple User';
     final email = credential.email ?? '${credential.userIdentifier}@apple.com';
 
     final user = User(
@@ -189,8 +191,10 @@ class _LoginPageState extends State<LoginPage> {
                             ? Icons.visibility
                             : Icons.visibility_off,
                       ),
-                      onPressed: () =>
-                          setState(() => _passwordVisible = !_passwordVisible),
+                      onPressed:
+                          () => setState(
+                            () => _passwordVisible = !_passwordVisible,
+                          ),
                     ),
                   ),
                   obscureText: !_passwordVisible,
@@ -201,13 +205,14 @@ class _LoginPageState extends State<LoginPage> {
                   width: double.infinity,
                   child: ElevatedButton(
                     onPressed: _isLoading ? null : _handleLogin,
-                    child: _isLoading
-                        ? const SizedBox(
-                            height: 16,
-                            width: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Text('Login'),
+                    child:
+                        _isLoading
+                            ? const SizedBox(
+                              height: 16,
+                              width: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                            : const Text('Login'),
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -217,31 +222,34 @@ class _LoginPageState extends State<LoginPage> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     ElevatedButton.icon(
-                      onPressed: _isLoading
-                          ? null
-                          : () async {
-                              setState(() => _isLoading = true);
-                              try {
-                                final user = await _handleGoogleSignIn();
-                                if (!context.mounted) return;
-                                if (user != null) {
-                                  final userBox = Hive.box<User>('userBox');
-                                  await userBox.put('currentUser', user);
-                                  widget.onLoginSuccess();
+                      onPressed:
+                          _isLoading
+                              ? null
+                              : () async {
+                                setState(() => _isLoading = true);
+                                try {
+                                  final user = await _handleGoogleSignIn();
+                                  if (!context.mounted) return;
+                                  if (user != null) {
+                                    final userBox = Hive.box<User>('userBox');
+                                    await userBox.put('currentUser', user);
+                                    widget.onLoginSuccess();
+                                  }
+                                } catch (e) {
+                                  if (!context.mounted) return;
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        'Google sign-in failed: $e',
+                                      ),
+                                    ),
+                                  );
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _isLoading = false);
+                                  }
                                 }
-                              } catch (e) {
-                                if (!context.mounted) return;
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text('Google sign-in failed: $e'),
-                                  ),
-                                );
-                              } finally {
-                                if (mounted) {
-                                  setState(() => _isLoading = false);
-                                }
-                              }
-                            },
+                              },
                       icon: const Icon(Icons.login),
                       label: const Text('Google'),
                       style: ElevatedButton.styleFrom(
@@ -251,31 +259,32 @@ class _LoginPageState extends State<LoginPage> {
                     ),
                     const SizedBox(width: 12),
                     ElevatedButton.icon(
-                      onPressed: _isLoading
-                          ? null
-                          : () async {
-                              setState(() => _isLoading = true);
-                              try {
-                                final user = await _handleAppleSignIn();
-                                if (!context.mounted) return;
-                                if (user != null) {
-                                  final userBox = Hive.box<User>('userBox');
-                                  await userBox.put('currentUser', user);
-                                  widget.onLoginSuccess();
+                      onPressed:
+                          _isLoading
+                              ? null
+                              : () async {
+                                setState(() => _isLoading = true);
+                                try {
+                                  final user = await _handleAppleSignIn();
+                                  if (!context.mounted) return;
+                                  if (user != null) {
+                                    final userBox = Hive.box<User>('userBox');
+                                    await userBox.put('currentUser', user);
+                                    widget.onLoginSuccess();
+                                  }
+                                } catch (e) {
+                                  if (!context.mounted) return;
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text('Apple sign-in failed: $e'),
+                                    ),
+                                  );
+                                } finally {
+                                  if (mounted) {
+                                    setState(() => _isLoading = false);
+                                  }
                                 }
-                              } catch (e) {
-                                if (!context.mounted) return;
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text('Apple sign-in failed: $e'),
-                                  ),
-                                );
-                              } finally {
-                                if (mounted) {
-                                  setState(() => _isLoading = false);
-                                }
-                              }
-                            },
+                              },
                       icon: const Icon(Icons.apple),
                       label: const Text('Apple'),
                       style: ElevatedButton.styleFrom(
@@ -287,15 +296,17 @@ class _LoginPageState extends State<LoginPage> {
                 ),
                 const SizedBox(height: 24),
                 TextButton(
-                  onPressed: _isLoading
-                      ? null
-                      : () => Navigator.pushNamed(context, '/register'),
+                  onPressed:
+                      _isLoading
+                          ? null
+                          : () => Navigator.pushNamed(context, '/register'),
                   child: const Text('Create an account'),
                 ),
                 TextButton(
-                  onPressed: _isLoading
-                      ? null
-                      : () => Navigator.pushNamed(context, '/forgot'),
+                  onPressed:
+                      _isLoading
+                          ? null
+                          : () => Navigator.pushNamed(context, '/forgot'),
                   child: const Text('Forgot password?'),
                 ),
               ],

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -24,6 +24,8 @@ class _ProfilePageState extends State<ProfilePage> {
   late final TextEditingController _nameCtrl;
   late final TextEditingController _emailCtrl;
   late final TextEditingController _avatarCtrl;
+  late final TextEditingController _bioCtrl;
+  late final TextEditingController _roomCtrl;
   XFile? _avatarFile;
 
   @override
@@ -35,6 +37,8 @@ class _ProfilePageState extends State<ProfilePage> {
     _nameCtrl = TextEditingController(text: _user.name);
     _emailCtrl = TextEditingController(text: _user.email);
     _avatarCtrl = TextEditingController(text: _user.avatarUrl ?? '');
+    _bioCtrl = TextEditingController(text: _user.bio ?? '');
+    _roomCtrl = TextEditingController(text: _user.room ?? '');
     _avatarCtrl.addListener(() => setState(() {}));
   }
 
@@ -43,6 +47,8 @@ class _ProfilePageState extends State<ProfilePage> {
     _nameCtrl.dispose();
     _emailCtrl.dispose();
     _avatarCtrl.dispose();
+    _bioCtrl.dispose();
+    _roomCtrl.dispose();
     super.dispose();
   }
 
@@ -73,11 +79,12 @@ class _ProfilePageState extends State<ProfilePage> {
       id: _user.id,
       name: _nameCtrl.text.trim(),
       email: _emailCtrl.text.trim(),
-      avatarUrl: _avatarCtrl.text.trim().isEmpty
-          ? null
-          : _avatarCtrl.text.trim(),
+      avatarUrl:
+          _avatarCtrl.text.trim().isEmpty ? null : _avatarCtrl.text.trim(),
       isAdmin: _user.isAdmin,
       isListed: _user.isListed,
+      bio: _bioCtrl.text.trim().isEmpty ? null : _bioCtrl.text.trim(),
+      room: _roomCtrl.text.trim().isEmpty ? null : _roomCtrl.text.trim(),
     );
     try {
       final user = await _service.updateProfile(updated);
@@ -99,20 +106,21 @@ class _ProfilePageState extends State<ProfilePage> {
   Future<void> _deleteAccount() async {
     final confirm = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete Account'),
-        content: const Text('This action cannot be undone. Continue?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
+      builder:
+          (ctx) => AlertDialog(
+            title: const Text('Delete Account'),
+            content: const Text('This action cannot be undone. Continue?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Delete'),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
     );
     if (confirm != true) return;
     try {
@@ -141,32 +149,43 @@ class _ProfilePageState extends State<ProfilePage> {
             children: [
               CircleAvatar(
                 radius: 40,
-                backgroundImage: avatarUrl.isNotEmpty
-                    ? NetworkImage(avatarUrl)
-                    : null,
-                child: avatarUrl.isEmpty
-                    ? const Icon(Icons.person, size: 40)
-                    : null,
+                backgroundImage:
+                    avatarUrl.isNotEmpty ? NetworkImage(avatarUrl) : null,
+                child:
+                    avatarUrl.isEmpty
+                        ? const Icon(Icons.person, size: 40)
+                        : null,
               ),
               const SizedBox(height: 16),
               TextFormField(
                 controller: _nameCtrl,
                 decoration: const InputDecoration(labelText: 'Name'),
-                validator: (v) =>
-                    v == null || v.trim().isEmpty ? 'Required' : null,
+                validator:
+                    (v) => v == null || v.trim().isEmpty ? 'Required' : null,
               ),
               const SizedBox(height: 12),
               TextFormField(
                 controller: _emailCtrl,
                 decoration: const InputDecoration(labelText: 'Email'),
                 keyboardType: TextInputType.emailAddress,
-                validator: (v) =>
-                    v == null || v.trim().isEmpty ? 'Required' : null,
+                validator:
+                    (v) => v == null || v.trim().isEmpty ? 'Required' : null,
               ),
               const SizedBox(height: 12),
               TextFormField(
                 controller: _avatarCtrl,
                 decoration: const InputDecoration(labelText: 'Avatar URL'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _bioCtrl,
+                decoration: const InputDecoration(labelText: 'Bio'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _roomCtrl,
+                decoration: const InputDecoration(labelText: 'Room'),
               ),
               const SizedBox(height: 12),
               Row(

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -40,6 +40,8 @@ class _SettingsPageState extends State<SettingsPage> {
       avatarUrl: _user.avatarUrl,
       isAdmin: _user.isAdmin,
       isListed: val,
+      bio: _user.bio,
+      room: _user.room,
     );
     try {
       final user = await _service.updateProfile(updated);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -9,6 +9,8 @@ const UserSchema = new mongoose.Schema({
   isAdmin: { type: Boolean, default: false },
   // Whether the user opted into the public directory
   isListed: { type: Boolean, default: false },
+  bio: { type: String, default: '' },
+  room: { type: String, default: '' },
   deviceTokens: { type: [String], default: [] },
   passwordResetToken: String,
   passwordResetExpires: Date,

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "jest"
+    "test": "jest -i"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -16,7 +16,7 @@ const router = express.Router();
 // POST /auth/register - create user
 router.post('/register', async (req, res) => {
   try {
-    const { name, email, password, avatarUrl, isAdmin } = req.body;
+    const { name, email, password, avatarUrl, isAdmin, bio, room } = req.body;
     if (!name || !email || !password) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
@@ -31,6 +31,8 @@ router.post('/register', async (req, res) => {
       passwordHash,
       avatarUrl,
       isAdmin: !!isAdmin,
+      bio: bio || '',
+      room: room || '',
     });
     const token = jwt.sign({ userId: user._id.toString() }, SECRET);
     res.status(201).json({
@@ -41,6 +43,8 @@ router.post('/register', async (req, res) => {
         email: user.email,
         avatarUrl: user.avatarUrl,
         isAdmin: user.isAdmin,
+        bio: user.bio,
+        room: user.room,
       },
     });
   } catch (err) {
@@ -65,6 +69,8 @@ router.post('/login', async (req, res) => {
         email: user.email,
         avatarUrl: user.avatarUrl,
         isAdmin: user.isAdmin,
+        bio: user.bio,
+        room: user.room,
       },
     });
   } catch (err) {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -21,8 +21,8 @@ router.use(auth);
 // PUT /users/me - update current user's profile
 router.put('/me', async (req, res) => {
   try {
-    const { name, email, avatarUrl } = req.body;
-    const updates = { name, email, avatarUrl };
+    const { name, email, avatarUrl, isListed, bio, room } = req.body;
+    const updates = { name, email, avatarUrl, isListed, bio, room };
     const user = await User.findByIdAndUpdate(req.userId, updates, {
       new: true,
     });
@@ -34,6 +34,9 @@ router.put('/me', async (req, res) => {
         email: user.email,
         avatarUrl: user.avatarUrl,
         isAdmin: user.isAdmin,
+        isListed: user.isListed,
+        bio: user.bio,
+        room: user.room,
       },
     });
   } catch (err) {

--- a/server/tests/users.test.js
+++ b/server/tests/users.test.js
@@ -42,7 +42,14 @@ describe('Users API', () => {
     const res = await request(app)
       .put('/api/users/me')
       .set('Authorization', `Bearer ${token}`)
-      .send({ name: 'New', email: 'new@test.com', avatarUrl: 'pic' });
+      .send({
+        name: 'New',
+        email: 'new@test.com',
+        avatarUrl: 'pic',
+        bio: 'hello',
+        room: 'A1',
+        isListed: true,
+      });
 
     expect(res.status).toBe(200);
     expect(res.body.data.name).toBe('New');
@@ -50,6 +57,9 @@ describe('Users API', () => {
     expect(updated.name).toBe('New');
     expect(updated.email).toBe('new@test.com');
     expect(updated.avatarUrl).toBe('pic');
+    expect(updated.bio).toBe('hello');
+    expect(updated.room).toBe('A1');
+    expect(updated.isListed).toBe(true);
   });
 
   test('DELETE /users/me removes account', async () => {

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -41,7 +41,13 @@ void main() {
         final box = Hive.box<User>('userBox');
         await box.put(
           'currentUser',
-          User(name: 'Old', email: 'old@test.com', isListed: false),
+          User(
+            name: 'Old',
+            email: 'old@test.com',
+            isListed: false,
+            bio: 'bio',
+            room: '1',
+          ),
         );
 
         final service = FakeUserService();
@@ -74,6 +80,12 @@ void main() {
         // 6) Enter new text into each field and tap “Save”:
         await tester.enterText(nameEditableFinder, 'New Name');
         await tester.enterText(emailEditableFinder, 'new@example.com');
+        // Scroll down to make sure the Save button is visible
+        await tester.scrollUntilVisible(
+          find.text('Save'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
         await tester.tap(find.text('Save'));
         // Wait 300ms for any save‐animation or Hive write to complete:
         await tester.pump(const Duration(milliseconds: 300));
@@ -81,10 +93,14 @@ void main() {
         // 7) Verify that service was called and Hive wrote the updated user:
         expect(service.updated!.name, 'New Name');
         expect(service.updated!.email, 'new@example.com');
+        expect(service.updated!.bio, 'bio');
+        expect(service.updated!.room, '1');
 
         final saved = Hive.box<User>('userBox').get('currentUser')!;
         expect(saved.name, 'New Name');
         expect(saved.email, 'new@example.com');
+        expect(saved.bio, 'bio');
+        expect(saved.room, '1');
 
         // 8) Re‐pump the ProfilePage and give it time to rebuild:
         await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- add new optional `bio` and `room` fields to user model
- include fields in API responses and profile update routes
- update login and profile pages to edit and display the new data
- extend Hive adapter and server tests for the extra fields
- adjust profile page widget test for longer form

## Testing
- `npm --prefix server test`
- `flutter test` *(fails: RootUnavailable / path deletion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843fa45fdb0832ba0999c2c11521af3