### PR TITLE
Add monthly stats charts

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -8,6 +8,7 @@ import 'booking_admin_page.dart';
 import 'map_admin_page.dart';
 import 'poll_admin_page.dart';
 import 'analytics_page.dart';
+import 'monthly_stats_page.dart';
 import 'gallery_admin_page.dart';
 import '../../utils/user_helpers.dart';
 
@@ -133,6 +134,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Analytics'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const MonthlyStatsPage()),
+                );
+              },
+              child: const Text('Monthly Charts'),
             ),
           ],
         ),

--- a/lib/pages/admin/monthly_stats_page.dart
+++ b/lib/pages/admin/monthly_stats_page.dart
@@ -1,0 +1,132 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../services/stats_service.dart';
+import '../../utils/user_helpers.dart';
+
+class MonthlyStatsPage extends StatefulWidget {
+  final StatsService? service;
+  const MonthlyStatsPage({super.key, this.service});
+
+  @override
+  State<MonthlyStatsPage> createState() => _MonthlyStatsPageState();
+}
+
+class _MonthlyStatsPageState extends State<MonthlyStatsPage> {
+  late final StatsService _service;
+  Map<String, List<int>> _stats = {};
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Admin access required')));
+      });
+    } else {
+      _service = widget.service ?? StatsService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final data = await _service.fetchMonthlyStats();
+    setState(() {
+      _stats = data;
+      _loaded = true;
+    });
+  }
+
+  List<String> _monthLabels() {
+    final now = DateTime.now();
+    return List.generate(12, (i) {
+      final dt = DateTime(now.year, now.month - 11 + i);
+      return '${dt.month}/${dt.year % 100}';
+    });
+  }
+
+  Widget _buildChart(String label, List<int> values, List<String> months) {
+    final spots = List.generate(values.length,
+        (i) => FlSpot(i.toDouble(), values[i].toDouble()));
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 200,
+            child: LineChart(
+              LineChartData(
+                lineBarsData: [
+                  LineChartBarData(spots: spots, isCurved: false),
+                ],
+                minY: 0,
+                titlesData: FlTitlesData(
+                  bottomTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      getTitlesWidget: (value, meta) {
+                        final idx = value.toInt();
+                        if (idx < months.length) {
+                          return SideTitleWidget(
+                            meta: meta,
+                            space: 4,
+                            child: Text(
+                              months[idx],
+                              style: const TextStyle(fontSize: 10),
+                            ),
+                          );
+                        }
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                  ),
+                  leftTitles: AxisTitles(
+                    sideTitles: SideTitles(showTitles: true),
+                  ),
+                  rightTitles:
+                      AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                ),
+                gridData: FlGridData(show: true),
+                borderData: FlBorderData(show: false),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    final months = _monthLabels();
+    if (!_loaded) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Monthly Stats')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Monthly Stats')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: _stats.entries
+              .map((e) => _buildChart(e.key, e.value, months))
+              .toList(),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -9,4 +9,11 @@ class StatsService extends ApiService {
       return map;
     });
   }
+
+  Future<Map<String, List<int>>> fetchMonthlyStats() async {
+    return get('/stats/monthly', (json) {
+      final map = Map<String, dynamic>.from(json['data'] as Map);
+      return map.map((k, v) => MapEntry(k, List<int>.from(v as List)));
+    });
+  }
 }

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -11,6 +11,7 @@ const LostItem = require('../models/LostItem');
 const BookingSlot = require('../models/BookingSlot');
 const BulletinPost = require('../models/BulletinPost');
 const Poll = require('../models/Poll');
+const mongoose = require('mongoose');
 
 const router = express.Router();
 router.use(auth);
@@ -44,6 +45,36 @@ router.get('/', async (req, res) => {
         polls,
       }
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/monthly', async (req, res) => {
+  try {
+    const now = new Date();
+    const months = [];
+    for (let i = 11; i >= 0; i--) {
+      const start = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const end = new Date(start.getFullYear(), start.getMonth() + 1, 1);
+      months.push({ start, end });
+    }
+
+    const data = { users: [], events: [], maintenance: [] };
+    for (const { start, end } of months) {
+      const startId = new mongoose.Types.ObjectId(start);
+      const endId = new mongoose.Types.ObjectId(end);
+      const [users, events, maintenance] = await Promise.all([
+        User.countDocuments({ _id: { $gte: startId, $lt: endId } }),
+        Event.countDocuments({ createdAt: { $gte: start, $lt: end } }),
+        MaintenanceRequest.countDocuments({ createdAt: { $gte: start, $lt: end } }),
+      ]);
+      data.users.push(users);
+      data.events.push(events);
+      data.maintenance.push(maintenance);
+    }
+
+    res.json({ data });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- implement new `/stats/monthly` endpoint for admin analytics
- expose `fetchMonthlyStats` in `StatsService`
- add MonthlyStatsPage displaying line charts using `fl_chart`
- link MonthlyStatsPage from AdminHomePage

## Testing
- `npm install`
- `npm test`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68448dd17d98832ba6794dfb6a0b456d