### PR TITLE
Implement centralized theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'models/models.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'services/notification_service.dart';
+import 'theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -149,11 +150,8 @@ class OlyAppState extends State<OlyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'OlyApp',
-      theme: ThemeData.from(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.white38),
-        useMaterial3: true,
-      ),
-      darkTheme: ThemeData.dark(useMaterial3: true),
+      theme: OlyTheme.light(),
+      darkTheme: OlyTheme.dark(),
       themeMode: _themeMode,
 
       routes: {

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Central location for light and dark theme configuration.
+class OlyTheme {
+  OlyTheme._();
+
+  /// Brand color shared between light and dark schemes.
+  static const Color _brandColor = Color(0xFF0066CC);
+
+  /// Light theme using Material 3.
+  static ThemeData light() {
+    final base = ThemeData.light(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: _brandColor,
+        brightness: Brightness.light,
+      ),
+      textTheme: GoogleFonts.robotoTextTheme(base.textTheme),
+    );
+  }
+
+  /// Dark theme using Material 3.
+  static ThemeData dark() {
+    final base = ThemeData.dark(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: _brandColor,
+        brightness: Brightness.dark,
+      ),
+      textTheme: GoogleFonts.robotoTextTheme(base.textTheme),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -477,6 +477,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -1307,7 +1315,7 @@ packages:
     source: hosted
     version: "1.0.1"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   path_provider: ^2.1.5
   file_picker: ^6.1.1
   fl_chart: ^1.0.0
+  google_fonts: ^6.1.0
 dev_dependencies:
   test: any
   flutter_test:


### PR DESCRIPTION
## Summary
- add `OlyTheme` with light and dark variants
- move theming into new file and use a shared brand color and font
- reference `OlyTheme` from `OlyApp`
- include `google_fonts` dependency

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684494d2fe5c832baa844993772649f8