### PR TITLE
Fix login page test password validation

### DIFF
--- a/test/login_page_error_test.dart
+++ b/test/login_page_error_test.dart
@@ -38,7 +38,8 @@ void main() {
     );
 
     await tester.enterText(find.byType(TextFormField).at(0), 'a@b.com');
-    await tester.enterText(find.byType(TextFormField).at(1), 'wrong');
+    // Password must satisfy minimum length validation.
+    await tester.enterText(find.byType(TextFormField).at(1), 'wrongpwd');
     await tester.tap(find.widgetWithText(ElevatedButton, 'Login'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- update login_page_error_test to use a password that satisfies validation

## Testing
- `npm test`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684ac63b8528832b9e2bd9d083d601ab