### PR TITLE
Add refresh and loading indicator for item grid

### DIFF
--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -28,6 +28,15 @@ class FakeItemService extends ItemService {
   }
 }
 
+class DelayedItemService extends FakeItemService {
+  DelayedItemService(super.items);
+  @override
+  Future<List<Item>> fetchItems() async {
+    await Future.delayed(const Duration(milliseconds: 50));
+    return super.fetchItems();
+  }
+}
+
 void main() {
   late Directory dir;
 
@@ -46,6 +55,17 @@ void main() {
   tearDown(() async {
     await Hive.close();
     await dir.delete(recursive: true);
+  });
+
+  testWidgets('Shows progress indicator while loading', (tester) async {
+    final service = DelayedItemService([]);
+    await tester.pumpWidget(
+      MaterialApp(home: ItemExchangePage(service: service)),
+    );
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(find.byType(CircularProgressIndicator), findsNothing);
   });
 
   testWidgets('Favorites filter shows only bookmarked items', (tester) async {


### PR DESCRIPTION
## Summary
- support async loading for ItemExchangePage
- show a progress indicator while items load and allow pull to refresh
- test progress indicator appearance

## Testing
- `flutter test` *(fails: Package file_picker does not provide an inline implementation)*

------
https://chatgpt.com/codex/tasks/task_e_6844950df528832bad8cc6c3f2664244