### PR TITLE
Add admin notices to item listings

### DIFF
--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,4 +1,5 @@
 part of 'models.dart';
+
 @HiveType(typeId: 4)
 enum ItemCategory {
   @HiveField(0)
@@ -22,17 +23,40 @@ class ItemRating {
   ItemRating({required this.rating, this.review});
 
   factory ItemRating.fromMap(Map<String, dynamic> map) => ItemRating(
-        rating: (map['rating'] as num).toInt(),
-        review: map['review'] as String?,
-      );
+    rating: (map['rating'] as num).toInt(),
+    review: map['review'] as String?,
+  );
 
   Map<String, dynamic> toMap() => {
-        'rating': rating,
-        if (review != null) 'review': review,
-      };
+    'rating': rating,
+    if (review != null) 'review': review,
+  };
 
   factory ItemRating.fromJson(Map<String, dynamic> json) =>
       ItemRating.fromMap(json);
+  Map<String, dynamic> toJson() => toMap();
+}
+
+enum ItemNoticeSeverity { info, warning, critical }
+
+class ItemNotice {
+  final String text;
+  final ItemNoticeSeverity severity;
+
+  const ItemNotice({required this.text, required this.severity});
+
+  factory ItemNotice.fromMap(Map<String, dynamic> map) => ItemNotice(
+    text: map['text'] as String? ?? '',
+    severity: ItemNoticeSeverity.values.firstWhere(
+      (e) => e.name == map['severity'],
+      orElse: () => ItemNoticeSeverity.info,
+    ),
+  );
+
+  Map<String, dynamic> toMap() => {'text': text, 'severity': severity.name};
+
+  factory ItemNotice.fromJson(Map<String, dynamic> json) =>
+      ItemNotice.fromMap(json);
   Map<String, dynamic> toJson() => toMap();
 }
 
@@ -56,6 +80,7 @@ class Item {
   final ItemCategory category;
   @HiveField(8)
   final DateTime createdAt;
+  final ItemNotice? notice;
   final bool completed;
   final List<ItemRating> ratings;
 
@@ -69,6 +94,7 @@ class Item {
     this.isFree = false,
     this.category = ItemCategory.other,
     DateTime? createdAt,
+    this.notice,
     this.completed = false,
     this.ratings = const [],
   }) : createdAt = createdAt ?? DateTime.now();
@@ -80,17 +106,18 @@ class Item {
     description: map['description'] as String?,
     imageUrl: map['imageUrl'] as String?,
     price: map['price'] != null ? (map['price'] as num).toDouble() : null,
-    isFree:
-        map['isFree'] is bool
-            ? map['isFree'] as bool
-            : (map['isFree'] as int) == 1,
-    category:
-        map['category'] is int
-            ? ItemCategory.values[map['category'] as int]
-            : ItemCategory.values.firstWhere(
-              (e) => e.name == map['category'] as String,
-            ),
+    isFree: map['isFree'] is bool
+        ? map['isFree'] as bool
+        : (map['isFree'] as int) == 1,
+    category: map['category'] is int
+        ? ItemCategory.values[map['category'] as int]
+        : ItemCategory.values.firstWhere(
+            (e) => e.name == map['category'] as String,
+          ),
     createdAt: _parseDate(map['createdAt']),
+    notice: map['notice'] is Map<String, dynamic>
+        ? ItemNotice.fromMap(map['notice'] as Map<String, dynamic>)
+        : null,
     completed: map['completed'] as bool? ?? false,
     ratings: (map['ratings'] as List<dynamic>? ?? const [])
         .map((e) => ItemRating.fromMap(Map<String, dynamic>.from(e)))
@@ -107,6 +134,7 @@ class Item {
     'isFree': isFree,
     'category': category.name,
     'createdAt': createdAt.toIso8601String(),
+    if (notice != null) 'notice': notice!.toMap(),
     'completed': completed,
     'ratings': ratings.map((e) => e.toMap()).toList(),
   };

--- a/lib/pages/item_detail_page.dart
+++ b/lib/pages/item_detail_page.dart
@@ -20,12 +20,25 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
   late ItemService _service;
   final _ratingCtrl = TextEditingController();
   final _reviewCtrl = TextEditingController();
+  final _noticeCtrl = TextEditingController();
+  ItemNoticeSeverity _noticeSeverity = ItemNoticeSeverity.info;
+  bool _savingNotice = false;
 
   @override
   void initState() {
     super.initState();
     _item = widget.item;
     _service = widget.service ?? ItemService();
+    _noticeCtrl.text = _item.notice?.text ?? '';
+    _noticeSeverity = _item.notice?.severity ?? ItemNoticeSeverity.info;
+  }
+
+  @override
+  void dispose() {
+    _ratingCtrl.dispose();
+    _reviewCtrl.dispose();
+    _noticeCtrl.dispose();
+    super.dispose();
   }
 
   Future<void> _requestItem(BuildContext context) async {
@@ -40,6 +53,87 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
     }
   }
 
