### PR TITLE
Harden auth, CORS, file uploads, and password policy

### DIFF
--- a/lib/utils/validators.dart
+++ b/lib/utils/validators.dart
@@ -7,7 +7,13 @@ String? validateEmail(String? value) {
 
 String? validatePassword(String? value) {
   if (value == null || value.isEmpty) return 'Password is required';
-  if (value.length < 6) return 'Password must be at least 6 characters';
+  if (value.length < 8) return 'Password must be at least 8 characters';
+  if (!RegExp(r'[A-Za-z]').hasMatch(value)) {
+    return 'Password must contain a letter';
+  }
+  if (!RegExp(r'\d').hasMatch(value)) {
+    return 'Password must contain a number';
+  }
   return null;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   firebase_core: ^2.27.0
   firebase_messaging: ^14.7.10
 
-  http: any
+  http: ^1.4.0
   google_sign_in: ^6.3.0
   sign_in_with_apple: ^7.0.1
   image_picker: ^1.1.2
@@ -59,7 +59,7 @@ dependencies:
   fl_chart: ^1.0.0
   google_fonts: ^6.1.0
 dev_dependencies:
-  test: any
+  test: ^1.25.0
   flutter_test:
     sdk: flutter
   google_sign_in_mocks: ^0.3.0

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,10 @@
 MONGODB_URI=mongodb://localhost:27017/olyapp
 PORT=3000
+
+# Required. Server refuses to start without it.
+JWT_SECRET=change-me-to-a-long-random-string
+
+# Comma-separated list of allowed CORS origins, e.g.
+#   CORS_ORIGINS=https://app.example.com,https://admin.example.com
+# Use "*" only for local development.
+CORS_ORIGINS=*

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,23 @@
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || value.trim() === '') {
+    throw new Error(
+      `Missing required environment variable: ${name}. Refuse to start with an insecure default.`
+    );
+  }
+  return value;
+}
+
+function parseCorsOrigins(raw) {
+  if (!raw || raw.trim() === '') return [];
+  if (raw.trim() === '*') return '*';
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+module.exports = {
+  jwtSecret: requireEnv('JWT_SECRET'),
+  corsOrigins: parseCorsOrigins(process.env.CORS_ORIGINS),
+};

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ const apiRouter = require('./api');
 const Event = require('./models/Event');
 const websocket = require('./socket');
 const errorHandler = require('./middleware/errorHandler');
+const { corsOrigins } = require('./config');
 
 const logger = createLogger({
   level: 'info',
@@ -27,7 +28,17 @@ const logger = createLogger({
 });
 
 const app = express();
-app.use(cors());
+const corsOptions =
+  corsOrigins === '*'
+    ? { origin: true }
+    : {
+        origin: (origin, cb) => {
+          if (!origin) return cb(null, true);
+          if (corsOrigins.includes(origin)) return cb(null, true);
+          return cb(new Error(`Origin ${origin} not allowed by CORS`));
+        },
+      };
+app.use(cors(corsOptions));
 app.use(helmet());
 app.use(express.json());
 app.use(morgan('tiny', { stream: { write: (msg) => logger.info(msg.trim()) } }));
@@ -50,8 +61,34 @@ connectToDatabase().catch((err) => {
   process.exit(1);
 });
 
-const authLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+const writeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
+});
+const globalLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.use('/api', globalLimiter);
 app.use('/api/auth', authLimiter);
+app.use('/api/items', writeLimiter);
+app.use('/api/maintenance', writeLimiter);
+app.use('/api/bulletin', writeLimiter);
+app.use('/api/lostfound', writeLimiter);
+app.use('/api/gallery', writeLimiter);
+app.use('/api/suggestions', writeLimiter);
 app.use('/api', apiRouter);
 app.use(errorHandler);
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'node',
   testTimeout: 30000,
+  setupFiles: ['<rootDir>/tests/jest.setup.js'],
 };

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,6 +1,5 @@
 const jwt = require('jsonwebtoken');
