### PR TITLE
Implement admin user management

### DIFF
--- a/lib/pages/admin/admin_home_page.dart
+++ b/lib/pages/admin/admin_home_page.dart
@@ -9,6 +9,7 @@ import 'map_admin_page.dart';
 import 'poll_admin_page.dart';
 import 'analytics_page.dart';
 import 'gallery_admin_page.dart';
+import 'user_admin_page.dart';
 import '../../utils/user_helpers.dart';
 
 class AdminHomePage extends StatelessWidget {
@@ -123,6 +124,16 @@ class AdminHomePage extends StatelessWidget {
                 );
               },
               child: const Text('Upload Gallery Image'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const UserAdminPage()),
+                );
+              },
+              child: const Text('Manage Users'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(

--- a/lib/pages/admin/user_admin_page.dart
+++ b/lib/pages/admin/user_admin_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/user_service.dart';
+import '../../utils/user_helpers.dart';
+
+class UserAdminPage extends StatefulWidget {
+  final UserService? service;
+  const UserAdminPage({super.key, this.service});
+
+  @override
+  State<UserAdminPage> createState() => _UserAdminPageState();
+}
+
+class _UserAdminPageState extends State<UserAdminPage> {
+  late final UserService _service;
+  final TextEditingController _searchCtrl = TextEditingController();
+  List<User> _users = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Admin access required')));
+      });
+    } else {
+      _service = widget.service ?? UserService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final users = await _service.fetchUsers(search: _searchCtrl.text);
+    if (mounted) setState(() => _users = users);
+  }
+
+  Future<void> _toggleAdmin(User user) async {
+    final updated = User(
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      avatarUrl: user.avatarUrl,
+      isAdmin: !user.isAdmin,
+      isListed: user.isListed,
+      bio: user.bio,
+      room: user.room,
+    );
+    await _service.updateUser(updated);
+    _load();
+  }
+
+  Future<void> _delete(User user) async {
+    if (user.id == null) return;
+    await _service.deleteUser(user.id!);
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manage Users')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _searchCtrl,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                hintText: 'Search users…',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: _load,
+                ),
+              ),
+              onChanged: (_) => _load(),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: ListView.builder(
+                itemCount: _users.length,
+                itemBuilder: (ctx, i) {
+                  final u = _users[i];
+                  return ListTile(
+                    leading: u.avatarUrl != null
+                        ? CircleAvatar(backgroundImage: NetworkImage(u.avatarUrl!))
+                        : const CircleAvatar(child: Icon(Icons.person)),
+                    title: Text(u.name),
+                    subtitle: Text(u.email),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Switch(
+                          value: u.isAdmin,
+                          onChanged: (_) => _toggleAdmin(u),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => _delete(u),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -2,12 +2,25 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/models.dart';
 import 'api_service.dart';
 
 class UserService extends ApiService {
   UserService({super.client});
+
+  Future<List<User>> fetchUsers({String? search}) async {
+    final uri = buildUri('/users',
+        search != null && search.isNotEmpty ? {'search': search} : null);
+    final res = await client.get(uri, headers: _authHeaders());
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>;
+      return list.map((e) => User.fromJson(e as Map<String, dynamic>)).toList();
+    }
+    throw Exception('Request failed: ${res.statusCode}');
+  }
 
   Future<User> updateProfile(User user) async {
     return put(
@@ -33,5 +46,27 @@ class UserService extends ApiService {
 
   Future<void> deleteAccount() async {
     await delete('/users/me', (_) => null);
+  }
+
+  Future<User> updateUser(User user) async {
+    if (user.id == null) throw ArgumentError('id required');
+    return put(
+      '/users/${user.id}',
+      user.toJson(),
+      (json) => User.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deleteUser(String id) async {
+    await delete('/users/$id', (_) => null);
+  }
+
+  Map<String, String> _authHeaders([Map<String, String>? headers]) {
+    final box = Hive.isBoxOpen('authBox') ? Hive.box('authBox') : null;
+    final token = box?.get('token') as String?;
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+      if (headers != null) ...headers,
+    };
   }
 }

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -3,6 +3,7 @@ const multer = require('multer');
 const path = require('path');
 const User = require('../models/User');
 const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
@@ -17,6 +18,23 @@ const upload = multer({ storage });
 
 const router = express.Router();
 router.use(auth);
+
+// GET /users - list users (admin only)
+router.get('/', requireAdmin, async (req, res) => {
+  try {
+    const query = {};
+    if (req.query.search) {
+      const regex = new RegExp(req.query.search, 'i');
+      query.$or = [{ name: regex }, { email: regex }];
+    }
+    const users = await User.find(query).select(
+      'name email avatarUrl isAdmin isListed bio room'
+    );
+    res.json({ data: users });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
 
 // PUT /users/me - update current user's profile
 router.put('/me', async (req, res) => {
@@ -62,6 +80,32 @@ router.delete('/me', async (req, res) => {
     const user = await User.findByIdAndDelete(req.userId);
     if (!user) return res.status(404).json({ error: 'User not found' });
     res.json({ message: 'Account deleted' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /users/:id - update user (admin only)
+router.put('/:id', requireAdmin, async (req, res) => {
+  try {
+    const { name, email, avatarUrl, isAdmin, isListed, bio, room } = req.body;
+    const updates = { name, email, avatarUrl, isAdmin, isListed, bio, room };
+    const user = await User.findByIdAndUpdate(req.params.id, updates, {
+      new: true,
+    });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ data: user });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /users/:id - remove user (admin only)
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const user = await User.findByIdAndDelete(req.params.id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ data: user });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- add server routes to list, update and delete users for admins
- add client `UserService` helpers to manage users
- create `UserAdminPage` to search, toggle admin status and delete users
- link to `UserAdminPage` from the admin home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448dbeaf0c832b8ee1b187dfe85d48