### PR TITLE
Add Tutoring Posts

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -23,6 +23,7 @@ part 'document.dart';
 part 'suggestion.dart';
 part 'gallery_image.dart';
 part 'study_group.dart';
+part 'tutoring_post.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/models/tutoring_post.dart
+++ b/lib/models/tutoring_post.dart
@@ -1,0 +1,49 @@
+part of 'models.dart';
+
+class TutoringPost {
+  final String? id;
+  final String userId;
+  final String subject;
+  final String description;
+  final bool isOffering;
+  final String contactUserId;
+  final DateTime createdAt;
+
+  TutoringPost({
+    this.id,
+    required this.userId,
+    required this.subject,
+    required this.description,
+    required this.isOffering,
+    required this.contactUserId,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  factory TutoringPost.fromMap(Map<String, dynamic> map) => TutoringPost(
+    id: map['id']?.toString() ?? map['_id']?.toString(),
+    userId: map['userId']?.toString() ?? '',
+    subject: map['subject'] as String? ?? '',
+    description: map['description'] as String? ?? '',
+    isOffering: map['isOffering'] is bool
+        ? map['isOffering'] as bool
+        : map['isOffering'].toString() == 'true' || map['isOffering'] == 1,
+    contactUserId: map['contactUserId']?.toString() ?? '',
+    createdAt: map['createdAt'] != null
+        ? _parseDate(map['createdAt'])
+        : DateTime.now(),
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'userId': userId,
+    'subject': subject,
+    'description': description,
+    'isOffering': isOffering,
+    'contactUserId': contactUserId,
+    'createdAt': createdAt.toIso8601String(),
+  };
+
+  factory TutoringPost.fromJson(Map<String, dynamic> json) =>
+      TutoringPost.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -20,6 +20,7 @@ import 'group_chat_page.dart';
 import 'wiki_page.dart';
 import 'clubs_page.dart';
 import 'study_groups_page.dart';
+import 'tutoring_page.dart';
 import 'documents_page.dart';
 import 'gallery_page.dart';
 import 'weather_page.dart';
@@ -384,9 +385,16 @@ class DashboardPage extends StatelessWidget {
                   colorScheme: colorScheme,
                   onTap: () => Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => const StudyGroupsPage(),
-                    ),
+                    MaterialPageRoute(builder: (_) => const StudyGroupsPage()),
+                  ),
+                ),
+                DashboardCard(
+                  icon: Icons.menu_book_outlined,
+                  label: 'Tutoring',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const TutoringPage()),
                   ),
                 ),
                 DashboardCard(

--- a/lib/pages/post_tutoring_page.dart
+++ b/lib/pages/post_tutoring_page.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/tutoring_service.dart';
+import '../utils/user_helpers.dart';
+
+class PostTutoringPage extends StatefulWidget {
+  final TutoringService? service;
+  const PostTutoringPage({super.key, this.service});
+
+  @override
+  State<PostTutoringPage> createState() => _PostTutoringPageState();
+}
+
+class _PostTutoringPageState extends State<PostTutoringPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TutoringService _service;
+  final _subjectCtrl = TextEditingController();
+  final _descCtrl = TextEditingController();
+  bool _isOffering = true;
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? TutoringService();
+  }
+
+  @override
+  void dispose() {
+    _subjectCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _submitting = true);
+    try {
+      final post = TutoringPost(
+        userId: currentUserId(),
+        subject: _subjectCtrl.text.trim(),
+        description: _descCtrl.text.trim(),
+        isOffering: _isOffering,
+        contactUserId: currentUserId(),
+      );
+      await _service.createPost(post);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Posted!')));
+        Navigator.pop(context, true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Tutoring Post')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _subjectCtrl,
+                decoration: const InputDecoration(labelText: 'Subject'),
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _descCtrl,
+                decoration: const InputDecoration(labelText: 'Description'),
+                maxLines: 3,
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              SwitchListTile(
+                title: const Text('Offering tutoring'),
+                value: _isOffering,
+                onChanged: (v) => setState(() => _isOffering = v),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                child: Text(_submitting ? 'Posting…' : 'Post'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/tutoring_page.dart
+++ b/lib/pages/tutoring_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../models/models.dart';
+import '../services/tutoring_service.dart';
+import 'post_tutoring_page.dart';
+
+class TutoringPage extends StatefulWidget {
+  final TutoringService? service;
+  const TutoringPage({super.key, this.service});
+
+  @override
+  State<TutoringPage> createState() => _TutoringPageState();
+}
+
+class _TutoringPageState extends State<TutoringPage> {
+  late final TutoringService _service;
+  List<TutoringPost> _posts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? TutoringService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final posts = await _service.fetchPosts();
+    if (mounted) setState(() => _posts = posts);
+  }
+
+  Future<void> _openForm() async {
+    final created = await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(builder: (_) => PostTutoringPage(service: _service)),
+    );
+    if (created == true) _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tutoring')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView.builder(
+          itemCount: _posts.length,
+          itemBuilder: (_, index) {
+            final post = _posts[index];
+            return ListTile(
+              title: Text(post.subject),
+              subtitle: Text(post.description),
+              trailing: Text(post.isOffering ? 'Offering' : 'Seeking'),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _openForm,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/services/tutoring_service.dart
+++ b/lib/services/tutoring_service.dart
@@ -1,0 +1,21 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class TutoringService extends ApiService {
+  TutoringService({super.client});
+
+  Future<List<TutoringPost>> fetchPosts() async {
+    return get('/tutoring', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => TutoringPost.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<TutoringPost> createPost(TutoringPost data) async {
+    return post('/tutoring', data.toJson(), (json) {
+      return TutoringPost.fromJson(json['data'] as Map<String, dynamic>);
+    });
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -22,6 +22,7 @@ const studyGroupsRouter = require('../routes/studygroups');
 const documentsRouter = require('../routes/documents');
 const suggestionsRouter = require("../routes/suggestions");
 const galleryRouter = require('../routes/gallery');
+const tutoringRouter = require('../routes/tutoring');
 
 router.get("/", (req, res) => {
   res.json({ message: "API is running" });
@@ -49,4 +50,5 @@ router.use('/studygroups', studyGroupsRouter);
 router.use('/documents', documentsRouter);
 router.use("/suggestions", suggestionsRouter);
 router.use('/gallery', galleryRouter);
+router.use('/tutoring', tutoringRouter);
 module.exports = router;

--- a/server/models/TutoringPost.js
+++ b/server/models/TutoringPost.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const TutoringPostSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  subject: { type: String, required: true },
+  description: { type: String, required: true },
+  isOffering: { type: Boolean, required: true },
+  contactUserId: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('TutoringPost', TutoringPostSchema);

--- a/server/routes/tutoring.js
+++ b/server/routes/tutoring.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const TutoringPost = require('../models/TutoringPost');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /tutoring - list posts
+router.get('/', async (req, res) => {
+  try {
+    const query = {};
+    if (req.query.isOffering !== undefined) {
+      query.isOffering = req.query.isOffering === 'true';
+    }
+    const posts = await TutoringPost.find(query);
+    res.json({ data: posts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /tutoring - create post
+router.post('/', async (req, res) => {
+  try {
+    const data = {
+      userId: req.userId,
+      subject: req.body.subject,
+      description: req.body.description,
+      isOffering: req.body.isOffering,
+      contactUserId: req.body.contactUserId || String(req.userId)
+    };
+    const post = await TutoringPost.create(data);
+    res.status(201).json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add TutoringPost model and `/tutoring` API routes
- expose tutoring router via API
- implement tutoring listing/service pages in Flutter
- hook tutoring page from main dashboard
- add TutoringService client API

## Testing
- `flutter analyze`
- `flutter test`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455f8397e0832b9412158581607352