+  Color _noticeColor(ItemNoticeSeverity severity) {
+    switch (severity) {
+      case ItemNoticeSeverity.warning:
+        return Colors.orange.shade100;
+      case ItemNoticeSeverity.critical:
+        return Colors.red.shade100;
+      case ItemNoticeSeverity.info:
+      default:
+        return Colors.blue.shade100;
+    }
+  }
+
+  Color _noticeTextColor(ItemNoticeSeverity severity, ColorScheme scheme) {
+    switch (severity) {
+      case ItemNoticeSeverity.warning:
+        return Colors.orange.shade900;
+      case ItemNoticeSeverity.critical:
+        return Colors.red.shade900;
+      case ItemNoticeSeverity.info:
+      default:
+        return scheme.primary;
+    }
+  }
+
+  Future<void> _saveNotice() async {
+    if (_item.id == null) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final text = _noticeCtrl.text.trim();
+    if (text.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Enter notice text or remove the notice.'),
+        ),
+      );
+      return;
+    }
+
+    setState(() => _savingNotice = true);
+    try {
+      final updated = await _service.updateNotice(
+        _item.id!,
+        text: text,
+        severity: _noticeSeverity,
+      );
+      if (!mounted) return;
+      setState(() {
+        _item = updated;
+        _noticeSeverity = updated.notice?.severity ?? _noticeSeverity;
+      });
+      messenger.showSnackBar(const SnackBar(content: Text('Notice saved.')));
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Failed to save notice: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _savingNotice = false);
+    }
+  }
+
+  Future<void> _clearNotice() async {
+    if (_item.id == null) return;
+    setState(() => _savingNotice = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final updated = await _service.clearNotice(_item.id!);
+      if (!mounted) return;
+      setState(() {
+        _item = updated;
+        _noticeCtrl.clear();
+        _noticeSeverity = ItemNoticeSeverity.info;
+      });
+      messenger.showSnackBar(const SnackBar(content: Text('Notice removed.')));
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Failed to remove notice: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _savingNotice = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -48,6 +142,7 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
       user = Hive.box<User>('userBox').get('currentUser');
     }
     final isOwner = user != null && user.id == _item.ownerId;
+    final isAdmin = user?.isAdmin ?? false;
     final favBox = Hive.box('favoritesBox');
     return Scaffold(
       appBar: AppBar(
@@ -87,8 +182,8 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder:
-                        (_) => PostItemPage(item: _item, service: _service),
+                    builder: (_) =>
+                        PostItemPage(item: _item, service: _service),
                   ),
                 );
               },
@@ -100,23 +195,22 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                 if (_item.id == null) return;
                 final confirm = await showDialog<bool>(
                   context: context,
-                  builder:
-                      (ctx) => AlertDialog(
-                        title: const Text('Delete Item'),
-                        content: const Text(
-                          'Are you sure you want to delete this item?',
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(ctx, false),
-                            child: const Text('Cancel'),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.pop(ctx, true),
-                            child: const Text('Delete'),
-                          ),
-                        ],
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Delete Item'),
+                    content: const Text(
+                      'Are you sure you want to delete this item?',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, false),
+                        child: const Text('Cancel'),
                       ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, true),
+                        child: const Text('Delete'),
+                      ),
+                    ],
+                  ),
                 );
                 if (confirm != true) return;
                 final svc = _service;
