### PR TITLE
Fix calendar-tab test overflow and split CI into parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,19 @@
-name: Flutter CI
+name: CI
 
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 jobs:
-  build:
+  flutter:
+    name: Flutter
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # ─────────── Set up & cache Flutter SDK ───────────
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -23,9 +24,8 @@ jobs:
           cache-path: '${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:'
           architecture: x64
 
-      # ─────────── Cache Flutter (pub) dependencies ───────────
-      - name: Cache Flutter pub‐cache
-        uses: actions/cache@v3
+      - name: Cache Flutter pub-cache
+        uses: actions/cache@v4
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-flutter-pub-${{ hashFiles('**/pubspec.yaml') }}
@@ -35,21 +35,25 @@ jobs:
       - name: Install Flutter dependencies
         run: flutter pub get
 
-      # ─────────── Run Flutter tests ───────────
       - name: Run Flutter tests
         run: flutter test
- 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
 
-      # ─────────── Cache npm dependencies ───────────
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Cache npm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
-          # Make sure this path matches where your package.json lives:
           key: ${{ runner.os }}-node-${{ hashFiles('server/package.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
@@ -60,4 +64,6 @@ jobs:
 
       - name: Run npm tests
         working-directory: server
+        env:
+          JWT_SECRET: ci-only-secret-do-not-use-in-prod
         run: npm test

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -35,10 +35,22 @@ class FakeItemService extends ItemService {
   Future<List<Item>> fetchItems() async => items;
 }
 
+// CalendarPage hosts TableCalendar + filter row + Expanded(ListView). Default
+// test viewport (~484px tall in Scaffold body) is shorter than the fixed
+// children, so navigating to the calendar tab overflows by ~12px. Real devices
+// are >600px and unaffected; tests that exercise the calendar tab use a taller
+// surface.
+void _useTallSurface(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 1200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
 void main() {
   testWidgets('Bottom navigation changes pages and FAB visibility', (
     tester,
   ) async {
+    _useTallSurface(tester);
     final fakeEventService = FakeEventService();
     final fakeMaintenanceService = FakeMaintenanceService();
 
@@ -100,6 +112,7 @@ void main() {
   });
 
   testWidgets('FAB on calendar tab opens add event dialog', (tester) async {
+    _useTallSurface(tester);
     final fakeEventService = FakeEventService();
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Unblocks CI so #176 (auth/CORS/uploads hardening) can land with a green build. Two narrowly-scoped changes:

- **Test fix**: two main_page_test cases that tap the Calendar tab were failing in CI with \`RenderFlex overflowed by 12 pixels\`. CalendarPage's Column (TableCalendar + filter row + Expanded list) is taller than the default 800x600 test surface allows in the Scaffold body (~484px usable). Real devices (>600px) are unaffected. Fixed by bumping the test surface to 800x1200 for the two affected tests only.
- **CI restructure**: split \`.github/workflows/main.yml\` into independent \`flutter\` and \`server\` jobs that run in parallel. Previously the server tests never ran when Flutter tests failed first. Also bumps Node 16 → 20 LTS, action versions to v4, and adds \`push: main\` so we get signal on main itself.

## Notes

- This PR is intentionally narrow so it can land independently. Stacked-first ahead of #176.
- I do not have Flutter installed locally to verify the test-surface bump, but the change is mechanical and uses the standard \`tester.view.physicalSize\` + \`addTearDown(tester.view.reset)\` pattern. CI on this PR will confirm.

## Test plan

- [ ] Flutter job goes green (in particular the two previously-failing main_page_test cases)
- [ ] Server job goes green
- [ ] Both jobs report independently