### PR TITLE
Show no items message when filtered

### DIFF
--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -247,18 +247,20 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
             Expanded(
               child: RefreshIndicator(
                 onRefresh: _loadItems,
-                child: _loading && _filteredItems.isEmpty
+                child: _loading
                     ? const Center(child: CircularProgressIndicator())
-                    : GridView.builder(
-                        gridDelegate:
-                            const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 2,
-                              mainAxisSpacing: 12,
-                              crossAxisSpacing: 12,
-                              childAspectRatio: 0.8,
-                            ),
-                        itemCount: _filteredItems.length,
-                        itemBuilder: (ctx, idx) {
+                    : _filteredItems.isEmpty
+                        ? const Center(child: Text('No items found.'))
+                        : GridView.builder(
+                            gridDelegate:
+                                const SliverGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: 2,
+                                  mainAxisSpacing: 12,
+                                  crossAxisSpacing: 12,
+                                  childAspectRatio: 0.8,
+                                ),
+                            itemCount: _filteredItems.length,
+                            itemBuilder: (ctx, idx) {
                           final item = _filteredItems[idx];
                           final favs = _favoriteIds();
                           final isFav =

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -135,6 +135,22 @@ void main() {
     expect(find.text('Laptop'), findsNothing);
   });
 
+  testWidgets('Empty filter shows message', (tester) async {
+    final service = FakeItemService([
+      Item(ownerId: '1', title: 'Chair', category: ItemCategory.furniture),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(home: ItemExchangePage(service: service)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, 'nomatch');
+    await tester.pumpAndSettle();
+
+    expect(find.text('No items found.'), findsOneWidget);
+  });
+
   testWidgets('Tapping item opens detail page', (tester) async {
     final item = Item(
       ownerId: '1',


### PR DESCRIPTION
## Summary
- show `No items found.` message in item exchange when filter results are empty
- test that filtering to zero items displays the message

## Testing
- `flutter pub get`
- `flutter analyze` *(fails to run in this environment)*
- `flutter test` *(fails to run in this environment)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b6167854832bbbe4186cb58c8bd7