### PR TITLE
Add notification preferences

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,14 +1,25 @@
 import 'api_service.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:hive/hive.dart';
 
 class NotificationService extends ApiService {
   NotificationService({super.client});
 
   Future<void> registerToken(String token) async {
+    final settings = Hive.box('settingsBox');
+    final events =
+        settings.get('eventNotifications', defaultValue: true) as bool;
+    final announcements =
+        settings.get('announcementNotifications', defaultValue: true) as bool;
+    if (!events && !announcements) return;
     await post('/notifications/register', {'token': token}, (_) => null);
   }
 
-  Future<int> sendNotification({required List<String> tokens, required String title, required String body}) async {
+  Future<int> sendNotification({
+    required List<String> tokens,
+    required String title,
+    required String body,
+  }) async {
     final result = await post('/notifications/send', {
       'tokens': tokens,
       'notification': {'title': title, 'body': body},

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -4,11 +4,29 @@ import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:oly_app/services/notification_service.dart';
+import 'package:hive/hive.dart';
+import 'dart:io';
 
-const apiUrl = String.fromEnvironment('API_URL', defaultValue: 'http://localhost:3000');
+const apiUrl = String.fromEnvironment(
+  'API_URL',
+  defaultValue: 'http://localhost:3000',
+);
 
 void main() {
   group('NotificationService', () {
+    late Directory dir;
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp();
+      Hive.init(dir.path);
+      await Hive.openBox('settingsBox');
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      await dir.delete(recursive: true);
+    });
+
     test('registerToken posts token', () async {
       final mockClient = MockClient((request) async {
         expect(request.method, equals('POST'));
@@ -20,6 +38,9 @@ void main() {
       });
 
       final service = NotificationService(client: mockClient);
+      final box = Hive.box('settingsBox');
+      await box.put('eventNotifications', true);
+      await box.put('announcementNotifications', true);
       await service.registerToken('abc');
     });
 
@@ -35,7 +56,11 @@ void main() {
       });
 
       final service = NotificationService(client: mockClient);
-      final count = await service.sendNotification(tokens: ['t1'], title: 'hi', body: 'b');
+      final count = await service.sendNotification(
+        tokens: ['t1'],
+        title: 'hi',
+        body: 'b',
+      );
       expect(count, 1);
     });
   });


### PR DESCRIPTION
## Summary
- store preference toggles for event reminders and announcements in `settingsBox`
- expose these settings in the Settings page
- register push tokens only when at least one notification type is enabled
- adapt NotificationService tests for new preferences
- refactor SettingsPage token registration

## Testing
- `dart test test/services/notification_service_test.dart` *(fails: Dart library 'dart:ui' not available)*

------
https://chatgpt.com/codex/tasks/task_e_684472c28714832ba81a47f4de9ecfd2