### PR TITLE
Add image loading/error handlers

### DIFF
--- a/lib/pages/gallery_page.dart
+++ b/lib/pages/gallery_page.dart
@@ -71,7 +71,22 @@ class _GalleryPageState extends State<GalleryPage> {
                 final img = _images[i];
                 return GestureDetector(
                   onTap: () => _view(img),
-                  child: Image.network(img.url, fit: BoxFit.cover),
+                  child: Image.network(
+                    img.url,
+                    fit: BoxFit.cover,
+                    loadingBuilder: (context, child, progress) {
+                      if (progress == null) return child;
+                      return const Center(child: CircularProgressIndicator());
+                    },
+                    errorBuilder: (context, error, stackTrace) => Container(
+                      color: cs.surfaceContainerHighest,
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.broken_image,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
                 );
               },
             ),
@@ -89,7 +104,22 @@ class _FullScreenImage extends StatelessWidget {
       backgroundColor: Colors.black,
       body: GestureDetector(
         onTap: () => Navigator.pop(context),
-        child: Center(child: InteractiveViewer(child: Image.network(url))),
+        child: Center(
+          child: InteractiveViewer(
+            child: Image.network(
+              url,
+              loadingBuilder: (context, child, progress) {
+                if (progress == null) return child;
+                return const Center(child: CircularProgressIndicator());
+              },
+              errorBuilder: (context, error, stackTrace) => Container(
+                color: Colors.black,
+                alignment: Alignment.center,
+                child: const Icon(Icons.broken_image, color: Colors.white),
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/item_detail_page.dart
+++ b/lib/pages/item_detail_page.dart
@@ -134,11 +134,30 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
             // Item Image
             _item.imageUrl != null
                 ? Image.network(
-                  _item.imageUrl!,
-                  height: 200,
-                  width: double.infinity,
-                  fit: BoxFit.cover,
-                )
+                    _item.imageUrl!,
+                    height: 200,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                    loadingBuilder: (context, child, progress) {
+                      if (progress == null) return child;
+                      return SizedBox(
+                        height: 200,
+                        width: double.infinity,
+                        child: const Center(child: CircularProgressIndicator()),
+                      );
+                    },
+                    errorBuilder: (context, error, stackTrace) => Container(
+                      height: 200,
+                      width: double.infinity,
+                      color: colorScheme.surfaceContainerHighest,
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.broken_image,
+                        size: 64,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  )
                 : Container(
                   height: 200,
                   color: colorScheme.surfaceContainerHighest,

--- a/lib/pages/lost_found_detail_page.dart
+++ b/lib/pages/lost_found_detail_page.dart
@@ -193,6 +193,25 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
                   height: 200,
                   width: double.infinity,
                   fit: BoxFit.cover,
+                  loadingBuilder: (context, child, progress) {
+                    if (progress == null) return child;
+                    return SizedBox(
+                      height: 200,
+                      width: double.infinity,
+                      child: const Center(child: CircularProgressIndicator()),
+                    );
+                  },
+                  errorBuilder: (context, error, stackTrace) => Container(
+                    height: 200,
+                    width: double.infinity,
+                    color: cs.surfaceContainerHighest,
+                    alignment: Alignment.center,
+                    child: Icon(
+                      Icons.broken_image,
+                      size: 64,
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
                 )
               : Container(
                   height: 200,


### PR DESCRIPTION
## Summary
- add `loadingBuilder` and `errorBuilder` to network images on detail pages and the gallery

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test` *(fails: RootUnavailable, theme_persistence_test did not complete)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bc08cbf8832bace0831433ca045e