### PR TITLE
Implement poll deletion admin UI

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -7,6 +7,7 @@ import 'bulletin_admin_page.dart';
 import 'booking_admin_page.dart';
 import 'map_admin_page.dart';
 import 'poll_admin_page.dart';
+import 'poll_list_admin_page.dart';
 import 'analytics_page.dart';
 import 'gallery_admin_page.dart';
 import '../../utils/user_helpers.dart';
@@ -113,6 +114,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Create Poll'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const PollListAdminPage()),
+                );
+              },
+              child: const Text('Manage Polls'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(

--- a/lib/pages/admin/poll_list_admin_page.dart
+++ b/lib/pages/admin/poll_list_admin_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import '../../models/models.dart';
+import '../../services/poll_service.dart';
+import '../../utils/user_helpers.dart';
+
+class PollListAdminPage extends StatefulWidget {
+  final PollService? service;
+  const PollListAdminPage({super.key, this.service});
+
+  @override
+  State<PollListAdminPage> createState() => _PollListAdminPageState();
+}
+
+class _PollListAdminPageState extends State<PollListAdminPage> {
+  late final PollService _service;
+  List<Poll> _polls = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Admin access required')));
+      });
+    } else {
+      _service = widget.service ?? PollService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final polls = await _service.fetchPolls();
+    setState(() => _polls = polls);
+  }
+
+  Future<void> _delete(String id) async {
+    await _service.deletePoll(id);
+    setState(() => _polls.removeWhere((p) => p.id == id));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manage Polls')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView.builder(
+          itemCount: _polls.length,
+          itemBuilder: (ctx, i) {
+            final poll = _polls[i];
+            return Card(
+              margin: const EdgeInsets.all(12),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      poll.question,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    for (var j = 0; j < poll.options.length; j++)
+                      Text(
+                        '${poll.options[j]} (${poll.counts.length > j ? poll.counts[j] : 0})',
+                      ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: poll.id != null
+                            ? () => _delete(poll.id!)
+                            : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/poll_service.dart
+++ b/lib/services/poll_service.dart
@@ -20,4 +20,8 @@ class PollService extends ApiService {
   Future<void> vote(String pollId, int option) async {
     await post('/polls/$pollId/vote', {'option': option}, (_) => null);
   }
+
+  Future<void> deletePoll(String id) async {
+    await delete('/polls/$id', (_) => null);
+  }
 }

--- a/server/routes/polls.js
+++ b/server/routes/polls.js
@@ -68,4 +68,16 @@ router.post('/:id/vote', async (req, res) => {
   }
 });
 
+// DELETE /polls/:id - remove poll and votes
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const poll = await Poll.findByIdAndDelete(req.params.id);
+    if (!poll) return res.status(404).json({ error: 'Poll not found' });
+    await PollVote.deleteMany({ pollId: poll._id });
+    res.json({ data: poll });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add DELETE /polls/:id API route that removes the poll and its votes
- support deleting polls in `PollService`
- add `PollListAdminPage` to list and remove polls
- link the new page from admin home page

## Testing
- `dart format lib/services/poll_service.dart lib/pages/admin/poll_list_admin_page.dart lib/pages/admin/admin_home_page.dart`
- `npm test --prefix server` *(fails: jest not found)*
- `flutter test` *(fails: RootUnavailable and package plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68448de9cb14832ba715dfe215f0cd3c