@@ -159,14 +253,14 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                     ),
                   )
                 : Container(
-                  height: 200,
-                  color: colorScheme.surfaceContainerHighest,
-                  child: Icon(
-                    Icons.image_not_supported,
-                    size: 64,
-                    color: colorScheme.onSurfaceVariant,
+                    height: 200,
+                    color: colorScheme.surfaceContainerHighest,
+                    child: Icon(
+                      Icons.image_not_supported,
+                      size: 64,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                   ),
-                ),
 
             // Details
             Padding(
@@ -196,6 +290,52 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
 
                   const SizedBox(height: 16),
 
+                  if (_item.notice != null && _item.notice!.text.isNotEmpty)
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: _noticeColor(_item.notice!.severity),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: _noticeTextColor(
+                            _item.notice!.severity,
+                            colorScheme,
+                          ),
+                        ),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Notice (${_item.notice!.severity.name.toUpperCase()})',
+                            style: Theme.of(context).textTheme.titleSmall
+                                ?.copyWith(
+                                  color: _noticeTextColor(
+                                    _item.notice!.severity,
+                                    colorScheme,
+                                  ),
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            _item.notice!.text,
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: _noticeTextColor(
+                                    _item.notice!.severity,
+                                    colorScheme,
+                                  ),
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                  if (_item.notice != null && _item.notice!.text.isNotEmpty)
+                    const SizedBox(height: 16),
+
                   // Description Section
                   Text(
                     'Description',
@@ -211,6 +351,69 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
 
                   const SizedBox(height: 24),
 
+                  if (isAdmin) ...[
+                    Text(
+                      'Admin Notice',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: colorScheme.secondary,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _noticeCtrl,
+                      decoration: const InputDecoration(
+                        labelText: 'Notice text',
+                        hintText: 'Enter notice to show on this listing',
+                      ),
+                      minLines: 1,
+                      maxLines: 3,
+                    ),
+                    const SizedBox(height: 8),
+                    DropdownButtonFormField<ItemNoticeSeverity>(
+                      value: _noticeSeverity,
+                      decoration: const InputDecoration(labelText: 'Severity'),
+                      items: const [
+                        DropdownMenuItem(
+                          value: ItemNoticeSeverity.info,
+                          child: Text('Info (blue)'),
+                        ),
+                        DropdownMenuItem(
+                          value: ItemNoticeSeverity.warning,
+                          child: Text('Warning (orange)'),
+                        ),
+                        DropdownMenuItem(
+                          value: ItemNoticeSeverity.critical,
+                          child: Text('Critical (red)'),
+                        ),
+                      ],
+                      onChanged: (val) {
+                        if (val == null) return;
+                        setState(() => _noticeSeverity = val);
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: ElevatedButton.icon(
+                            icon: const Icon(Icons.save),
+                            label: const Text('Save notice'),
+                            onPressed: _savingNotice ? null : _saveNotice,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            icon: const Icon(Icons.delete_forever),
+                            label: const Text('Remove notice'),
+                            onPressed: _savingNotice ? null : _clearNotice,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+
                   // Action Buttons
                   Row(
                     children: [
@@ -223,11 +426,10 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder:
-                                    (_) => ItemChatPage(
-                                      item: _item,
-                                      service: _service,
-                                    ),
+                                builder: (_) => ItemChatPage(
+                                  item: _item,
+                                  service: _service,
+                                ),
                               ),
                             );
                           },

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -24,8 +24,8 @@ class ItemService extends ApiService {
       await box?.put('items', items.map((e) => e.toJson()).toList());
       return items;
     } catch (e) {
-      final cached = box?.get('items', defaultValue: const <dynamic>[])
-          as List?;
+      final cached =
+          box?.get('items', defaultValue: const <dynamic>[]) as List?;
       if (cached == null || cached.isEmpty) {
         rethrow;
       }
@@ -38,12 +38,9 @@ class ItemService extends ApiService {
   /// Creates a new item listing.
   Future<Item> createItem(Item item, {File? imageFile}) async {
     if (imageFile != null) {
-      final request =
-          http.MultipartRequest('POST', buildUri('/items'))
-            ..fields.addAll(item.toJson().map((k, v) => MapEntry(k, '$v')))
-            ..files.add(
-              await http.MultipartFile.fromPath('image', imageFile.path),
-            );
+      final request = http.MultipartRequest('POST', buildUri('/items'))
+        ..fields.addAll(item.toJson().map((k, v) => MapEntry(k, '$v')))
+        ..files.add(await http.MultipartFile.fromPath('image', imageFile.path));
       final streamed = await client.send(request);
       final response = await http.Response.fromStream(streamed);
       if (response.statusCode == 201 || response.statusCode == 200) {
@@ -95,6 +92,28 @@ class ItemService extends ApiService {
     );
   }
 
+  /// Sets or updates an admin notice for an item.
+  Future<Item> updateNotice(
+    int itemId, {
+    required String text,
+    required ItemNoticeSeverity severity,
+  }) async {
+    return post(
+      '/items/$itemId/notice',
+      {'text': text, 'severity': severity.name},
+      (json) => Item.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Removes the admin notice for an item.
+  Future<Item> clearNotice(int itemId) async {
+    return post(
+      '/items/$itemId/notice',
+      {'text': null},
+      (json) => Item.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
   /// Deletes the item with the given [id].
   Future<void> deleteItem(int id) async {
     await post('/items/$id/delete', {}, (_) => null);
@@ -102,8 +121,10 @@ class ItemService extends ApiService {
 
   /// Submits a rating for the item with [itemId].
   Future<void> submitRating(int itemId, int rating, {String? review}) async {
-    await post('/items/$itemId/ratings',
-        {'rating': rating, 'review': review}, (_) => null);
+    await post('/items/$itemId/ratings', {
+      'rating': rating,
+      'review': review,
+    }, (_) => null);
   }
 
   /// Fetches ratings for the item with [itemId].

--- a/server/models/Item.js
+++ b/server/models/Item.js
@@ -12,6 +12,14 @@ const ItemSchema = new mongoose.Schema({
     enum: ['furniture', 'books', 'electronics', 'other', 'appliances', 'clothing'],
     default: 'other'
   },
+  notice: {
+    _id: false,
+    text: String,
+    severity: {
+      type: String,
+      enum: ['info', 'warning', 'critical']
+    }
+  },
   createdAt: { type: Date, default: Date.now },
   requested: { type: Boolean, default: false },
   completed: { type: Boolean, default: false },

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const Item = require('../models/Item');
 const Message = require('../models/Message');
+const User = require('../models/User');
 const auth = require('../middleware/auth');
 const multer = require('multer');
 const path = require('path');
@@ -19,6 +20,15 @@ const upload = multer({ storage });
 const socket = require('../socket');
 const router = express.Router();
 router.use(auth);
+
+async function requireAdmin(req, res) {
+  const user = await User.findById(req.userId);
+  if (!user || !user.isAdmin) {
+    res.status(403).json({ error: 'Admin access required' });
+    return false;
+  }
+  return true;
+}
 
 // GET /items - list items
 router.get('/', async (req, res) => {
@@ -87,7 +97,35 @@ router.post('/:id/request', async (req, res) => {
 // POST /items/:id - update item
 router.post('/:id', async (req, res) => {
   try {
-    const item = await Item.findByIdAndUpdate(req.params.id, req.body, {
+    const updates = { ...req.body };
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'notice')) {
+      const isAdmin = await requireAdmin(req, res);
+      if (!isAdmin) return;
+    }
+
+    const item = await Item.findByIdAndUpdate(req.params.id, updates, {
+      new: true
+    });
+    if (!item) return res.status(404).json({ error: 'Item not found' });
+    res.json({ data: item });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /items/:id/notice - set or clear admin notice
+router.post('/:id/notice', async (req, res) => {
+  try {
+    const isAdmin = await requireAdmin(req, res);
+    if (!isAdmin) return;
+
+    const { text, severity } = req.body;
+    const update = text
+      ? { notice: { text, severity } }
+      : { $unset: { notice: '' } };
+
+    const item = await Item.findByIdAndUpdate(req.params.id, update, {
       new: true
     });
     if (!item) return res.status(404).json({ error: 'Item not found' });


### PR DESCRIPTION
## Summary
- add an admin-managed notice to item listings in the backend, including validation and dedicated endpoints
- extend the mobile models and service layer to handle notice text and severity values
- display listing notices with severity colors and provide admin-only controls to set or clear them

## Testing
- npm test -- --runInBand *(fails: jest not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fb39d818832ba3c82313c8cdc75b)