### PR TITLE
Add security reports feature

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -24,6 +24,7 @@ part 'suggestion.dart';
 part 'gallery_image.dart';
 part 'study_group.dart';
 part 'tutoring_post.dart';
+part 'security_report.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/models/security_report.dart
+++ b/lib/models/security_report.dart
@@ -1,0 +1,37 @@
+part of 'models.dart';
+
+class SecurityReport {
+  final String? id;
+  final String reporterId;
+  final String description;
+  final String location;
+  final DateTime timestamp;
+
+  SecurityReport({
+    this.id,
+    required this.reporterId,
+    required this.description,
+    required this.location,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  factory SecurityReport.fromMap(Map<String, dynamic> map) => SecurityReport(
+        id: map['id']?.toString(),
+        reporterId: map['reporterId'] as String,
+        description: map['description'] as String,
+        location: map['location'] as String,
+        timestamp: _parseDate(map['timestamp']),
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'reporterId': reporterId,
+        'description': description,
+        'location': location,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory SecurityReport.fromJson(Map<String, dynamic> json) =>
+      SecurityReport.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/pages/security_reports/security_report_admin_page.dart
+++ b/lib/pages/security_reports/security_report_admin_page.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/security_report_service.dart';
+import '../../utils/user_helpers.dart';
+
+class SecurityReportAdminPage extends StatefulWidget {
+  final SecurityReportService? service;
+  const SecurityReportAdminPage({super.key, this.service});
+
+  @override
+  State<SecurityReportAdminPage> createState() => _SecurityReportAdminPageState();
+}
+
+class _SecurityReportAdminPageState extends State<SecurityReportAdminPage> {
+  late final SecurityReportService _service;
+  List<SecurityReport> _reports = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Admin access required')),
+        );
+      });
+    } else {
+      _service = widget.service ?? SecurityReportService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final list = await _service.fetchReports();
+    if (!mounted) return;
+    setState(() => _reports = list);
+  }
+
+  Future<void> _delete(SecurityReport r) async {
+    if (r.id == null) return;
+    await _service.deleteReport(r.id!);
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Security Reports')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _reports.isEmpty
+            ? const Center(child: Text('No reports'))
+            : ListView.builder(
+                itemCount: _reports.length,
+                itemBuilder: (_, i) {
+                  final r = _reports[i];
+                  return ListTile(
+                    title: Text(r.location),
+                    subtitle: Text('${r.description}\n${r.timestamp}'),
+                    isThreeLine: true,
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => _delete(r),
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/pages/security_reports/security_report_page.dart
+++ b/lib/pages/security_reports/security_report_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/security_report_service.dart';
+import '../../utils/user_helpers.dart';
+
+class SecurityReportPage extends StatefulWidget {
+  final SecurityReportService? service;
+  const SecurityReportPage({super.key, this.service});
+
+  @override
+  State<SecurityReportPage> createState() => _SecurityReportPageState();
+}
+
+class _SecurityReportPageState extends State<SecurityReportPage> {
+  late final SecurityReportService _service;
+  final TextEditingController _descCtrl = TextEditingController();
+  final TextEditingController _locCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? SecurityReportService();
+  }
+
+  Future<void> _submit() async {
+    final desc = _descCtrl.text.trim();
+    final loc = _locCtrl.text.trim();
+    if (desc.isEmpty || loc.isEmpty) return;
+    try {
+      await _service.createReport(SecurityReport(
+        reporterId: currentUserId(),
+        description: desc,
+        location: loc,
+      ));
+      if (!mounted) return;
+      _descCtrl.clear();
+      _locCtrl.clear();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Report submitted')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to submit')),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _descCtrl.dispose();
+    _locCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Report Security Issue'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _locCtrl,
+              decoration: const InputDecoration(labelText: 'Location'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _descCtrl,
+              decoration: const InputDecoration(labelText: 'Description'),
+              minLines: 3,
+              maxLines: 5,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(onPressed: _submit, child: const Text('Submit')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/security_report_service.dart
+++ b/lib/services/security_report_service.dart
@@ -1,0 +1,36 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class SecurityReportService extends ApiService {
+  SecurityReportService({super.client});
+
+  Future<SecurityReport> createReport(SecurityReport report) async {
+    return post(
+      '/security_reports',
+      report.toJson(),
+      (json) => SecurityReport.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<List<SecurityReport>> fetchReports() async {
+    return get('/security_reports', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => SecurityReport.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<SecurityReport> updateReport(SecurityReport report) async {
+    if (report.id == null) throw ArgumentError('id required');
+    return put(
+      '/security_reports/${report.id}',
+      report.toJson(),
+      (json) => SecurityReport.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deleteReport(String id) async {
+    await delete('/security_reports/$id', (_) => null);
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -23,6 +23,7 @@ const documentsRouter = require('../routes/documents');
 const suggestionsRouter = require("../routes/suggestions");
 const galleryRouter = require('../routes/gallery');
 const tutoringRouter = require('../routes/tutoring');
+const securityReportsRouter = require('../routes/security_reports');
 
 router.get("/", (req, res) => {
   res.json({ message: "API is running" });
@@ -51,4 +52,5 @@ router.use('/documents', documentsRouter);
 router.use("/suggestions", suggestionsRouter);
 router.use('/gallery', galleryRouter);
 router.use('/tutoring', tutoringRouter);
+router.use('/security_reports', securityReportsRouter);
 module.exports = router;

--- a/server/models/SecurityReport.js
+++ b/server/models/SecurityReport.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const SecurityReportSchema = new mongoose.Schema({
+  reporterId: { type: String, required: true },
+  description: { type: String, required: true },
+  location: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('SecurityReport', SecurityReportSchema);

--- a/server/routes/security_reports.js
+++ b/server/routes/security_reports.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const SecurityReport = require('../models/SecurityReport');
+const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /security_reports - list reports
+router.get('/', async (req, res) => {
+  try {
+    const reports = await SecurityReport.find();
+    res.json({ data: reports });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /security_reports/:id - get one report
+router.get('/:id', async (req, res) => {
+  try {
+    const report = await SecurityReport.findById(req.params.id);
+    if (!report) return res.status(404).json({ error: 'Report not found' });
+    res.json({ data: report });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /security_reports - create report
+router.post('/', async (req, res) => {
+  try {
+    const report = await SecurityReport.create({
+      reporterId: req.userId,
+      description: req.body.description,
+      location: req.body.location,
+      timestamp: req.body.timestamp,
+    });
+    res.status(201).json({ data: report });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /security_reports/:id - update report
+router.put('/:id', requireAdmin, async (req, res) => {
+  try {
+    const report = await SecurityReport.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!report) return res.status(404).json({ error: 'Report not found' });
+    res.json({ data: report });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /security_reports/:id - delete report
+router.delete('/:id', requireAdmin, async (req, res) => {
+  try {
+    const report = await SecurityReport.findByIdAndDelete(req.params.id);
+    if (!report) return res.status(404).json({ error: 'Report not found' });
+    res.json({ data: report });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/security_reports.test.js
+++ b/server/tests/security_reports.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const apiRouter = require('../api');
+
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+function getToken(id = 1) {
+  return jwt.sign({ userId: id }, SECRET);
+}
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('SecurityReports API', () => {
+  test('POST creates and GET lists reports', async () => {
+    const token = getToken();
+    const create = await request(app)
+      .post('/api/security_reports')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ description: 'Test issue', location: 'Lobby' });
+    expect(create.status).toBe(201);
+
+    const list = await request(app)
+      .get('/api/security_reports')
+      .set('Authorization', `Bearer ${token}`);
+    expect(list.status).toBe(200);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].location).toBe('Lobby');
+  });
+});


### PR DESCRIPTION
## Summary
- add `SecurityReport` mongoose model
- add `/security_reports` CRUD API
- expose the new router in `api/index.js`
- add Flutter `SecurityReport` model and service
- implement pages for reporting security issues and viewing them as admin
- test security report routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845649ecb2c832ba54988b0117e8241