### PR TITLE
Implement central async error handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ const cron = require('node-cron');
 const Event = require('./models/Event');
 const http = require('http');
 const websocket = require('./socket');
+const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
 app.use(cors());
@@ -33,6 +34,7 @@ connectToDatabase().catch((err) => {
 
 const apiRouter = require('./api');
 app.use('/api', apiRouter);
+app.use(errorHandler);
 
 // Send event reminders 15 minutes before start
 cron.schedule('* * * * *', async () => {

--- a/server/middleware/catchAsync.js
+++ b/server/middleware/catchAsync.js
@@ -1,0 +1,5 @@
+module.exports = function catchAsync(fn) {
+  return function(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,0 +1,10 @@
+function errorHandler(err, req, res, next) {
+  // Log unexpected errors for debugging
+  if (!err.status || err.status >= 500) {
+    console.error(err);
+  }
+  const status = err.status || (err.name === 'ValidationError' ? 400 : 500);
+  res.status(status).json({ error: err.message });
+}
+
+module.exports = errorHandler;

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -5,13 +5,13 @@ const User = require('../models/User');
 const auth = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
 const QRCode = require('qrcode');
+const catchAsync = require('../middleware/catchAsync');
 
 const router = express.Router();
 router.use(auth);
 
 // GET /events - list events
-router.get('/', async (req, res) => {
-  try {
+router.get('/', catchAsync(async (req, res) => {
     const events = await Event.find();
     const result = [];
     const addInterval = (date, interval) => {
@@ -47,14 +47,10 @@ router.get('/', async (req, res) => {
       }
     }
     res.json({ data: result });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
-});
+  }));
 
 // POST /events - create event
-router.post('/', requireAdmin, async (req, res) => {
-  try {
+router.post('/', requireAdmin, catchAsync(async (req, res) => {
     const data = {
       title: req.body.title,
       date: req.body.date,
@@ -70,14 +66,10 @@ router.post('/', requireAdmin, async (req, res) => {
     };
     const event = await Event.create(data);
     res.json({ data: event });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // PUT /events/:id - update event
-router.put('/:id', requireAdmin, async (req, res) => {
-  try {
+router.put('/:id', requireAdmin, catchAsync(async (req, res) => {
     const data = {
       title: req.body.title,
       date: req.body.date,
@@ -96,25 +88,17 @@ router.put('/:id', requireAdmin, async (req, res) => {
     });
     if (!event) return res.status(404).json({ error: 'Event not found' });
     res.json({ data: event });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // DELETE /events/:id - remove event
-router.delete('/:id', requireAdmin, async (req, res) => {
-  try {
+router.delete('/:id', requireAdmin, catchAsync(async (req, res) => {
     const event = await Event.findByIdAndDelete(req.params.id);
     if (!event) return res.status(404).json({ error: 'Event not found' });
     res.json({ data: event });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // POST /events/:id/rsvp - add attendee
-router.post('/:id/rsvp', async (req, res) => {
-  try {
+router.post('/:id/rsvp', catchAsync(async (req, res) => {
     const event = await Event.findById(req.params.id);
     if (!event) return res.status(404).json({ error: 'Event not found' });
     const numericId = Number(req.userId);
@@ -137,63 +121,43 @@ router.post('/:id/rsvp', async (req, res) => {
     }
     await event.save();
     res.json(event);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // GET /events/:id/attendees - list attendees
-router.get('/:id/attendees', async (req, res) => {
-  try {
+router.get('/:id/attendees', catchAsync(async (req, res) => {
     const event = await Event.findById(req.params.id);
     if (!event) return res.status(404).json({ error: 'Event not found' });
     res.json({ data: event.attendees });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // GET /events/:id/comments - list comments
-router.get('/:id/comments', async (req, res) => {
-  try {
+router.get('/:id/comments', catchAsync(async (req, res) => {
     const comments = await EventComment.find({ eventId: req.params.id });
     res.json({ data: comments });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // POST /events/:id/comments - create comment
-router.post('/:id/comments', async (req, res) => {
-  try {
+router.post('/:id/comments', catchAsync(async (req, res) => {
     const comment = await EventComment.create({
       eventId: req.params.id,
       content: req.body.content,
       date: req.body.date,
     });
     res.status(201).json({ data: comment });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 // GET /events/:id/qr - return QR code image
-router.get('/:id/qr', async (req, res) => {
-  try {
+router.get('/:id/qr', catchAsync(async (req, res) => {
     const event = await Event.findById(req.params.id);
     if (!event) return res.status(404).json({ error: 'Event not found' });
     const data = `event:${event._id}`;
     const buffer = await QRCode.toBuffer(data, { type: 'png' });
     res.set('Content-Type', 'image/png');
     res.send(buffer);
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
-});
+  }));
 
 // POST /events/:id/checkin - record user check-in
-router.post('/:id/checkin', async (req, res) => {
-  try {
+router.post('/:id/checkin', catchAsync(async (req, res) => {
     const numericId = Number(req.userId);
     const event = await Event.findById(req.params.id);
     if (!event) return res.status(404).json({ error: 'Event not found' });
@@ -202,9 +166,6 @@ router.post('/:id/checkin', async (req, res) => {
       await event.save();
     }
     res.json({ data: event.checkIns });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+  }));
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add catchAsync helper and errorHandler middleware
- refactor events and maintenance routes to use catchAsync
- register the new error middleware in server

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684571f46448832b85c8cbffba1dd71b