### PR TITLE
Add websocket server and real-time client

### DIFF
--- a/lib/pages/item_chat_page.dart
+++ b/lib/pages/item_chat_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import '../models/models.dart';
 import '../services/item_service.dart';
 import '../utils/user_helpers.dart';
+import '../services/chat_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'dart:convert';
 
 class ItemChatPage extends StatefulWidget {
   final Item item;
@@ -17,12 +20,27 @@ class _ItemChatPageState extends State<ItemChatPage> {
   final TextEditingController _messageCtrl = TextEditingController();
 
   List<Message> _messages = [];
+  final ChatService _chat = ChatService();
+  WebSocketChannel? _channel;
 
   @override
   void initState() {
     super.initState();
     _service = widget.service ?? ItemService();
     _loadMessages();
+    _connectSocket();
+  }
+
+  void _connectSocket() {
+    if (widget.item.id == null) return;
+    _channel = _chat.connect(widget.item.id!.toString());
+    _channel!.stream.listen((event) {
+      final data = jsonDecode(event as String) as Map<String, dynamic>;
+      final msg = Message.fromJson(data['data'] as Map<String, dynamic>);
+      if (mounted && !_messages.any((m) => m.id == msg.id)) {
+        setState(() => _messages.add(msg));
+      }
+    });
   }
 
   Future<void> _loadMessages() async {
@@ -45,9 +63,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
       content: text,
     );
     try {
-      final saved = await _service.sendMessage(message);
-      if (!mounted) return;
-      setState(() => _messages.add(saved));
+      await _service.sendMessage(message);
       _messageCtrl.clear();
     } catch (_) {
       // ignore errors in example
@@ -57,6 +73,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
   @override
   void dispose() {
     _messageCtrl.dispose();
+    _channel?.sink.close();
     super.dispose();
   }
 
@@ -80,16 +97,16 @@ class _ItemChatPageState extends State<ItemChatPage> {
                 final msg = _messages[index];
                 final isMe = msg.senderId == currentUserId();
                 return Align(
-                  alignment:
-                      isMe ? Alignment.centerRight : Alignment.centerLeft,
+                  alignment: isMe
+                      ? Alignment.centerRight
+                      : Alignment.centerLeft,
                   child: Container(
                     margin: const EdgeInsets.symmetric(vertical: 4),
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color:
-                          isMe
-                              ? colorScheme.primaryContainer
-                              : colorScheme.surfaceContainerHighest,
+                      color: isMe
+                          ? colorScheme.primaryContainer
+                          : colorScheme.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(msg.content),

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,20 +1,34 @@
+import 'dart:convert';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
 import '../models/models.dart';
 import 'api_service.dart';
 
 class ChatService extends ApiService {
   ChatService({super.client});
 
-  Future<ChatChannel> createChannel(String name, {List<String> participants = const []}) async {
-    return post('/channels', {
-      'name': name,
-      'participants': participants,
-    }, (json) {
+  WebSocketChannel connect(String roomId) {
+    final wsUrl = ApiService.baseUrl.replaceFirst('http', 'ws');
+    final channel = WebSocketChannel.connect(Uri.parse(wsUrl));
+    channel.sink.add(jsonEncode({'type': 'join', 'room': roomId}));
+    return channel;
+  }
+
+  Future<ChatChannel> createChannel(
+    String name, {
+    List<String> participants = const [],
+  }) async {
+    return post('/channels', {'name': name, 'participants': participants}, (
+      json,
+    ) {
       return ChatChannel.fromJson(json['data'] as Map<String, dynamic>);
     });
   }
 
   Future<ChatChannel> addParticipant(String channelId, String userId) async {
-    return post('/channels/$channelId/participants', {'userId': userId}, (json) {
+    return post('/channels/$channelId/participants', {'userId': userId}, (
+      json,
+    ) {
       return ChatChannel.fromJson(json['data'] as Map<String, dynamic>);
     });
   }
@@ -28,14 +42,14 @@ class ChatService extends ApiService {
   Future<List<Message>> fetchMessages(String channelId) async {
     return get('/channels/$channelId/messages', (json) {
       final list = json['data'] as List<dynamic>;
-      return list.map((e) => Message.fromJson(e as Map<String, dynamic>)).toList();
+      return list
+          .map((e) => Message.fromJson(e as Map<String, dynamic>))
+          .toList();
     });
   }
 
   Future<Message> sendMessage(String channelId, String content) async {
-    return post('/channels/$channelId/messages', {
-      'content': content,
-    }, (json) {
+    return post('/channels/$channelId/messages', {'content': content}, (json) {
       return Message.fromJson(json['data'] as Map<String, dynamic>);
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   geolocator: ^11.0.0
   mobile_scanner: ^3.5.0
   share_plus: ^7.2.1
+  web_socket_channel: ^3.0.3
   url_launcher: ^6.2.6
   path_provider: ^2.1.5
   file_picker: ^6.1.1

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,8 @@ const path = require('path');
 const admin = require('firebase-admin');
 const cron = require('node-cron');
 const Event = require('./models/Event');
+const http = require('http');
+const websocket = require('./socket');
 
 const app = express();
 app.use(cors());
@@ -64,7 +66,9 @@ cron.schedule('* * * * *', async () => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
+const server = http.createServer(app);
+websocket.init(server);
+server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
 

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.0",
     "multer": "^1.4.5-lts.1",
-    "qrcode": "^1.5.1"
+    "qrcode": "^1.5.1",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -2,6 +2,7 @@ const express = require('express');
 const Conversation = require('../models/Conversation');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
+const socket = require('../socket');
 
 const router = express.Router();
 router.use(auth);
@@ -73,6 +74,7 @@ router.post('/:id/messages', async (req, res) => {
       senderId: req.userId,
       content: req.body.content,
     });
+    socket.broadcast(req.params.id.toString(), message);
     res.status(201).json({ data: message });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/routes/directory.js
+++ b/server/routes/directory.js
@@ -3,6 +3,7 @@ const User = require('../models/User');
 const Conversation = require('../models/Conversation');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
+const socket = require('../socket');
 
 const router = express.Router();
 router.use(auth);
@@ -53,6 +54,7 @@ router.post('/:id/messages', async (req, res) => {
       senderId: req.userId,
       content: req.body.content
     });
+    socket.broadcast(convo._id.toString(), message);
     res.status(201).json({ data: message });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -16,6 +16,7 @@ const storage = multer.diskStorage({
 });
 const upload = multer({ storage });
 
+const socket = require('../socket');
 const router = express.Router();
 router.use(auth);
 
@@ -66,6 +67,7 @@ router.post('/:id/messages', async (req, res) => {
       requestType: 'Item'
     };
     const message = await Message.create(messageData);
+    socket.broadcast(req.params.id.toString(), message);
     res.status(201).json(message);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/routes/lostfound.js
+++ b/server/routes/lostfound.js
@@ -2,6 +2,7 @@ const express = require('express');
 const LostItem = require('../models/LostItem');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
+const socket = require('../socket');
 const multer = require('multer');
 const path = require('path');
 
@@ -77,6 +78,7 @@ router.post('/:id/messages', async (req, res) => {
       requestType: 'LostItem'
     };
     const message = await Message.create(messageData);
+    socket.broadcast(req.params.id.toString(), message);
     res.status(201).json(message);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -5,6 +5,7 @@ const auth = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
 const multer = require('multer');
 const path = require('path');
+const socket = require('../socket');
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
@@ -67,6 +68,7 @@ router.post('/:id/messages', async (req, res) => {
       requestType: 'MaintenanceRequest'
     };
     const message = await Message.create(messageData);
+    socket.broadcast(req.params.id.toString(), message);
     res.status(201).json({ data: message });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,31 @@
+const { WebSocketServer, WebSocket } = require('ws');
+
+let wss;
+
+function init(server) {
+  wss = new WebSocketServer({ server });
+  wss.on('connection', (socket) => {
+    socket.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data);
+        if (msg.type === 'join' && msg.room) {
+          socket.room = msg.room.toString();
+        }
+      } catch (_) {
+        // ignore parse errors
+      }
+    });
+  });
+}
+
+function broadcast(room, message) {
+  if (!wss) return;
+  const payload = JSON.stringify({ type: 'message', room, data: message });
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN && client.room === room) {
+      client.send(payload);
+    }
+  });
+}
+
+module.exports = { init, broadcast };


### PR DESCRIPTION
## Summary
- include `ws` server in `server/socket.js`
- wire websocket server to Express
- update chat service to open websocket connections
- connect chat pages for real-time messages
- use `WebSocket.OPEN` constant

## Testing
- `npm test`
- `dart test` *(fails: Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684472b5cbf0832b807e13d3ca4ea139