### PR TITLE
Add job posting feature

### DIFF
--- a/lib/models/job_post.dart
+++ b/lib/models/job_post.dart
@@ -1,0 +1,46 @@
+part of 'models.dart';
+
+class JobPost {
+  final String? id;
+  final String ownerId;
+  final String title;
+  final String description;
+  final String? pay;
+  final String? contact;
+  final DateTime createdAt;
+
+  JobPost({
+    this.id,
+    required this.ownerId,
+    required this.title,
+    required this.description,
+    this.pay,
+    this.contact,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  factory JobPost.fromMap(Map<String, dynamic> map) => JobPost(
+    id: map['id']?.toString() ?? map['_id']?.toString(),
+    ownerId: map['ownerId']?.toString() ?? '',
+    title: map['title'] as String? ?? '',
+    description: map['description'] as String? ?? '',
+    pay: map['pay'] as String?,
+    contact: map['contact'] as String?,
+    createdAt: map['createdAt'] != null
+        ? _parseDate(map['createdAt'])
+        : DateTime.now(),
+  );
+
+  Map<String, dynamic> toMap() => {
+    if (id != null) 'id': id,
+    'ownerId': ownerId,
+    'title': title,
+    'description': description,
+    if (pay != null) 'pay': pay,
+    if (contact != null) 'contact': contact,
+    'createdAt': createdAt.toIso8601String(),
+  };
+
+  factory JobPost.fromJson(Map<String, dynamic> json) => JobPost.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -24,6 +24,7 @@ part 'suggestion.dart';
 part 'gallery_image.dart';
 part 'study_group.dart';
 part 'tutoring_post.dart';
+part 'job_post.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/pages/job_posts/job_posts_page.dart
+++ b/lib/pages/job_posts/job_posts_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/job_post_service.dart';
+import '../job_posts/post_job_page.dart';
+
+class JobPostsPage extends StatefulWidget {
+  final JobPostService? service;
+  const JobPostsPage({super.key, this.service});
+
+  @override
+  State<JobPostsPage> createState() => _JobPostsPageState();
+}
+
+class _JobPostsPageState extends State<JobPostsPage> {
+  late final JobPostService _service;
+  List<JobPost> _posts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? JobPostService();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final posts = await _service.fetchPosts();
+    if (mounted) setState(() => _posts = posts);
+  }
+
+  Future<void> _openForm() async {
+    final created = await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(builder: (_) => PostJobPage(service: _service)),
+    );
+    if (created == true) _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Job Posts')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: ListView.separated(
+          itemCount: _posts.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (_, index) {
+            final post = _posts[index];
+            return ListTile(
+              title: Text(post.title),
+              subtitle: Text(post.description),
+              trailing: post.pay != null ? Text(post.pay!) : null,
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _openForm,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/pages/job_posts/post_job_page.dart
+++ b/lib/pages/job_posts/post_job_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import '../../models/models.dart';
+import '../../services/job_post_service.dart';
+import '../../utils/user_helpers.dart';
+
+class PostJobPage extends StatefulWidget {
+  final JobPostService? service;
+  const PostJobPage({super.key, this.service});
+
+  @override
+  State<PostJobPage> createState() => _PostJobPageState();
+}
+
+class _PostJobPageState extends State<PostJobPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleCtrl = TextEditingController();
+  final _descCtrl = TextEditingController();
+  final _payCtrl = TextEditingController();
+  final _contactCtrl = TextEditingController();
+  bool _submitting = false;
+  late final JobPostService _service;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? JobPostService();
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _descCtrl.dispose();
+    _payCtrl.dispose();
+    _contactCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _submitting = true);
+    try {
+      final post = JobPost(
+        ownerId: currentUserId(),
+        title: _titleCtrl.text.trim(),
+        description: _descCtrl.text.trim(),
+        pay: _payCtrl.text.trim().isEmpty ? null : _payCtrl.text.trim(),
+        contact: _contactCtrl.text.trim().isEmpty
+            ? null
+            : _contactCtrl.text.trim(),
+      );
+      await _service.createPost(post);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Posted!')));
+        Navigator.pop(context, true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Job Post')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _titleCtrl,
+                decoration: const InputDecoration(labelText: 'Title'),
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _descCtrl,
+                decoration: const InputDecoration(labelText: 'Description'),
+                maxLines: 3,
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _payCtrl,
+                decoration: const InputDecoration(labelText: 'Pay (optional)'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _contactCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Contact info (optional)',
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submitting ? null : _submit,
+                child: Text(_submitting ? 'Posting…' : 'Post'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -21,6 +21,7 @@ import 'wiki_page.dart';
 import 'clubs_page.dart';
 import 'study_groups_page.dart';
 import 'tutoring_page.dart';
+import 'job_posts/job_posts_page.dart';
 import 'documents_page.dart';
 import 'gallery_page.dart';
 import 'weather_page.dart';
@@ -395,6 +396,15 @@ class DashboardPage extends StatelessWidget {
                   onTap: () => Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const TutoringPage()),
+                  ),
+                ),
+                DashboardCard(
+                  icon: Icons.work,
+                  label: 'Jobs',
+                  colorScheme: colorScheme,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const JobPostsPage()),
                   ),
                 ),
                 DashboardCard(

--- a/lib/services/job_post_service.dart
+++ b/lib/services/job_post_service.dart
@@ -1,0 +1,36 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class JobPostService extends ApiService {
+  JobPostService({super.client});
+
+  Future<List<JobPost>> fetchPosts() async {
+    return get('/job_posts', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => JobPost.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<JobPost> createPost(JobPost job) async {
+    return post(
+      '/job_posts',
+      job.toJson(),
+      (json) => JobPost.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<JobPost> updatePost(JobPost job) async {
+    if (job.id == null) throw ArgumentError('id required');
+    return put(
+      '/job_posts/${job.id}',
+      job.toJson(),
+      (json) => JobPost.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deletePost(String id) async {
+    await delete('/job_posts/$id', (_) => null);
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -23,6 +23,7 @@ const documentsRouter = require('../routes/documents');
 const suggestionsRouter = require("../routes/suggestions");
 const galleryRouter = require('../routes/gallery');
 const tutoringRouter = require('../routes/tutoring');
+const jobPostsRouter = require('../routes/job_posts');
 
 router.get("/", (req, res) => {
   res.json({ message: "API is running" });
@@ -51,4 +52,5 @@ router.use('/documents', documentsRouter);
 router.use("/suggestions", suggestionsRouter);
 router.use('/gallery', galleryRouter);
 router.use('/tutoring', tutoringRouter);
+router.use('/job_posts', jobPostsRouter);
 module.exports = router;

--- a/server/models/JobPost.js
+++ b/server/models/JobPost.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const JobPostSchema = new mongoose.Schema({
+  ownerId: { type: String, required: true },
+  title: { type: String, required: true },
+  description: { type: String, required: true },
+  pay: { type: String },
+  contact: { type: String },
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('JobPost', JobPostSchema);

--- a/server/routes/job_posts.js
+++ b/server/routes/job_posts.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const JobPost = require('../models/JobPost');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /job_posts - list posts
+router.get('/', async (req, res) => {
+  try {
+    const posts = await JobPost.find();
+    res.json({ data: posts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /job_posts - create post
+router.post('/', async (req, res) => {
+  try {
+    const data = {
+      ownerId: req.userId,
+      title: req.body.title,
+      description: req.body.description,
+      pay: req.body.pay,
+      contact: req.body.contact
+    };
+    const post = await JobPost.create(data);
+    res.status(201).json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT /job_posts/:id - update post
+router.put('/:id', async (req, res) => {
+  try {
+    const post = await JobPost.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
+    if (!post) return res.status(404).json({ error: 'Post not found' });
+    res.json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE /job_posts/:id - delete post
+router.delete('/:id', async (req, res) => {
+  try {
+    const post = await JobPost.findByIdAndDelete(req.params.id);
+    if (!post) return res.status(404).json({ error: 'Post not found' });
+    res.json({ data: post });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- backend: create JobPost model and CRUD routes
- frontend: add job post model, service, and pages
- integrate job posts into dashboard
- expose job posts API in router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684565cda7a4832b9bb4ebc797ddba91