### PR TITLE
Add sorting dropdown to item exchange

### DIFF
--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -22,6 +22,7 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
   final _maxPriceCtrl = TextEditingController();
   String _selectedCategory = 'All';
   bool _onlyFavorites = false;
+  String _sortOrder = 'newest';
   bool _loading = false;
 
   final _categories = [
@@ -87,6 +88,24 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
         results = results
             .where((item) => item.id != null && favs.contains(item.id))
             .toList();
+      }
+      switch (_sortOrder) {
+        case 'priceAsc':
+          results.sort(
+            (a, b) => (a.price ?? double.infinity).compareTo(
+              b.price ?? double.infinity,
+            ),
+          );
+          break;
+        case 'priceDesc':
+          results.sort(
+            (a, b) => (b.price ?? -double.infinity).compareTo(
+              a.price ?? -double.infinity,
+            ),
+          );
+          break;
+        default:
+          results.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       }
       _filteredItems = results;
     });
@@ -192,6 +211,32 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                     ),
                     onChanged: (_) => _filter(),
                   ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 12),
+
+            DropdownButton<String>(
+              key: const ValueKey('sortDropdown'),
+              value: _sortOrder,
+              isExpanded: true,
+              onChanged: (val) {
+                if (val == null) return;
+                setState(() {
+                  _sortOrder = val;
+                  _filter();
+                });
+              },
+              items: const [
+                DropdownMenuItem(value: 'newest', child: Text('Newest')),
+                DropdownMenuItem(
+                  value: 'priceAsc',
+                  child: Text('Price: Low to High'),
+                ),
+                DropdownMenuItem(
+                  value: 'priceDesc',
+                  child: Text('Price: High to Low'),
                 ),
               ],
             ),

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -154,6 +154,37 @@ void main() {
     expect(find.byType(ItemDetailPage), findsOneWidget);
   });
 
+  testWidgets('Sort dropdown orders items', (tester) async {
+    final service = FakeItemService([
+      Item(ownerId: '1', title: 'Old', price: 10, createdAt: DateTime(2022)),
+      Item(ownerId: '1', title: 'New', price: 1, createdAt: DateTime(2023)),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ItemExchangePage(service: service)),
+    );
+    await tester.pumpAndSettle();
+
+    var firstCard = tester.widget<ItemCard>(find.byType(ItemCard).at(0));
+    expect(firstCard.title, 'New');
+
+    await tester.tap(find.byKey(const ValueKey('sortDropdown')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Price: Low to High').last);
+    await tester.pumpAndSettle();
+
+    firstCard = tester.widget<ItemCard>(find.byType(ItemCard).at(0));
+    expect(firstCard.title, 'New');
+
+    await tester.tap(find.byKey(const ValueKey('sortDropdown')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Price: High to Low').last);
+    await tester.pumpAndSettle();
+
+    firstCard = tester.widget<ItemCard>(find.byType(ItemCard).at(0));
+    expect(firstCard.title, 'Old');
+  });
+
   testWidgets('Owner can edit an item', (tester) async {
     await tester.runAsync(() async {
       await Hive.box<User>('userBox').put(


### PR DESCRIPTION
## Summary
- add `_sortOrder` state to item exchange page
- expose dropdown to choose sort method
- sort items when filters apply
- test sort dropdown behaviour

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6844a389eda8832b90f28e4d6e816144