-
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const { jwtSecret: SECRET } = require('../config');
 
 module.exports = function (req, res, next) {
   const header = req.get('Authorization');

--- a/server/middleware/uploads.js
+++ b/server/middleware/uploads.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const crypto = require('crypto');
+const multer = require('multer');
+
+const UPLOAD_DIR = path.join(__dirname, '..', 'uploads');
+
+const IMAGE_MIME_WHITELIST = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+]);
+
+const DOCUMENT_MIME_WHITELIST = new Set([
+  ...IMAGE_MIME_WHITELIST,
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/plain',
+  'text/csv',
+]);
+
+const EXT_BY_MIME = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+  'image/heic': '.heic',
+  'image/heif': '.heif',
+  'application/pdf': '.pdf',
+  'application/msword': '.doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.ms-excel': '.xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'text/plain': '.txt',
+  'text/csv': '.csv',
+};
+
+function safeExtension(mime, originalName) {
+  if (EXT_BY_MIME[mime]) return EXT_BY_MIME[mime];
+  const fallback = path.extname(originalName || '').toLowerCase();
+  if (/^\.[a-z0-9]{1,8}$/.test(fallback)) return fallback;
+  return '';
+}
+
+function makeStorage() {
+  return multer.diskStorage({
+    destination: (req, file, cb) => cb(null, UPLOAD_DIR),
+    filename: (req, file, cb) => {
+      const random = crypto.randomBytes(16).toString('hex');
+      cb(null, `${Date.now()}-${random}${safeExtension(file.mimetype, file.originalname)}`);
+    },
+  });
+}
+
+function makeFileFilter(whitelist) {
+  return (req, file, cb) => {
+    if (whitelist.has(file.mimetype)) return cb(null, true);
+    cb(new Error(`Unsupported file type: ${file.mimetype}`));
+  };
+}
+
+function imageUploader({ maxBytes = 5 * 1024 * 1024 } = {}) {
+  return multer({
+    storage: makeStorage(),
+    limits: { fileSize: maxBytes, files: 1 },
+    fileFilter: makeFileFilter(IMAGE_MIME_WHITELIST),
+  });
+}
+
+function documentUploader({ maxBytes = 15 * 1024 * 1024 } = {}) {
+  return multer({
+    storage: makeStorage(),
+    limits: { fileSize: maxBytes, files: 1 },
+    fileFilter: makeFileFilter(DOCUMENT_MIME_WHITELIST),
+  });
+}
+
+module.exports = {
+  imageUploader,
+  documentUploader,
+  IMAGE_MIME_WHITELIST,
+  DOCUMENT_MIME_WHITELIST,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -20,9 +20,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.0",
     "morgan": "^1.10.0",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.0",
     "node-cron": "^3.0.2",
-    "nodemailer": "^7.0.3",
+    "nodemailer": "^8.0.7",
     "qrcode": "^1.5.1",
     "winston": "^3.8.2",
     "ws": "^8.13.0"

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -5,9 +5,8 @@ const crypto = require('crypto');
 const nodemailer = require('nodemailer');
 const User = require('../models/User');
 const validate = require('../middleware/validate');
-const { registerSchema, loginSchema } = require('../validation/auth');
-
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const { registerSchema, loginSchema, resetConfirmSchema } = require('../validation/auth');
+const { jwtSecret: SECRET } = require('../config');
 
 const transporter = nodemailer.createTransport({
   jsonTransport: true,
@@ -104,12 +103,9 @@ router.post('/reset', async (req, res) => {
 });
 
 // POST /auth/reset/confirm - set new password
-router.post('/reset/confirm', async (req, res) => {
+router.post('/reset/confirm', validate(resetConfirmSchema), async (req, res) => {
   try {
     const { token, password } = req.body;
-    if (!token || !password) {
-      return res.status(400).json({ error: 'Missing fields' });
-    }
     const hashed = crypto.createHash('sha256').update(token).digest('hex');
     const user = await User.findOne({
       passwordResetToken: hashed,

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -1,19 +1,9 @@
 const express = require('express');
-const multer = require('multer');
-const path = require('path');
 const Document = require('../models/Document');
 const auth = require('../middleware/auth');
+const { documentUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = documentUploader();
 
 const router = express.Router();
 router.use(auth);

--- a/server/routes/gallery.js
+++ b/server/routes/gallery.js
@@ -1,19 +1,9 @@
 const express = require('express');
-const multer = require('multer');
-const path = require('path');
 const GalleryImage = require('../models/GalleryImage');
 const auth = require('../middleware/auth');
+const { imageUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = imageUploader();
 
 const router = express.Router();
 router.use(auth);

--- a/server/routes/items.js
+++ b/server/routes/items.js
@@ -2,19 +2,9 @@ const express = require('express');
 const Item = require('../models/Item');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
-const multer = require('multer');
-const path = require('path');
+const { imageUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = imageUploader();
 
 const socket = require('../socket');
 const router = express.Router();

--- a/server/routes/lostfound.js
+++ b/server/routes/lostfound.js
@@ -3,19 +3,9 @@ const LostItem = require('../models/LostItem');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
 const socket = require('../socket');
-const multer = require('multer');
-const path = require('path');
+const { imageUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = imageUploader();
 
 const router = express.Router();
 router.use(auth);

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -3,20 +3,10 @@ const MaintenanceRequest = require('../models/MaintenanceRequest');
 const Message = require('../models/Message');
 const auth = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
-const multer = require('multer');
-const path = require('path');
 const socket = require('../socket');
+const { imageUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = imageUploader();
 
 const router = express.Router();
 router.use(auth);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,20 +1,10 @@
 const express = require('express');
-const multer = require('multer');
-const path = require('path');
 const User = require('../models/User');
 const auth = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
+const { imageUploader } = require('../middleware/uploads');
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, path.join(__dirname, '../uploads'));
-  },
-  filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    cb(null, unique + path.extname(file.originalname));
-  }
-});
-const upload = multer({ storage });
+const upload = imageUploader();
 
 const router = express.Router();
 router.use(auth);

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -18,7 +18,7 @@ jest.spyOn(admin, 'messaging').mockReturnValue({
   sendEachForMulticast: jest.fn().mockResolvedValue({ successCount: 1 }),
 });
 
-const SECRET = process.env.JWT_SECRET || 'secretkey'; 
+const SECRET = process.env.JWT_SECRET;
 
 function getToken(id = 1) {
   return jwt.sign({ userId: id }, SECRET);

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -8,7 +8,7 @@ const User = require('../models/User');
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 let app;
 let mongo;
@@ -34,7 +34,7 @@ describe('Auth API', () => {
   test('registers and logs in a user', async () => {
     const reg = await request(app)
       .post('/api/auth/register')
-      .send({ name: 'Test', email: 'a@b.c', password: 'pass' });
+      .send({ name: 'Test', email: 'a@b.c', password: 'Passw0rd!' });
     expect(reg.status).toBe(201);
     expect(reg.body).toHaveProperty('token');
     expect(() => jwt.verify(reg.body.token, SECRET)).not.toThrow();
@@ -42,7 +42,7 @@ describe('Auth API', () => {
 
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'a@b.c', password: 'pass' });
+      .send({ email: 'a@b.c', password: 'Passw0rd!' });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('token');
     expect(() => jwt.verify(res.body.token, SECRET)).not.toThrow();
@@ -52,7 +52,7 @@ describe('Auth API', () => {
   test('invalid credentials return HTTP 401', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ name: 'Test', email: 'x@y.z', password: 'pass' });
+      .send({ name: 'Test', email: 'x@y.z', password: 'Passw0rd!' });
 
     const res = await request(app)
       .post('/api/auth/login')
@@ -64,7 +64,7 @@ describe('Auth API', () => {
   test('POST /auth/reset stores hashed token', async () => {
     await request(app)
       .post('/api/auth/register')
-      .send({ name: 'Test', email: 'reset@test.com', password: 'pass' });
+      .send({ name: 'Test', email: 'reset@test.com', password: 'Passw0rd!' });
 
     const res = await request(app)
       .post('/api/auth/reset')
@@ -89,11 +89,11 @@ describe('Auth API', () => {
 
     const res = await request(app)
       .post('/api/auth/reset/confirm')
-      .send({ token, password: 'newpass' });
+      .send({ token, password: 'NewPassw0rd!' });
     expect(res.status).toBe(200);
 
     const updated = await User.findById(user._id);
-    const match = await bcrypt.compare('newpass', updated.passwordHash);
+    const match = await bcrypt.compare('NewPassw0rd!', updated.passwordHash);
     expect(match).toBe(true);
     expect(updated.passwordResetToken).toBeUndefined();
     expect(updated.passwordResetExpires).toBeUndefined();

--- a/server/tests/bookings.test.js
+++ b/server/tests/bookings.test.js
@@ -7,7 +7,7 @@ const apiRouter = require('../api');
 const BookingSlot = require('../models/BookingSlot');
 const User = require('../models/User');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 function getToken(id = 1) {
   return jwt.sign({ userId: id }, SECRET);

--- a/server/tests/jest.setup.js
+++ b/server/tests/jest.setup.js
@@ -1,0 +1,2 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-only-secret-do-not-use-in-prod';
+process.env.CORS_ORIGINS = process.env.CORS_ORIGINS || '*';

--- a/server/tests/lostfound.test.js
+++ b/server/tests/lostfound.test.js
@@ -6,7 +6,7 @@ const jwt = require('jsonwebtoken');
 const apiRouter = require('../api');
 const LostItem = require('../models/LostItem');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 function getToken(id = 1) {
   return jwt.sign({ userId: id }, SECRET);

--- a/server/tests/noise_reports.test.js
+++ b/server/tests/noise_reports.test.js
@@ -6,7 +6,7 @@ const jwt = require('jsonwebtoken');
 const apiRouter = require('../api');
 const User = require('../models/User');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 function tokenFor(id) {
   return jwt.sign({ userId: id }, SECRET);

--- a/server/tests/security_reports.test.js
+++ b/server/tests/security_reports.test.js
@@ -5,7 +5,7 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const apiRouter = require('../api');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 function getToken(id = 1) {
   return jwt.sign({ userId: id }, SECRET);

--- a/server/tests/stats.test.js
+++ b/server/tests/stats.test.js
@@ -9,7 +9,7 @@ const Event = require('../models/Event');
 const Item = require('../models/Item');
 const ServiceListing = require('../models/ServiceListing');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 let app;
 let mongo;

--- a/server/tests/users.test.js
+++ b/server/tests/users.test.js
@@ -7,7 +7,7 @@ const apiRouter = require('../api');
 const User = require('../models/User');
 const bcrypt = require('bcryptjs');
 
-const SECRET = process.env.JWT_SECRET || 'secretkey';
+const SECRET = process.env.JWT_SECRET;
 
 let app;
 let mongo;

--- a/server/validation/auth.js
+++ b/server/validation/auth.js
@@ -1,18 +1,36 @@
 const Joi = require('joi');
 
+const strongPassword = Joi.string()
+  .min(8)
+  .pattern(/[A-Za-z]/, 'letter')
+  .pattern(/\d/, 'number')
+  .required()
+  .messages({
+    'string.min': 'Password must be at least 8 characters',
+    'string.pattern.name': 'Password must contain a {#name}',
+  });
+
 const registerSchema = Joi.object({
   name: Joi.string().required(),
   email: Joi.string().email({ tlds: { allow: false } }).required(),
-  password: Joi.string().min(1).required(),
+  password: strongPassword,
   avatarUrl: Joi.string().allow(''),
   isAdmin: Joi.boolean(),
   bio: Joi.string().allow(''),
   room: Joi.string().allow(''),
 });
 
+// Login intentionally keeps a lenient schema so legacy users (with
+// pre-policy passwords) can still authenticate. New/changed passwords
+// go through `strongPassword` at register and reset/confirm.
 const loginSchema = Joi.object({
   email: Joi.string().email({ tlds: { allow: false } }).required(),
   password: Joi.string().min(1).required(),
 });
 
-module.exports = { registerSchema, loginSchema };
+const resetConfirmSchema = Joi.object({
+  token: Joi.string().required(),
+  password: strongPassword,
+});
+
+module.exports = { registerSchema, loginSchema, resetConfirmSchema };

--- a/test/login_page_error_test.dart
+++ b/test/login_page_error_test.dart
@@ -38,8 +38,8 @@ void main() {
     );
 
     await tester.enterText(find.byType(TextFormField).at(0), 'a@b.com');
-    // Password must satisfy minimum length validation.
-    await tester.enterText(find.byType(TextFormField).at(1), 'wrongpwd');
+    // Password must satisfy client-side validation (>=8 chars, letter + digit).
+    await tester.enterText(find.byType(TextFormField).at(1), 'Wrongpwd1');
     await tester.tap(find.widgetWithText(ElevatedButton, 'Login'));
     await tester.pumpAndSettle();
 

--- a/test/login_validation_test.dart
+++ b/test/login_validation_test.dart
@@ -22,11 +22,19 @@ void main() {
     });
 
     test('too short password', () {
-      expect(validatePassword('123'), 'Password must be at least 6 characters');
+      expect(validatePassword('Aa1!'), 'Password must be at least 8 characters');
+    });
+
+    test('missing letter', () {
+      expect(validatePassword('12345678'), 'Password must contain a letter');
+    });
+
+    test('missing digit', () {
+      expect(validatePassword('abcdefgh'), 'Password must contain a number');
     });
 
     test('valid password', () {
-      expect(validatePassword('123456'), isNull);
+      expect(validatePassword('Passw0rd'), isNull);
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 1 of the inherited-repo improvement plan: close the critical security gaps surfaced during code review.

- **JWT**: server now refuses to start without `JWT_SECRET` set (previously fell back to literal `'secretkey'`).
- **CORS**: replaced wildcard `cors()` with an allowlist read from the new `CORS_ORIGINS` env var.
- **Rate limiting**: extended past `/api/auth` — global 300/min, write-heavy routes (items, maintenance, bulletin, lostfound, gallery, suggestions) capped at 30 non-GET req/min.
- **File uploads**: shared `imageUploader()` / `documentUploader()` middleware enforcing MIME allowlist, size caps (5 MB images / 15 MB documents), single-file uploads, and crypto-random filenames. Six route files de-duplicated.
- **Dependencies**: multer 1.4.5-lts → 2.x (1.x deprecated/CVEs), nodemailer 7.x → 8.x (SMTP-command-injection advisories).
- **Password policy**: 6-char → 8-char minimum + at least one letter and one digit, enforced on register and reset/confirm. Login remains lenient so legacy users still authenticate.
- **Flutter deps**: pinned `http: ^1.4.0` and `test: ^1.25.0` (were `any`).

## Notes

- Existing users keep their passwords — the new policy only gates new registrations and resets.
- `server/.env.example` updated with `JWT_SECRET` and `CORS_ORIGINS` documentation. Deployment configs need a real `JWT_SECRET` set before the next release or the server will refuse to start.
- `server/package-lock.json` is intentionally not committed (matches prior repo state, commit f60d5b0).

## Test plan

- [x] `cd server && npm test` — 51/51 passing
- [ ] `flutter pub get`
- [ ] `flutter test`
- [ ] `flutter analyze`
- [ ] Smoke-test login + register against a server with a real `JWT_SECRET` set
- [ ] Confirm CORS preflight from the configured origins succeeds and unknown origins are rejected
- [ ] Try uploading a non-image to `/api/users/me/avatar` and confirm it 400s with `Unsupported file type`