### PR TITLE
Handle API error details

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -9,12 +9,14 @@ import '../services/auth_service.dart';
 /// A simple login page with email/password and placeholder Google/Apple login buttons.
 class LoginPage extends StatefulWidget {
   final VoidCallback onLoginSuccess;
+  final AuthService? service;
   final GoogleSignIn? googleSignIn;
   final Future<AuthorizationCredentialAppleID> Function()? appleSignIn;
 
   const LoginPage({
     super.key,
     required this.onLoginSuccess,
+    this.service,
     this.googleSignIn,
     this.appleSignIn,
   });
@@ -51,7 +53,7 @@ class _LoginPageState extends State<LoginPage> {
       };
     }
 
-    final service = AuthService();
+    final service = widget.service ?? AuthService();
     return service.login(email, password);
   }
 
@@ -82,9 +84,11 @@ class _LoginPageState extends State<LoginPage> {
       widget.onLoginSuccess();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Login failed: $e')));
+      final message =
+          e is Exception ? e.toString().replaceFirst('Exception: ', '') : '$e';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
     } finally {
       if (mounted) {
         setState(() => _isLoading = false);

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -29,6 +29,18 @@ class ApiService {
     };
   }
 
+  Exception _errorFromResponse(http.Response response) {
+    try {
+      if (response.body.isNotEmpty) {
+        final json = jsonDecode(response.body);
+        if (json is Map && json['error'] is String) {
+          return Exception(json['error']);
+        }
+      }
+    } catch (_) {}
+    return Exception('Request failed: ${response.statusCode}');
+  }
+
   Future<T> get<T>(String path, T Function(dynamic json) parser) async {
     final response = await _client.get(
       buildUri(path),
@@ -38,7 +50,7 @@ class ApiService {
       final data = jsonDecode(response.body);
       return parser(data);
     } else {
-      throw Exception('Request failed: ${response.statusCode}');
+      throw _errorFromResponse(response);
     }
   }
 
@@ -56,7 +68,7 @@ class ApiService {
       final data = jsonDecode(response.body);
       return parser(data);
     } else {
-      throw Exception('Request failed: ${response.statusCode}');
+      throw _errorFromResponse(response);
     }
   }
 
@@ -74,7 +86,7 @@ class ApiService {
       final data = jsonDecode(response.body);
       return parser(data);
     } else {
-      throw Exception('Request failed: ${response.statusCode}');
+      throw _errorFromResponse(response);
     }
   }
 
@@ -88,7 +100,7 @@ class ApiService {
       final data = jsonDecode(body);
       return parser(data);
     } else {
-      throw Exception('Request failed: ${response.statusCode}');
+      throw _errorFromResponse(response);
     }
   }
 }

--- a/test/login_page_error_test.dart
+++ b/test/login_page_error_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:oly_app/models/models.dart';
+import 'package:oly_app/pages/login_page.dart';
+import 'package:oly_app/services/auth_service.dart';
+
+class FakeAuthService extends AuthService {
+  @override
+  Future<Map<String, dynamic>> login(String email, String password) async {
+    throw Exception('Invalid credentials');
+  }
+}
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(UserAdapter());
+    await Hive.openBox('authBox');
+    await Hive.openBox<User>('userBox');
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('shows server error on invalid credentials', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LoginPage(onLoginSuccess: () {}, service: FakeAuthService()),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).at(0), 'a@b.com');
+    await tester.enterText(find.byType(TextFormField).at(1), 'wrong');
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Login'));
+    await tester.pump();
+
+    expect(find.text('Invalid credentials'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- parse JSON error messages in `ApiService`
- allow injecting an `AuthService` into `LoginPage`
- display server error text on failed login
- test login error handling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474d627260832bb6d1da79c04df9e1