### PR TITLE
Implement document sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ flutter run --dart-define=API_URL=http://localhost:3000
 Run server tests with:
 ```bash
 cd server
+npm install  # install dev dependencies like jest
 npm test
 ```
 

--- a/lib/models/document.dart
+++ b/lib/models/document.dart
@@ -1,0 +1,33 @@
+part of 'models.dart';
+
+class Document {
+  final String? id;
+  final String uploaderId;
+  final String fileName;
+  final String url;
+
+  Document({
+    this.id,
+    required this.uploaderId,
+    required this.fileName,
+    required this.url,
+  });
+
+  factory Document.fromMap(Map<String, dynamic> map) => Document(
+        id: map['id']?.toString() ?? map['_id']?.toString(),
+        uploaderId: map['uploaderId'] as String,
+        fileName: map['fileName'] as String,
+        url: map['url'] as String,
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'uploaderId': uploaderId,
+        'fileName': fileName,
+        'url': url,
+      };
+
+  factory Document.fromJson(Map<String, dynamic> json) =>
+      Document.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -19,6 +19,7 @@ part 'chat_channel.dart';
 part 'club.dart';
 part 'wiki_article.dart';
 part 'emergency_contact.dart';
+part 'document.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/pages/club_detail_page.dart
+++ b/lib/pages/club_detail_page.dart
@@ -5,6 +5,7 @@ import '../services/club_service.dart';
 import '../services/chat_service.dart';
 import '../utils/user_helpers.dart';
 import 'group_chat_page.dart';
+import 'documents_page.dart';
 
 class ClubDetailPage extends StatefulWidget {
   final Club club;
@@ -73,6 +74,14 @@ class _ClubDetailPageState extends State<ClubDetailPage> {
                   ? null
                   : (isMember ? _openChat : _joinAndChat),
               child: Text(isMember ? 'Open Chat' : 'Join & Chat'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const DocumentsPage()),
+              ),
+              child: const Text('Documents'),
             ),
           ],
         ),

--- a/lib/pages/documents_page.dart
+++ b/lib/pages/documents_page.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import '../models/models.dart';
+import '../services/document_service.dart';
+
+class DocumentsPage extends StatefulWidget {
+  final DocumentService? service;
+  const DocumentsPage({super.key, this.service});
+
+  @override
+  State<DocumentsPage> createState() => _DocumentsPageState();
+}
+
+class _DocumentsPageState extends State<DocumentsPage> {
+  late final DocumentService _service;
+  List<Document> _documents = [];
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? DocumentService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final list = await _service.fetchDocuments();
+      if (mounted) setState(() => _documents = list);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed to load: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _pickAndUpload() async {
+    final result = await FilePicker.platform.pickFiles();
+    if (result == null || result.files.isEmpty) return;
+    final path = result.files.single.path;
+    if (path == null) return;
+    final file = File(path);
+    try {
+      final doc = await _service.uploadDocument(file);
+      if (mounted) setState(() => _documents.add(doc));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Documents'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _documents.isEmpty
+              ? const Center(child: Text('No documents uploaded.'))
+              : ListView.separated(
+                  itemCount: _documents.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (_, i) {
+                    final doc = _documents[i];
+                    return ListTile(
+                      title: Text(doc.fileName),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.download),
+                        onPressed: () async {
+                          final bytes = await _service.downloadDocument(doc.url);
+                          final fileName = doc.fileName.split('/').last;
+                          final dir = await FilePicker.platform.getDirectoryPath();
+                          if (dir == null) return;
+                          final out = File('$dir/$fileName');
+                          await out.writeAsBytes(bytes);
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Saved to $dir')));
+                          }
+                        },
+                      ),
+                    );
+                  },
+                ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _pickAndUpload,
+        child: const Icon(Icons.upload_file),
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -19,6 +19,7 @@ import 'create_channel_page.dart';
 import 'group_chat_page.dart';
 import 'wiki_page.dart';
 import 'clubs_page.dart';
+import 'documents_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -372,6 +373,15 @@ class DashboardPage extends StatelessWidget {
                   onTap: () => Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const ClubsPage()),
