### PR TITLE
Add community gallery feature

### DIFF
--- a/lib/models/gallery_image.dart
+++ b/lib/models/gallery_image.dart
@@ -1,0 +1,33 @@
+part of 'models.dart';
+
+class GalleryImage {
+  final String? id;
+  final String uploaderId;
+  final String url;
+  final String? caption;
+
+  GalleryImage({
+    this.id,
+    required this.uploaderId,
+    required this.url,
+    this.caption,
+  });
+
+  factory GalleryImage.fromMap(Map<String, dynamic> map) => GalleryImage(
+    id: map['id']?.toString() ?? map['_id']?.toString(),
+    uploaderId: map['uploaderId'] as String,
+    url: map['url'] as String,
+    caption: map['caption'] as String?,
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'uploaderId': uploaderId,
+    'url': url,
+    'caption': caption,
+  };
+
+  factory GalleryImage.fromJson(Map<String, dynamic> json) =>
+      GalleryImage.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -21,6 +21,7 @@ part 'wiki_article.dart';
 part 'emergency_contact.dart';
 part 'document.dart';
 part 'suggestion.dart';
+part 'gallery_image.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -7,6 +7,7 @@ import 'booking_admin_page.dart';
 import 'map_admin_page.dart';
 import 'poll_admin_page.dart';
 import 'analytics_page.dart';
+import 'gallery_admin_page.dart';
 import '../../utils/user_helpers.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -101,6 +102,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Create Poll'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const GalleryAdminPage()),
