### PR TITLE
Add confirmation dialogs for deleting listings and articles

### DIFF
--- a/lib/pages/post_service_listing_page.dart
+++ b/lib/pages/post_service_listing_page.dart
@@ -82,6 +82,26 @@ class _PostServiceListingPageState extends State<PostServiceListingPage> {
   Future<void> _delete() async {
     final id = widget.listing?.id;
     if (id == null) return;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Listing'),
+        content: const Text(
+          'Are you sure you want to delete this listing?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
     await _service.deleteListing(id);
     if (mounted) {
       ScaffoldMessenger.of(

--- a/lib/pages/wiki_page.dart
+++ b/lib/pages/wiki_page.dart
@@ -91,6 +91,26 @@ class _WikiPageState extends State<WikiPage> {
 
   Future<void> _delete(WikiArticle article) async {
     if (article.id == null) return;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Article'),
+        content: const Text(
+          'Are you sure you want to delete this article?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
     await _service.deleteArticle(article.id!);
     if (!mounted) return;
     setState(() => _articles.removeWhere((a) => a.id == article.id));


### PR DESCRIPTION
## Summary
- confirm deletion of a service listing before calling the API
- confirm deletion of a wiki article before calling the API

## Testing
- `flutter analyze`
- `flutter test` *(fails: RootUnavailable / plugin issues)*

------
https://chatgpt.com/codex/tasks/task_e_6844baef6430832b8943fa1dbe3e5166