+                  ),
+                ),
+                DashboardCard(
+                  icon: Icons.description,
+                  label: 'Documents',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const DocumentsPage()),
                   ),
                 ),
                 DashboardCard(

--- a/lib/services/document_service.dart
+++ b/lib/services/document_service.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../models/models.dart';
+import 'api_service.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class DocumentService extends ApiService {
+  DocumentService({super.client});
+
+  Future<List<Document>> fetchDocuments() async {
+    return get('/documents', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => Document.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<Document> uploadDocument(File file) async {
+    final request = http.MultipartRequest('POST', buildUri('/documents'))
+      ..files.add(await http.MultipartFile.fromPath('file', file.path));
+    request.headers.addAll(_authHeaders());
+    final streamed = await client.send(request);
+    final response = await http.Response.fromStream(streamed);
+    if (response.statusCode == 201 || response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return Document.fromJson(data['data'] as Map<String, dynamic>);
+    }
+    throw Exception('Request failed: ${response.statusCode}');
+  }
+
+  Future<Uint8List> downloadDocument(String url) async {
+    final uri = url.startsWith('http') ? Uri.parse(url) : buildUri('')
+        .replace(path: url.startsWith('/') ? url : '/$url');
+    final res = await client.get(uri, headers: _authHeaders());
+    if (res.statusCode == 200) {
+      return res.bodyBytes;
+    }
+    throw Exception('Failed to download');
+  }
+
+  Map<String, String> _authHeaders([Map<String, String>? headers]) {
+    final box = Hive.isBoxOpen('authBox') ? Hive.box('authBox') : null;
+    final token = box?.get('token') as String?;
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+      if (headers != null) ...headers,
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,6 +254,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   file_selector_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   share_plus: ^7.2.1
   url_launcher: ^6.2.6
   path_provider: ^2.1.5
+  file_picker: ^6.1.1
   fl_chart: ^1.0.0
 dev_dependencies:
   test: any

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -18,6 +18,7 @@ const channelsRouter = require('../routes/channels');
 const wikiRouter = require('../routes/wiki');
 const emergencyContactsRouter = require('../routes/emergency_contacts');
 const clubsRouter = require('../routes/clubs');
+const documentsRouter = require('../routes/documents');
 
 router.get('/', (req, res) => {
   res.json({ message: 'API is running' });
@@ -41,4 +42,5 @@ router.use('/channels', channelsRouter);
 router.use('/wiki', wikiRouter);
 router.use('/emergency_contacts', emergencyContactsRouter);
 router.use('/clubs', clubsRouter);
+router.use('/documents', documentsRouter);
 module.exports = router;

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const DocumentSchema = new mongoose.Schema({
+  uploaderId: { type: String, required: true },
+  fileName: { type: String, required: true },
+  url: { type: String, required: true },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Document', DocumentSchema);

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const Document = require('../models/Document');
+const auth = require('../middleware/auth');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../uploads'));
+  },
+  filename: (req, file, cb) => {
+    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+const upload = multer({ storage });
+
+const router = express.Router();
+router.use(auth);
+
+// GET /documents - list documents
+router.get('/', async (req, res) => {
+  try {
+    const docs = await Document.find();
+    res.json({ data: docs });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /documents - upload new file
+router.post('/', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'File required' });
+    const doc = await Document.create({
+      uploaderId: String(req.userId),
+      fileName: req.file.originalname,
+      url: `/uploads/${req.file.filename}`,
+    });
+    res.status(201).json({ data: doc });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- allow storing Document models on Flutter side
- create backend model and routes for file uploads
- register document API routes
- implement DocumentService for upload/download
- add DocumentsPage UI and navigation from dashboard and clubs
- include file_picker dependency for selecting files
- clarify server testing instructions

## Testing
- `flutter test test/sample_test.dart`
- `npm test --prefix server` *(fails: MongoMemoryServer errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843fa46a384832b97251893cf3e13e5