### PR TITLE
Classify upload/CORS errors and honour trust-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ app.*.map.json
 
 # Node server
 server/node_modules/
+
+# Server upload directory — keep the placeholder but ignore uploaded files
+server/uploads/*
+!server/uploads/.gitkeep

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,10 @@ JWT_SECRET=change-me-to-a-long-random-string
 #   CORS_ORIGINS=https://app.example.com,https://admin.example.com
 # Use "*" only for local development.
 CORS_ORIGINS=*
+
+# When deployed behind a reverse proxy (nginx, Cloudflare, etc.), set the
+# number of hops to trust so req.ip and rate limits use the real client IP.
+# Leave unset for local dev. Examples:
+#   TRUST_PROXY=1       # one proxy in front of the server
+#   TRUST_PROXY=loopback
+#TRUST_PROXY=

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,16 @@ const logger = createLogger({
 });
 
 const app = express();
+
+// Trust proxy headers when deployed behind nginx/Cloudflare/etc. so that
+// express-rate-limit, req.ip, and req.protocol see the real client. Disabled
+// by default to avoid IP spoofing in setups without a proxy.
+const trustProxy = process.env.TRUST_PROXY;
+if (trustProxy) {
+  const numeric = Number(trustProxy);
+  app.set('trust proxy', Number.isFinite(numeric) ? numeric : trustProxy);
+}
+
 const corsOptions =
   corsOrigins === '*'
     ? { origin: true }
@@ -35,7 +45,9 @@ const corsOptions =
         origin: (origin, cb) => {
           if (!origin) return cb(null, true);
           if (corsOrigins.includes(origin)) return cb(null, true);
-          return cb(new Error(`Origin ${origin} not allowed by CORS`));
+          const err = new Error(`Origin ${origin} not allowed by CORS`);
+          err.status = 403;
+          return cb(err);
         },
       };
 app.use(cors(corsOptions));

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+function statusFor(err) {
+  if (err.status) return err.status;
+  if (err.name === 'MulterError') {
+    return err.code === 'LIMIT_FILE_SIZE' || err.code === 'LIMIT_FILE_COUNT'
+      ? 413
+      : 400;
+  }
+  if (err.name === 'ValidationError') return 400;
+  return 500;
+}
+
 function errorHandler(err, req, res, next) {
-  // Log unexpected errors for debugging
-  if (!err.status || err.status >= 500) {
+  const status = statusFor(err);
+  if (status >= 500) {
     console.error(err);
   }
-  const status = err.status || (err.name === 'ValidationError' ? 400 : 500);
   res.status(status).json({ error: err.message });
 }
 

--- a/server/middleware/uploads.js
+++ b/server/middleware/uploads.js
@@ -60,7 +60,9 @@ function makeStorage() {
 function makeFileFilter(whitelist) {
   return (req, file, cb) => {
     if (whitelist.has(file.mimetype)) return cb(null, true);
-    cb(new Error(`Unsupported file type: ${file.mimetype}`));
+    const err = new Error(`Unsupported file type: ${file.mimetype}`);
+    err.status = 400;
+    cb(err);
   };
 }
 

--- a/server/tests/uploads.test.js
+++ b/server/tests/uploads.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+const request = require('supertest');
+const express = require('express');
+const { imageUploader } = require('../middleware/uploads');
+const errorHandler = require('../middleware/errorHandler');
+
+const UPLOAD_DIR = path.join(__dirname, '..', 'uploads');
+const createdFiles = [];
+
+function rememberCreated(res) {
+  if (res.body && res.body.filename) createdFiles.push(res.body.filename);
+}
+
+afterAll(() => {
+  for (const name of createdFiles) {
+    try {
+      fs.unlinkSync(path.join(UPLOAD_DIR, name));
+    } catch (_) {
+      // already gone — ignore
+    }
+  }
+});
+
+function buildApp({ maxBytes } = {}) {
+  const app = express();
+  const upload = imageUploader(maxBytes ? { maxBytes } : undefined);
+  app.post('/upload', upload.single('image'), (req, res) => {
+    res.status(200).json({ filename: req.file && req.file.filename });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe('Upload error classification', () => {
+  test('accepts a valid PNG', async () => {
+    const app = buildApp();
+    // 8-byte PNG signature is enough for Multer to accept the part; the MIME
+    // type comes from the supertest `contentType` argument, not the bytes.
+    const pngHeader = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    const res = await request(app)
+      .post('/upload')
+      .attach('image', pngHeader, { filename: 'pixel.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+    expect(res.body.filename).toMatch(/\.png$/);
+    rememberCreated(res);
+  });
+
+  test('rejects an unsupported MIME type with 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/upload')
+      .attach('image', Buffer.from('hello'), {
+        filename: 'note.txt',
+        contentType: 'text/plain',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unsupported file type/);
+  });
+
+  test('rejects an oversize file with 413', async () => {
+    const app = buildApp({ maxBytes: 10 });
+    const res = await request(app)
+      .post('/upload')
+      .attach('image', Buffer.alloc(64, 0xff), {
+        filename: 'big.png',
+        contentType: 'image/png',
+      });
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/File too large|file size/i);
+  });
+});


### PR DESCRIPTION
## Summary

Two narrow follow-ups to #176:

1. Map upload + CORS rejections to the right HTTP status instead of falling through to 500:
   - Multer \`LIMIT_FILE_SIZE\` / \`LIMIT_FILE_COUNT\` → **413**
   - Other Multer error codes → **400**
   - \`imageUploader\`/\`documentUploader\` MIME-rejection error now tagged \`status: 400\`
   - CORS allowlist rejection error now tagged \`status: 403\`

2. Add \`TRUST_PROXY\` env var so \`express-rate-limit\` and \`req.ip\` see the real client behind nginx/Cloudflare/etc. Disabled by default to avoid spoofing in setups without a proxy.

Plus 3 new tests covering the upload/error path end-to-end, and a \`.gitignore\` entry so accidentally-created uploads don't get committed.

## Test plan

- [x] \`cd server && npm test\` — 54/54 passing locally
- [ ] CI passes
- [ ] Manual: deploy with \`TRUST_PROXY=1\` behind a proxy and confirm \`req.ip\` resolves correctly
- [ ] Manual: try uploading an .mp3 to an image endpoint and confirm the response is 400, not 500