### PR TITLE
Add system theme option

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,7 +68,7 @@ class OlyApp extends StatefulWidget {
 class OlyAppState extends State<OlyApp> {
   bool _loggedIn = false;
   bool _isAdmin = false;
-  ThemeMode _themeMode = ThemeMode.light;
+  ThemeMode _themeMode = ThemeMode.system;
   bool _seenOnboarding = true;
   final List<Map<String, String?>> _notifications = [];
 
@@ -77,12 +77,12 @@ class OlyAppState extends State<OlyApp> {
     super.initState();
     final settingsBox = Hive.box('settingsBox');
     final stored =
-        settingsBox.get('themeMode', defaultValue: 'light') as String;
+        settingsBox.get('themeMode', defaultValue: 'system') as String;
     _seenOnboarding =
         settingsBox.get('seenOnboarding', defaultValue: false) as bool;
     _themeMode = ThemeMode.values.firstWhere(
       (m) => m.name == stored,
-      orElse: () => ThemeMode.light,
+      orElse: () => ThemeMode.system,
     );
     final authBox = Hive.box('authBox');
     final token = authBox.get('token');

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -18,7 +18,7 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  bool _darkMode = false;
+  ThemeMode _themeMode = ThemeMode.system;
   bool _listed = false;
   bool _eventNotif = true;
   bool _announcementNotif = true;
@@ -30,7 +30,11 @@ class _SettingsPageState extends State<SettingsPage> {
     super.initState();
     _service = widget.service ?? UserService();
     final settingsBox = Hive.box('settingsBox');
-    _darkMode = settingsBox.get('themeMode', defaultValue: 'light') == 'dark';
+    final stored = settingsBox.get('themeMode', defaultValue: 'system') as String;
+    _themeMode = ThemeMode.values.firstWhere(
+      (m) => m.name == stored,
+      orElse: () => ThemeMode.system,
+    );
     _eventNotif =
         settingsBox.get('eventNotifications', defaultValue: true) as bool;
     _announcementNotif =
@@ -78,14 +82,30 @@ class _SettingsPageState extends State<SettingsPage> {
       appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         children: [
-          SwitchListTile(
-            title: const Text('Dark Mode'),
-            value: _darkMode,
-            onChanged: (val) {
-              setState(() => _darkMode = val);
-              final mode = val ? ThemeMode.dark : ThemeMode.light;
-              OlyApp.of(context)?.updateThemeMode(mode);
-            },
+          ListTile(
+            title: const Text('Theme'),
+            trailing: DropdownButton<ThemeMode>(
+              value: _themeMode,
+              onChanged: (mode) {
+                if (mode == null) return;
+                setState(() => _themeMode = mode);
+                OlyApp.of(context)?.updateThemeMode(mode);
+              },
+              items: const [
+                DropdownMenuItem(
+                  value: ThemeMode.system,
+                  child: Text('System'),
+                ),
+                DropdownMenuItem(
+                  value: ThemeMode.light,
+                  child: Text('Light'),
+                ),
+                DropdownMenuItem(
+                  value: ThemeMode.dark,
+                  child: Text('Dark'),
+                ),
+              ],
+            ),
           ),
           SwitchListTile(
             title: const Text('Appear in Directory'),

--- a/test/theme_persistence_test.dart
+++ b/test/theme_persistence_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:oly_app/main.dart';
+import 'package:oly_app/models/models.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserAdapter());
+    Hive.registerAdapter(NotificationRecordAdapter());
+    await Hive.openBox('settingsBox');
+    await Hive.openBox('authBox');
+    await Hive.openBox<User>('userBox');
+    await Hive.openBox<NotificationRecord>('notificationsBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('theme persists across restart', (tester) async {
+    await tester.pumpWidget(const OlyApp());
+    await tester.pumpAndSettle();
+
+    final state = tester.state<OlyAppState>(find.byType(OlyApp));
+    state.updateThemeMode(ThemeMode.dark);
+    await tester.pumpAndSettle();
+
+    expect(
+      (tester.widget(find.byType(MaterialApp)) as MaterialApp).themeMode,
+      ThemeMode.dark,
+    );
+
+    await tester.pumpWidget(Container());
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(const OlyApp());
+    await tester.pumpAndSettle();
+
+    expect(
+      (tester.widget(find.byType(MaterialApp)) as MaterialApp).themeMode,
+      ThemeMode.dark,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- change SettingsPage theme control to a dropdown including a `System` option
- default to ThemeMode.system in both SettingsPage and OlyAppState
- save/load theme mode via Hive including the new `system` option
- add widget test verifying theme persistence across app restarts

## Testing
- `flutter test test/theme_persistence_test.dart -r compact` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_6844b6271d08832b91ff9214f55127ff