+                );
+              },
+              child: const Text('Upload Gallery Image'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(

--- a/lib/pages/admin/gallery_admin_page.dart
+++ b/lib/pages/admin/gallery_admin_page.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../services/gallery_service.dart';
+import '../../utils/user_helpers.dart';
+
+class GalleryAdminPage extends StatefulWidget {
+  const GalleryAdminPage({super.key});
+
+  @override
+  State<GalleryAdminPage> createState() => _GalleryAdminPageState();
+}
+
+class _GalleryAdminPageState extends State<GalleryAdminPage> {
+  final GalleryService _service = GalleryService();
+  final ImagePicker _picker = ImagePicker();
+  XFile? _file;
+  bool _uploading = false;
+
+  Future<void> _pick() async {
+    final f = await _picker.pickImage(source: ImageSource.gallery);
+    if (f != null) setState(() => _file = f);
+  }
+
+  Future<void> _upload() async {
+    if (_file == null) return;
+    setState(() => _uploading = true);
+    try {
+      await _service.uploadImage(File(_file!.path));
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Uploaded!')));
+        setState(() => _file = null);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload Gallery Image')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_file != null) ...[
+              Image.file(File(_file!.path), height: 200),
+              const SizedBox(height: 12),
+            ],
+            ElevatedButton.icon(
+              onPressed: _pick,
+              icon: const Icon(Icons.photo_library),
+              label: const Text('Choose Image'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _uploading ? null : _upload,
+              child: Text(_uploading ? 'Uploading…' : 'Upload'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/gallery_page.dart
+++ b/lib/pages/gallery_page.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/gallery_service.dart';
+
+class GalleryPage extends StatefulWidget {
+  final GalleryService? service;
+  const GalleryPage({super.key, this.service});
+
+  @override
+  State<GalleryPage> createState() => _GalleryPageState();
+}
+
+class _GalleryPageState extends State<GalleryPage> {
+  late final GalleryService _service;
+  List<GalleryImage> _images = [];
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? GalleryService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final imgs = await _service.fetchImages();
+      if (mounted) setState(() => _images = imgs);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to load: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  void _view(GalleryImage img) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => _FullScreenImage(url: img.url)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Community Gallery'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _images.isEmpty
+          ? const Center(child: Text('No images uploaded.'))
+          : GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                mainAxisSpacing: 4,
+                crossAxisSpacing: 4,
+              ),
+              itemCount: _images.length,
+              itemBuilder: (ctx, i) {
+                final img = _images[i];
+                return GestureDetector(
+                  onTap: () => _view(img),
+                  child: Image.network(img.url, fit: BoxFit.cover),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _FullScreenImage extends StatelessWidget {
+  final String url;
+  const _FullScreenImage({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: GestureDetector(
+        onTap: () => Navigator.pop(context),
+        child: Center(child: InteractiveViewer(child: Image.network(url))),
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -20,6 +20,7 @@ import 'group_chat_page.dart';
 import 'wiki_page.dart';
 import 'clubs_page.dart';
 import 'documents_page.dart';
+import 'gallery_page.dart';
 import '../models/models.dart';
 import '../services/event_service.dart';
 
@@ -382,6 +383,15 @@ class DashboardPage extends StatelessWidget {
                   onTap: () => Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const DocumentsPage()),
+                  ),
+                ),
+                DashboardCard(
+                  icon: Icons.photo,
+                  label: 'Gallery',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const GalleryPage()),
                   ),
                 ),
                 DashboardCard(

--- a/lib/services/gallery_service.dart
+++ b/lib/services/gallery_service.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/models.dart';
+import 'api_service.dart';
+
+class GalleryService extends ApiService {
+  GalleryService({super.client});
+
+  Future<List<GalleryImage>> fetchImages() async {
+    return get('/gallery', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => GalleryImage.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<GalleryImage> uploadImage(File file) async {
+    final request = http.MultipartRequest('POST', buildUri('/gallery'))
+      ..files.add(await http.MultipartFile.fromPath('image', file.path));
+    request.headers.addAll(_authHeaders());
+    final streamed = await client.send(request);
+    final response = await http.Response.fromStream(streamed);
+    if (response.statusCode == 201 || response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return GalleryImage.fromJson(data['data'] as Map<String, dynamic>);
+    }
+    throw Exception('Request failed: ${response.statusCode}');
+  }
+
+  Map<String, String> _authHeaders([Map<String, String>? headers]) {
+    final box = Hive.isBoxOpen('authBox') ? Hive.box('authBox') : null;
+    final token = box?.get('token') as String?;
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+      if (headers != null) ...headers,
+    };
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -19,7 +19,8 @@ const wikiRouter = require('../routes/wiki');
 const emergencyContactsRouter = require('../routes/emergency_contacts');
 const clubsRouter = require('../routes/clubs');
 const documentsRouter = require('../routes/documents');
-const suggestionsRouter = require("../routes/suggestions"); 
+const suggestionsRouter = require("../routes/suggestions");
+const galleryRouter = require('../routes/gallery');
 
 router.get("/", (req, res) => {
   res.json({ message: "API is running" });
@@ -44,5 +45,6 @@ router.use('/wiki', wikiRouter);
 router.use('/emergency_contacts', emergencyContactsRouter);
 router.use('/clubs', clubsRouter);
 router.use('/documents', documentsRouter);
-router.use("/suggestions", suggestionsRouter);  
+router.use("/suggestions", suggestionsRouter);
+router.use('/gallery', galleryRouter);
 module.exports = router;

--- a/server/models/GalleryImage.js
+++ b/server/models/GalleryImage.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const GalleryImageSchema = new mongoose.Schema({
+  uploaderId: { type: String, required: true },
+  url: { type: String, required: true },
+  caption: String,
+}, { timestamps: true });
+
+module.exports = mongoose.model('GalleryImage', GalleryImageSchema);

--- a/server/routes/gallery.js
+++ b/server/routes/gallery.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const GalleryImage = require('../models/GalleryImage');
+const auth = require('../middleware/auth');
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../uploads'));
+  },
+  filename: (req, file, cb) => {
+    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+const upload = multer({ storage });
+
+const router = express.Router();
+router.use(auth);
+
+// GET /gallery - list images
+router.get('/', async (req, res) => {
+  try {
+    const images = await GalleryImage.find();
+    res.json({ data: images });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /gallery - upload image
+router.post('/', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'Image required' });
+    const img = await GalleryImage.create({
+      uploaderId: String(req.userId),
+      url: `/uploads/${req.file.filename}`,
+    });
+    res.status(201).json({ data: img });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- allow uploading and listing gallery images on server
- expose new `/gallery` API endpoint
- add GalleryService and GalleryImage model
- create gallery page with fullscreen view
- provide admin page to upload images
- link gallery from dashboard and admin tools

## Testing
- `npm test`
- `flutter test` *(fails: Failed to update packages)*

------
https://chatgpt.com/codex/tasks/task_e_68446344d9e0832bb0c399bc6abbb567