### PR TITLE
Add password confirmation to registration

### DIFF
--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -18,6 +18,7 @@ class _RegisterPageState extends State<RegisterPage> {
   final _nameCtrl = TextEditingController();
   final _emailCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
+  final _confirmPasswordCtrl = TextEditingController();
   bool _loading = false;
   bool _passwordVisible = false;
 
@@ -26,11 +27,18 @@ class _RegisterPageState extends State<RegisterPage> {
     _nameCtrl.dispose();
     _emailCtrl.dispose();
     _passwordCtrl.dispose();
+    _confirmPasswordCtrl.dispose();
     super.dispose();
   }
 
   Future<void> _register() async {
     if (!_formKey.currentState!.validate()) return;
+    if (_confirmPasswordCtrl.text != _passwordCtrl.text) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Passwords do not match')),
+      );
+      return;
+    }
     setState(() => _loading = true);
     try {
       final service = AuthService();
@@ -116,6 +124,19 @@ class _RegisterPageState extends State<RegisterPage> {
                   ),
                   obscureText: !_passwordVisible,
                   validator: validatePassword,
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _confirmPasswordCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Confirm password',
+                    filled: true,
+                    fillColor: cs.surfaceContainerHighest,
+                    prefixIcon: const Icon(Icons.lock),
+                  ),
+                  obscureText: true,
+                  validator: (v) =>
+                      validateConfirmPassword(v, _passwordCtrl.text),
                 ),
                 const SizedBox(height: 24),
                 SizedBox(

--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -10,3 +10,9 @@ String? validatePassword(String? value) {
   if (value.length < 6) return 'Password must be at least 6 characters';
   return null;
 }
+
+String? validateConfirmPassword(String? value, String original) {
+  if (value == null || value.isEmpty) return 'Please confirm password';
+  if (value != original) return 'Passwords do not match';
+  return null;
+}

--- a/test/login_validation_test.dart
+++ b/test/login_validation_test.dart
@@ -29,4 +29,19 @@ void main() {
       expect(validatePassword('123456'), isNull);
     });
   });
+
+  group('validateConfirmPassword', () {
+    test('empty confirmation', () {
+      expect(validateConfirmPassword('', 'password'), 'Please confirm password');
+    });
+
+    test('mismatch confirmation', () {
+      expect(
+          validateConfirmPassword('abc', 'password'), 'Passwords do not match');
+    });
+
+    test('matching confirmation', () {
+      expect(validateConfirmPassword('password', 'password'), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- validate matching passwords with `validateConfirmPassword`
- show a Confirm password field on the registration form
- ensure `_register()` checks passwords match before calling the service
- test confirm password validator logic

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68456dbc30d4832bb0ca51e60276a679