### PR TITLE
Add noise reports feature

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -25,6 +25,7 @@ part 'gallery_image.dart';
 part 'study_group.dart';
 part 'tutoring_post.dart';
 part 'security_report.dart';
+part 'noise_report.dart';
 
 DateTime _parseDate(dynamic value) {
   if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);

--- a/lib/models/noise_report.dart
+++ b/lib/models/noise_report.dart
@@ -1,0 +1,37 @@
+part of 'models.dart';
+
+class NoiseReport {
+  final String? id;
+  final String reporterId;
+  final String description;
+  final String location;
+  final DateTime timestamp;
+
+  NoiseReport({
+    this.id,
+    required this.reporterId,
+    required this.description,
+    required this.location,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  factory NoiseReport.fromMap(Map<String, dynamic> map) => NoiseReport(
+        id: map['id']?.toString(),
+        reporterId: map['reporterId'] as String,
+        description: map['description'] as String,
+        location: map['location'] as String,
+        timestamp: _parseDate(map['timestamp']),
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (id != null) 'id': id,
+        'reporterId': reporterId,
+        'description': description,
+        'location': location,
+        'timestamp': timestamp.toIso8601String(),
+      };
+
+  factory NoiseReport.fromJson(Map<String, dynamic> json) =>
+      NoiseReport.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}

--- a/lib/pages/noise_reports/noise_report_admin_page.dart
+++ b/lib/pages/noise_reports/noise_report_admin_page.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/noise_report_service.dart';
+import '../../utils/user_helpers.dart';
+
+class NoiseReportAdminPage extends StatefulWidget {
+  final NoiseReportService? service;
+  const NoiseReportAdminPage({super.key, this.service});
+
+  @override
+  State<NoiseReportAdminPage> createState() => _NoiseReportAdminPageState();
+}
+
+class _NoiseReportAdminPageState extends State<NoiseReportAdminPage> {
+  late final NoiseReportService _service;
+  List<NoiseReport> _reports = [];
+
+  @override
+  void initState() {
+    super.initState();
+    if (!currentUserIsAdmin()) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Admin access required')),
+        );
+      });
+    } else {
+      _service = widget.service ?? NoiseReportService();
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final list = await _service.fetchReports();
+    if (!mounted) return;
+    setState(() => _reports = list);
+  }
+
+  Future<void> _delete(NoiseReport r) async {
+    if (r.id == null) return;
+    await _service.deleteReport(r.id!);
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!currentUserIsAdmin()) return const SizedBox.shrink();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Noise Reports')),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _reports.isEmpty
+            ? const Center(child: Text('No reports'))
+            : ListView.builder(
+                itemCount: _reports.length,
+                itemBuilder: (_, i) {
+                  final r = _reports[i];
+                  return ListTile(
+                    title: Text(r.location),
+                    subtitle: Text('${r.description}\n${r.timestamp}'),
+                    isThreeLine: true,
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () => _delete(r),
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/pages/noise_reports/noise_report_page.dart
+++ b/lib/pages/noise_reports/noise_report_page.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../../models/models.dart';
+import '../../services/noise_report_service.dart';
+import '../../utils/user_helpers.dart';
+
+class NoiseReportPage extends StatefulWidget {
+  final NoiseReportService? service;
+  const NoiseReportPage({super.key, this.service});
+
+  @override
+  State<NoiseReportPage> createState() => _NoiseReportPageState();
+}
+
+class _NoiseReportPageState extends State<NoiseReportPage> {
+  late final NoiseReportService _service;
+  final TextEditingController _descCtrl = TextEditingController();
+  final TextEditingController _locCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _service = widget.service ?? NoiseReportService();
+  }
+
+  Future<void> _submit() async {
+    final desc = _descCtrl.text.trim();
+    final loc = _locCtrl.text.trim();
+    if (desc.isEmpty || loc.isEmpty) return;
+    try {
+      await _service.createReport(NoiseReport(
+        reporterId: currentUserId(),
+        description: desc,
+        location: loc,
+      ));
+      if (!mounted) return;
+      _descCtrl.clear();
+      _locCtrl.clear();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Report submitted')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to submit')),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _descCtrl.dispose();
+    _locCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Report Noise Issue'),
+        backgroundColor: cs.primaryContainer,
+        foregroundColor: cs.onPrimaryContainer,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _locCtrl,
+              decoration: const InputDecoration(labelText: 'Location'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _descCtrl,
+              decoration: const InputDecoration(labelText: 'Description'),
+              minLines: 3,
+              maxLines: 5,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(onPressed: _submit, child: const Text('Submit')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/noise_report_service.dart
+++ b/lib/services/noise_report_service.dart
@@ -1,0 +1,36 @@
+import '../models/models.dart';
+import 'api_service.dart';
+
+class NoiseReportService extends ApiService {
+  NoiseReportService({super.client});
+
+  Future<NoiseReport> createReport(NoiseReport report) async {
+    return post(
+      '/noise_reports',
+      report.toJson(),
+      (json) => NoiseReport.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<List<NoiseReport>> fetchReports() async {
+    return get('/noise_reports', (json) {
+      final list = json['data'] as List<dynamic>;
+      return list
+          .map((e) => NoiseReport.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  Future<NoiseReport> updateReport(NoiseReport report) async {
+    if (report.id == null) throw ArgumentError('id required');
+    return put(
+      '/noise_reports/${report.id}',
+      report.toJson(),
+      (json) => NoiseReport.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  Future<void> deleteReport(String id) async {
+    await delete('/noise_reports/$id', (_) => null);
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -24,6 +24,7 @@ const suggestionsRouter = require("../routes/suggestions");
 const galleryRouter = require('../routes/gallery');
 const tutoringRouter = require('../routes/tutoring');
 const securityReportsRouter = require('../routes/security_reports');
+const noiseReportsRouter = require('../routes/noise_reports');
 
 router.get("/", (req, res) => {
   res.json({ message: "API is running" });
@@ -53,4 +54,5 @@ router.use("/suggestions", suggestionsRouter);
 router.use('/gallery', galleryRouter);
 router.use('/tutoring', tutoringRouter);
 router.use('/security_reports', securityReportsRouter);
+router.use('/noise_reports', noiseReportsRouter);
 module.exports = router;

--- a/server/models/NoiseReport.js
+++ b/server/models/NoiseReport.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const NoiseReportSchema = new mongoose.Schema({
+  reporterId: { type: String, required: true },
+  location: { type: String, required: true },
+  description: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('NoiseReport', NoiseReportSchema);

--- a/server/routes/noise_reports.js
+++ b/server/routes/noise_reports.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const NoiseReport = require('../models/NoiseReport');
+const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
+
+const router = express.Router();
+router.use(auth);
+
+// GET /noise_reports - list reports (admin only)
+router.get('/', requireAdmin, async (req, res) => {
+  try {
+    const reports = await NoiseReport.find();
+    res.json({ data: reports });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /noise_reports - create new report
+router.post('/', async (req, res) => {
+  try {
+    const report = await NoiseReport.create({
+      reporterId: req.userId,
+      location: req.body.location,
+      description: req.body.description,
+      timestamp: req.body.timestamp,
+    });
+    res.status(201).json({ data: report });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/tests/noise_reports.test.js
+++ b/server/tests/noise_reports.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const apiRouter = require('../api');
+const User = require('../models/User');
+
+const SECRET = process.env.JWT_SECRET || 'secretkey';
+
+function tokenFor(id) {
+  return jwt.sign({ userId: id }, SECRET);
+}
+
+let app;
+let mongo;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  await mongoose.connect(mongo.getUri());
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+describe('NoiseReports API', () => {
+  test('POST creates report and GET requires admin', async () => {
+    const user = await User.create({ name: 'u', email: 'u@t.c', passwordHash: 'x' });
+    const admin = await User.create({ name: 'a', email: 'a@t.c', passwordHash: 'x', isAdmin: true });
+
+    const userToken = tokenFor(user._id);
+    const adminToken = tokenFor(admin._id);
+
+    const create = await request(app)
+      .post('/api/noise_reports')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ location: 'Bldg 1', description: 'Loud music' });
+    expect(create.status).toBe(201);
+
+    const nonAdminList = await request(app)
+      .get('/api/noise_reports')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(nonAdminList.status).toBe(403);
+
+    const list = await request(app)
+      .get('/api/noise_reports')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(list.status).toBe(200);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].location).toBe('Bldg 1');
+  });
+});


### PR DESCRIPTION
## Summary
- add `NoiseReport` Mongoose model
- implement `/api/noise_reports` routes
- register new router in API
- support noise reports in Flutter models and services
- add pages for filing and viewing noise reports
- test noise report API

## Testing
- `npm test`
- `flutter test` *(fails: Package file_picker references default implementations)*

------
https://chatgpt.com/codex/tasks/task_e_684565c3f050832b9115d42ef51d8297