### PR TITLE
Add register option to welcome screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'pages/register_page.dart';
 import 'pages/forgot_password_page.dart';
 import 'pages/reset_password_page.dart';
 import 'pages/onboarding_page.dart';
+import 'pages/auth_home_page.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
 import 'dart:io';
@@ -157,6 +158,7 @@ class OlyAppState extends State<OlyApp> {
       themeMode: _themeMode,
 
       routes: {
+        '/login': (_) => LoginPage(onLoginSuccess: _handleLogin),
         '/register': (_) => RegisterPage(onRegistered: _handleLogin),
         '/forgot': (_) => const ForgotPasswordPage(),
         '/reset': (_) => const ResetPasswordPage(),
@@ -165,7 +167,7 @@ class OlyAppState extends State<OlyApp> {
           ? OnboardingPage(onFinish: _finishOnboarding)
           : _loggedIn
           ? MainPage(isAdmin: _isAdmin, onLogout: _logout)
-          : LoginPage(onLoginSuccess: () => _handleLogin()),
+          : const AuthHomePage(),
     );
   }
 }

--- a/lib/pages/auth_home_page.dart
+++ b/lib/pages/auth_home_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+/// Simple landing page with Login and Register buttons.
+class AuthHomePage extends StatelessWidget {
+  const AuthHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Welcome')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.pushNamed(context, '/login'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: cs.primary,
+                    foregroundColor: cs.onPrimary,
+                  ),
+                  child: const Text('Login'),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.pushNamed(context, '/register'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: cs.secondary,
+                    foregroundColor: cs.onSecondary,
+                  ),
+                  child: const Text('Register'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AuthHomePage` with Login and Register buttons
- include the new page in `main.dart` so unauthenticated users see the landing page
- expose `/login` route to navigate from the landing page

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b4076088832ba1975291132b37cd