### PR TITLE
Add websocket presence notifications

### DIFF
--- a/lib/pages/item_chat_page.dart
+++ b/lib/pages/item_chat_page.dart
@@ -22,6 +22,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
   List<Message> _messages = [];
   final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
+  bool _online = false;
 
   @override
   void initState() {
@@ -36,9 +37,16 @@ class _ItemChatPageState extends State<ItemChatPage> {
     _channel = _chat.connect(widget.item.id!.toString());
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
-      final msg = Message.fromJson(data['data'] as Map<String, dynamic>);
-      if (mounted && !_messages.any((m) => m.id == msg.id)) {
-        setState(() => _messages.add(msg));
+      if (data['type'] == 'message') {
+        final msg = Message.fromJson(data['data'] as Map<String, dynamic>);
+        if (mounted && !_messages.any((m) => m.id == msg.id)) {
+          setState(() => _messages.add(msg));
+        }
+      } else if (data['type'] == 'online' || data['type'] == 'offline') {
+        final uid = data['userId'] as String?;
+        if (uid != null && uid != currentUserId()) {
+          setState(() => _online = data['type'] == 'online');
+        }
       }
     });
   }
@@ -82,7 +90,17 @@ class _ItemChatPageState extends State<ItemChatPage> {
     final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.item.title),
+        title: Row(
+          children: [
+            Text(widget.item.title),
+            const SizedBox(width: 8),
+            Icon(
+              Icons.circle,
+              size: 10,
+              color: _online ? Colors.green : Colors.grey,
+            ),
+          ],
+        ),
         backgroundColor: colorScheme.primaryContainer,
         foregroundColor: colorScheme.onPrimaryContainer,
         elevation: 1,

--- a/lib/pages/maintenance_chat_page.dart
+++ b/lib/pages/maintenance_chat_page.dart
@@ -21,6 +21,7 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
   List<Message> _messages = [];
   final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
+  bool _online = false;
 
   @override
   void initState() {
@@ -34,9 +35,16 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
     _channel = _chat.connect(widget.request.id!.toString());
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
-      final msg = Message.fromJson(data['data'] as Map<String, dynamic>);
-      if (mounted && !_messages.any((m) => m.id == msg.id)) {
-        setState(() => _messages.add(msg));
+      if (data['type'] == 'message') {
+        final msg = Message.fromJson(data['data'] as Map<String, dynamic>);
+        if (mounted && !_messages.any((m) => m.id == msg.id)) {
+          setState(() => _messages.add(msg));
+        }
+      } else if (data['type'] == 'online' || data['type'] == 'offline') {
+        final uid = data['userId'] as String?;
+        if (uid != null && uid != currentUserId()) {
+          setState(() => _online = data['type'] == 'online');
+        }
       }
     });
   }
@@ -71,7 +79,17 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
     final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.request.subject),
+        title: Row(
+          children: [
+            Text(widget.request.subject),
+            const SizedBox(width: 8),
+            Icon(
+              Icons.circle,
+              size: 10,
+              color: _online ? Colors.green : Colors.grey,
+            ),
+          ],
+        ),
         backgroundColor: colorScheme.primaryContainer,
         foregroundColor: colorScheme.onPrimaryContainer,
         elevation: 1,

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import '../utils/user_helpers.dart';
 
 import '../models/models.dart';
 import 'api_service.dart';
@@ -10,7 +11,9 @@ class ChatService extends ApiService {
   WebSocketChannel connect(String roomId) {
     final wsUrl = ApiService.baseUrl.replaceFirst('http', 'ws');
     final channel = WebSocketChannel.connect(Uri.parse(wsUrl));
-    channel.sink.add(jsonEncode({'type': 'join', 'room': roomId}));
+    channel.sink.add(
+      jsonEncode({'type': 'join', 'room': roomId, 'userId': currentUserId()}),
+    );
     return channel;
   }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -10,9 +10,17 @@ function init(server) {
         const msg = JSON.parse(data);
         if (msg.type === 'join' && msg.room) {
           socket.room = msg.room.toString();
+          socket.userId = msg.userId?.toString();
+          broadcastPresence(socket.room, 'online', socket.userId, socket);
         }
       } catch (_) {
         // ignore parse errors
+      }
+    });
+
+    socket.on('close', () => {
+      if (socket.room && socket.userId) {
+        broadcastPresence(socket.room, 'offline', socket.userId, socket);
       }
     });
   });
@@ -23,6 +31,20 @@ function broadcast(room, message) {
   const payload = JSON.stringify({ type: 'message', room, data: message });
   wss.clients.forEach((client) => {
     if (client.readyState === WebSocket.OPEN && client.room === room) {
+      client.send(payload);
+    }
+  });
+}
+
+function broadcastPresence(room, type, userId, exclude) {
+  if (!wss || !room || !userId) return;
+  const payload = JSON.stringify({ type, room, userId });
+  wss.clients.forEach((client) => {
+    if (
+      client.readyState === WebSocket.OPEN &&
+      client.room === room &&
+      client !== exclude
+    ) {
       client.send(payload);
     }
   });


### PR DESCRIPTION
## Summary
- broadcast online/offline events from websocket server
- attach userId when connecting to websockets
- listen for presence events in chat pages
- show basic presence indicators in chat page headers

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68447e4da560832b83e64649c7fd7827