### PR TITLE
Add weather page

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -20,6 +20,7 @@ import 'group_chat_page.dart';
 import 'wiki_page.dart';
 import 'clubs_page.dart';
 import 'documents_page.dart';
+import 'weather_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -382,6 +383,15 @@ class DashboardPage extends StatelessWidget {
                   onTap: () => Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const DocumentsPage()),
+                  ),
+                ),
+                DashboardCard(
+                  icon: Icons.cloud,
+                  label: 'Weather',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const WeatherPage()),
                   ),
                 ),
                 DashboardCard(

--- a/lib/pages/weather_page.dart
+++ b/lib/pages/weather_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import '../services/weather_service.dart';
+
+class WeatherPage extends StatefulWidget {
+  final WeatherService? service;
+  const WeatherPage({super.key, this.service});
+
+  @override
+  State<WeatherPage> createState() => _WeatherPageState();
+}
+
+class _WeatherPageState extends State<WeatherPage> {
+  late final WeatherService _service;
+  WeatherData? _data;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? WeatherService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final data = await _service.fetchWeather(48.1740, 11.5475);
+      if (!mounted) return;
+      setState(() {
+        _data = data;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Weather'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _data == null
+          ? const Center(child: Text('Failed to load'))
+          : RefreshIndicator(
+              onRefresh: _load,
+              child: ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  Text(
+                    'Current: ${_data!.current.temperature.toStringAsFixed(1)}°C, '
+                    'wind ${_data!.current.windspeed.toStringAsFixed(1)} km/h',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Next hours:',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  ..._data!.forecast.map(
+                    (f) => ListTile(
+                      leading: Text(
+                        '${f.time.hour.toString().padLeft(2, '0')}:00',
+                      ),
+                      title: Text('${f.temperature.toStringAsFixed(1)}°C'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class WeatherService {
+  WeatherService({http.Client? client}) : _client = client ?? http.Client();
+  final http.Client _client;
+
+  Future<WeatherData> fetchWeather(double lat, double lon) async {
+    final uri = Uri.parse(
+      'https://api.open-meteo.com/v1/forecast'
+      '?latitude=$lat&longitude=$lon&current_weather=true'
+      '&hourly=temperature_2m,weathercode&forecast_days=1',
+    );
+    final res = await _client.get(uri);
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final current = data['current_weather'] as Map<String, dynamic>;
+      final hourly = data['hourly'] as Map<String, dynamic>;
+      final times = (hourly['time'] as List).cast<String>();
+      final temps = (hourly['temperature_2m'] as List).cast<num>();
+      final codes = (hourly['weathercode'] as List).cast<int>();
+      final forecast = <WeatherForecast>[];
+      for (var i = 0; i < times.length && i < 12; i++) {
+        forecast.add(
+          WeatherForecast(
+            time: DateTime.parse(times[i]),
+            temperature: temps[i].toDouble(),
+            code: codes[i],
+          ),
+        );
+      }
+      return WeatherData(
+        current: WeatherCondition(
+          temperature: (current['temperature'] as num).toDouble(),
+          windspeed: (current['windspeed'] as num).toDouble(),
+          code: current['weathercode'] as int,
+        ),
+        forecast: forecast,
+      );
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
+}
+
+class WeatherData {
+  final WeatherCondition current;
+  final List<WeatherForecast> forecast;
+  WeatherData({required this.current, required this.forecast});
+}
+
+class WeatherCondition {
+  final double temperature;
+  final double windspeed;
+  final int code;
+  WeatherCondition({
+    required this.temperature,
+    required this.windspeed,
+    required this.code,
+  });
+}
+
+class WeatherForecast {
+  final DateTime time;
+  final double temperature;
+  final int code;
+  WeatherForecast({
+    required this.time,
+    required this.temperature,
+    required this.code,
+  });
+}


### PR DESCRIPTION
## Summary
- implement a simple weather API client
- add a `WeatherPage` to display current conditions and a short-term forecast
- link the new page from the dashboard

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684462b005e0832bad341249c12bbe9c