### PR TITLE
Add Hive caching for directory users

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ void main() async {
   await Hive.openBox('itemsBox');
   await Hive.openBox('userBox');
   await Hive.openBox('authBox');
+  await Hive.openBox('directoryBox');
   await Hive.openBox('favoritesBox');
   await Hive.openBox('settingsBox');
   await Hive.openBox('pinsBox');

--- a/lib/pages/directory_page.dart
+++ b/lib/pages/directory_page.dart
@@ -27,19 +27,23 @@ class _DirectoryPageState extends State<DirectoryPage> {
 
   Future<void> _loadUsers() async {
     setState(() => _loading = true);
+    final cached = _service.loadCachedUsers(search: _searchCtrl.text);
+    if (cached.isNotEmpty) {
+      setState(() => _users = cached);
+    }
     try {
       final users = await _service.fetchUsers(search: _searchCtrl.text);
       if (!mounted) return;
-      setState(() {
-        _users = users;
-        _loading = false;
-      });
+      setState(() => _users = users);
     } catch (_) {
       if (!mounted) return;
-      setState(() => _loading = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Failed to load users')));
+      if (_users.isEmpty) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Failed to load users')));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
     }
   }
 

--- a/lib/services/directory_service.dart
+++ b/lib/services/directory_service.dart
@@ -7,16 +7,44 @@ import 'api_service.dart';
 class DirectoryService extends ApiService {
   DirectoryService({super.client});
 
+  String _cacheKey(String? search) => 'users_${search ?? ''}';
+
+  List<User> loadCachedUsers({String? search}) {
+    final box = Hive.isBoxOpen('directoryBox') ? Hive.box('directoryBox') : null;
+    final cached = box?.get(_cacheKey(search), defaultValue: const <dynamic>[])
+        as List?;
+    if (cached == null || cached.isEmpty) return [];
+    return cached
+        .map((e) => User.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
   Future<List<User>> fetchUsers({String? search}) async {
-    final uri = buildUri('/directory',
-        search != null && search.isNotEmpty ? {'search': search} : null);
-    final res = await client.get(uri, headers: _authHeaders());
-    if (res.statusCode == 200) {
-      final data = jsonDecode(res.body) as Map<String, dynamic>;
-      final list = data['data'] as List<dynamic>;
-      return list.map((e) => User.fromJson(e as Map<String, dynamic>)).toList();
+    final box = Hive.isBoxOpen('directoryBox') ? Hive.box('directoryBox') : null;
+    try {
+      final uri = buildUri('/directory',
+          search != null && search.isNotEmpty ? {'search': search} : null);
+      final res = await client.get(uri, headers: _authHeaders());
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body) as Map<String, dynamic>;
+        final list = data['data'] as List<dynamic>;
+        final users =
+            list.map((e) => User.fromJson(e as Map<String, dynamic>)).toList();
+        await box?.put(
+          _cacheKey(search),
+          users.map((u) => u.toJson()).toList(),
+        );
+        return users;
+      }
+      throw Exception('Request failed: ${res.statusCode}');
+    } catch (_) {
+      final cached = box?.get(_cacheKey(search), defaultValue: const <dynamic>[])
+          as List?;
+      if (cached == null || cached.isEmpty) rethrow;
+      return cached
+          .map((e) => User.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
     }
-    throw Exception('Request failed: ${res.statusCode}');
   }
 
   Future<List<Message>> fetchMessages(String userId) async {

--- a/test/services/directory_service_test.dart
+++ b/test/services/directory_service_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+import 'package:hive/hive.dart';
+
+import 'package:oly_app/services/directory_service.dart';
+import 'package:oly_app/models/models.dart';
+
+void main() {
+  group('DirectoryService caching', () {
+    late Directory dir;
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp();
+      Hive.init(dir.path);
+      Hive.registerAdapter(UserAdapter());
+      await Hive.openBox('directoryBox');
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      await dir.delete(recursive: true);
+    });
+
+    test('returns cached users when request fails', () async {
+      final box = Hive.box('directoryBox');
+      await box.put('users_', [
+        User(name: 'Cached', email: 'c@example.com')
+            .toJson(),
+      ]);
+
+      final mockClient = MockClient((_) async => http.Response('err', 500));
+      final service = DirectoryService(client: mockClient);
+      final users = await service.fetchUsers();
+      expect(users, hasLength(1));
+      expect(users.first.name, 'Cached');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- cache directory users in a new Hive `directoryBox`
- open `directoryBox` on startup
- show cached directory users in `DirectoryPage`
- test that `DirectoryService` falls back to cache when the API fails

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456dba2b60832ba1f9cad761de2a1c