### PR TITLE
Add loading logic to directory page

### DIFF
--- a/test/directory_page_test.dart
+++ b/test/directory_page_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/directory_page.dart';
+import 'package:oly_app/services/directory_service.dart';
+
+class FakeDirectoryService extends DirectoryService {
+  final List<User> users;
+  FakeDirectoryService([this.users = const []]);
+
+  @override
+  Future<List<User>> fetchUsers({String? search}) async => users;
+}
+
+void main() {
+  testWidgets('Displays empty message when no users', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: DirectoryPage(service: FakeDirectoryService())),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No residents found.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- show CircularProgressIndicator while loading directory users
- show snackbar on load failure
- handle empty list message in DirectoryPage
- test empty state message

## Testing
- `flutter analyze`
- `flutter test`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b61e36d8832b9b6e302b877b391c