### PR TITLE
Add Riverpod foundation and migrate ItemExchangePage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'pages/login_page.dart';
 import 'pages/main_page.dart';
 import 'pages/register_page.dart';
@@ -55,7 +56,7 @@ void main() async {
     }
   }
 
-  runApp(const OlyApp());
+  runApp(const ProviderScope(child: OlyApp()));
 }
 
 class OlyApp extends StatefulWidget {

--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -1,31 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../providers/item_providers.dart';
+import '../services/item_service.dart';
 import '../widgets/item_card.dart';
 import 'item_detail_page.dart';
 import 'post_item_page.dart';
-import '../models/models.dart';
-import '../services/item_service.dart';
-import '../utils/item_filter.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 
-class ItemExchangePage extends StatefulWidget {
+class ItemExchangePage extends StatelessWidget {
+  /// Optional service override. Mainly used by widget tests; production
+  /// callers rely on the top-level [ProviderScope] in main.dart.
   final ItemService? service;
+
   const ItemExchangePage({super.key, this.service});
 
   @override
-  State<ItemExchangePage> createState() => _ItemExchangePageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _ItemExchangeBody();
+    }
+    return ProviderScope(
+      overrides: [itemServiceProvider.overrideWithValue(service!)],
+      child: const _ItemExchangeBody(),
+    );
+  }
 }
 
-class _ItemExchangePageState extends State<ItemExchangePage> {
-  late final ItemService _service;
+class _ItemExchangeBody extends ConsumerStatefulWidget {
+  const _ItemExchangeBody();
+
+  @override
+  ConsumerState<_ItemExchangeBody> createState() => _ItemExchangeBodyState();
+}
+
+class _ItemExchangeBodyState extends ConsumerState<_ItemExchangeBody> {
   final _searchCtrl = TextEditingController();
   final _minPriceCtrl = TextEditingController();
   final _maxPriceCtrl = TextEditingController();
-  String _selectedCategory = 'All';
-  bool _onlyFavorites = false;
-  String _sortOrder = 'newest';
-  bool _loading = false;
 
-  final _categories = [
+  static const _categories = [
     'All',
     'Furniture',
     'Books',
@@ -34,85 +48,22 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
     'Clothing',
   ];
 
-  List<Item> _allItems = [];
-  List<Item> _filteredItems = [];
-
-  Set<int> _favoriteIds() {
-    final box = Hive.box('favoritesBox');
-    return (box.get('ids', defaultValue: const <int>[]) as List)
-        .cast<int>()
-        .toSet();
-  }
-
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? ItemService();
-    _loadItems();
-  }
-
-  Future<void> _loadItems() async {
-    setState(() => _loading = true);
-    try {
-      final items = await _service.fetchItems();
-      if (!mounted) return;
-      setState(() {
-        _allItems = items;
-        _filteredItems = List.from(_allItems);
-        _loading = false;
-      });
-      _filter();
-    } finally {
-      if (mounted && _loading) setState(() => _loading = false);
-    }
-  }
-
-  void _filter() {
-    final query = _searchCtrl.text;
-    final minPrice = double.tryParse(_minPriceCtrl.text);
-    final maxPrice = double.tryParse(_maxPriceCtrl.text);
-    setState(() {
-      var results = filterItems(_allItems, query, _selectedCategory);
-      if (minPrice != null) {
-        results = results
-            .where((item) => (item.price ?? 0) >= minPrice)
-            .toList();
-      }
-      if (maxPrice != null) {
-        results = results
-            .where((item) => (item.price ?? 0) <= maxPrice)
-            .toList();
-      }
-      if (_onlyFavorites) {
-        final favs = _favoriteIds();
-        results = results
-            .where((item) => item.id != null && favs.contains(item.id))
-            .toList();
-      }
-      switch (_sortOrder) {
-        case 'priceAsc':
-          results.sort(
-            (a, b) => (a.price ?? double.infinity).compareTo(
-              b.price ?? double.infinity,
-            ),
-          );
-          break;
-        case 'priceDesc':
-          results.sort(
-            (a, b) => (b.price ?? -double.infinity).compareTo(
-              a.price ?? -double.infinity,
-            ),
-          );
-          break;
-        default:
-          results.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-      }
-      _filteredItems = results;
-    });
+  void dispose() {
+    _searchCtrl.dispose();
+    _minPriceCtrl.dispose();
+    _maxPriceCtrl.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final itemsAsync = ref.watch(itemsProvider);
+    final filters = ref.watch(itemFiltersProvider);
+    final filteredItems = ref.watch(filteredItemsProvider);
+    final favorites = ref.watch(favoritesProvider);
+    final filtersNotifier = ref.read(itemFiltersProvider.notifier);
+
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -136,12 +87,12 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                         borderSide: BorderSide.none,
                       ),
                     ),
-                    onChanged: (_) => _filter(),
+                    onChanged: filtersNotifier.setSearch,
                   ),
                 ),
                 IconButton(
                   icon: const Icon(Icons.refresh),
-                  onPressed: _loadItems,
+                  onPressed: () => ref.invalidate(itemsProvider),
                 ),
               ],
             ),
@@ -156,16 +107,11 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                 separatorBuilder: (_, __) => const SizedBox(width: 8),
                 itemBuilder: (ctx, i) {
                   final cat = _categories[i];
-                  final selected = cat == _selectedCategory;
+                  final selected = cat == filters.selectedCategory;
                   return ChoiceChip(
                     label: Text(cat),
                     selected: selected,
-                    onSelected: (_) {
-                      setState(() {
-                        _selectedCategory = cat;
-                        _filter();
-                      });
-                    },
+                    onSelected: (_) => filtersNotifier.setCategory(cat),
                   );
                 },
               ),
@@ -177,13 +123,8 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
               alignment: Alignment.centerLeft,
               child: FilterChip(
                 label: const Text('Favorites'),
-                selected: _onlyFavorites,
-                onSelected: (val) {
-                  setState(() {
-                    _onlyFavorites = val;
-                    _filter();
-                  });
-                },
+                selected: filters.onlyFavorites,
+                onSelected: filtersNotifier.setOnlyFavorites,
               ),
             ),
 
@@ -198,7 +139,8 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                     ),
-                    onChanged: (_) => _filter(),
+                    onChanged: (val) =>
+                        filtersNotifier.setMinPrice(double.tryParse(val)),
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -209,7 +151,8 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
                     keyboardType: const TextInputType.numberWithOptions(
                       decimal: true,
                     ),
-                    onChanged: (_) => _filter(),
+                    onChanged: (val) =>
+                        filtersNotifier.setMaxPrice(double.tryParse(val)),
                   ),
                 ),
               ],
@@ -219,14 +162,11 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
 
             DropdownButton<String>(
               key: const ValueKey('sortDropdown'),
-              value: _sortOrder,
+              value: filters.sortOrder,
               isExpanded: true,
               onChanged: (val) {
                 if (val == null) return;
-                setState(() {
-                  _sortOrder = val;
-                  _filter();
-                });
+                filtersNotifier.setSortOrder(val);
               },
               items: const [
                 DropdownMenuItem(value: 'newest', child: Text('Newest')),
@@ -246,72 +186,65 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
             // Grid of items
             Expanded(
               child: RefreshIndicator(
-                onRefresh: _loadItems,
-                child: _loading
+                onRefresh: () async => ref.invalidate(itemsProvider),
+                child: itemsAsync.isLoading
                     ? const Center(child: CircularProgressIndicator())
-                    : _filteredItems.isEmpty
+                    : filteredItems.isEmpty
                         ? const Center(child: Text('No items found.'))
                         : GridView.builder(
                             gridDelegate:
                                 const SliverGridDelegateWithFixedCrossAxisCount(
-                                  crossAxisCount: 2,
-                                  mainAxisSpacing: 12,
-                                  crossAxisSpacing: 12,
-                                  childAspectRatio: 0.8,
-                                ),
-                            itemCount: _filteredItems.length,
+                              crossAxisCount: 2,
+                              mainAxisSpacing: 12,
+                              crossAxisSpacing: 12,
+                              childAspectRatio: 0.8,
+                            ),
+                            itemCount: filteredItems.length,
                             itemBuilder: (ctx, idx) {
-                          final item = _filteredItems[idx];
-                          final favs = _favoriteIds();
-                          final isFav =
-                              item.id != null && favs.contains(item.id);
-                          return Stack(
-                            children: [
-                              InkWell(
-                                borderRadius: BorderRadius.circular(12),
-                                onTap: () {
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (_) =>
-                                          ItemDetailPage(item: item),
-                                    ),
-                                  );
-                                },
-                                child: ItemCard(
-                                  title: item.title,
-                                  averageRating: item.ratings.isNotEmpty
-                                      ? item.averageRating
-                                      : null,
-                                ),
-                              ),
-                              if (item.id != null)
-                                Positioned(
-                                  top: 0,
-                                  right: 0,
-                                  child: IconButton(
-                                    key: Key('toggleFavorite_${item.id}'),
-                                    icon: Icon(
-                                      isFav ? Icons.star : Icons.star_border,
-                                      color: Colors.amber,
-                                    ),
-                                    onPressed: () {
-                                      final box = Hive.box('favoritesBox');
-                                      final set = favs.toSet();
-                                      if (isFav) {
-                                        set.remove(item.id);
-                                      } else {
-                                        set.add(item.id as int);
-                                      }
-                                      box.put('ids', set.toList());
-                                      _filter();
+                              final item = filteredItems[idx];
+                              final isFav =
+                                  item.id != null && favorites.contains(item.id);
+                              return Stack(
+                                children: [
+                                  InkWell(
+                                    borderRadius: BorderRadius.circular(12),
+                                    onTap: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (_) =>
+                                              ItemDetailPage(item: item),
+                                        ),
+                                      );
                                     },
+                                    child: ItemCard(
+                                      title: item.title,
+                                      averageRating: item.ratings.isNotEmpty
+                                          ? item.averageRating
+                                          : null,
+                                    ),
                                   ),
-                                ),
-                            ],
-                          );
-                        },
-                      ),
+                                  if (item.id != null)
+                                    Positioned(
+                                      top: 0,
+                                      right: 0,
+                                      child: IconButton(
+                                        key: Key('toggleFavorite_${item.id}'),
+                                        icon: Icon(
+                                          isFav
+                                              ? Icons.star
+                                              : Icons.star_border,
+                                          color: Colors.amber,
+                                        ),
+                                        onPressed: () => ref
+                                            .read(favoritesProvider.notifier)
+                                            .toggle(item.id as int),
+                                      ),
+                                    ),
+                                ],
+                              );
+                            },
+                          ),
               ),
             ),
           ],
@@ -326,8 +259,8 @@ class _ItemExchangePageState extends State<ItemExchangePage> {
             context,
             MaterialPageRoute(builder: (_) => const PostItemPage()),
           );
-          if (created == true) {
-            _loadItems();
+          if (created == true && mounted) {
+            ref.invalidate(itemsProvider);
           }
         },
         child: const Icon(Icons.add),

--- a/lib/providers/item_providers.dart
+++ b/lib/providers/item_providers.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/models.dart';
+import '../services/item_service.dart';
+import '../utils/item_filter.dart';
+
+/// Single source of truth for the [ItemService] instance.
+/// Overridden in tests via [ProviderScope.overrides].
+final itemServiceProvider = Provider<ItemService>((ref) => ItemService());
+
+/// Loads the catalogue of items. Refresh by invalidating the provider
+/// (e.g. `ref.invalidate(itemsProvider)`).
+final itemsProvider = FutureProvider<List<Item>>((ref) async {
+  final service = ref.watch(itemServiceProvider);
+  return service.fetchItems();
+});
+
+/// Filter and sort settings for the item exchange page.
+class ItemFilters {
+  final String search;
+  final String selectedCategory;
+  final double? minPrice;
+  final double? maxPrice;
+  final bool onlyFavorites;
+  final String sortOrder;
+
+  const ItemFilters({
+    this.search = '',
+    this.selectedCategory = 'All',
+    this.minPrice,
+    this.maxPrice,
+    this.onlyFavorites = false,
+    this.sortOrder = 'newest',
+  });
+
+  ItemFilters copyWith({
+    String? search,
+    String? selectedCategory,
+    Object? minPrice = _sentinel,
+    Object? maxPrice = _sentinel,
+    bool? onlyFavorites,
+    String? sortOrder,
+  }) {
+    return ItemFilters(
+      search: search ?? this.search,
+      selectedCategory: selectedCategory ?? this.selectedCategory,
+      minPrice: identical(minPrice, _sentinel) ? this.minPrice : minPrice as double?,
+      maxPrice: identical(maxPrice, _sentinel) ? this.maxPrice : maxPrice as double?,
+      onlyFavorites: onlyFavorites ?? this.onlyFavorites,
+      sortOrder: sortOrder ?? this.sortOrder,
+    );
+  }
+
+  static const _sentinel = Object();
+}
+
+class ItemFiltersNotifier extends Notifier<ItemFilters> {
+  @override
+  ItemFilters build() => const ItemFilters();
+
+  void setSearch(String value) => state = state.copyWith(search: value);
+  void setCategory(String value) => state = state.copyWith(selectedCategory: value);
+  void setMinPrice(double? value) => state = state.copyWith(minPrice: value);
+  void setMaxPrice(double? value) => state = state.copyWith(maxPrice: value);
+  void setOnlyFavorites(bool value) => state = state.copyWith(onlyFavorites: value);
+  void setSortOrder(String value) => state = state.copyWith(sortOrder: value);
+}
+
+final itemFiltersProvider =
+    NotifierProvider<ItemFiltersNotifier, ItemFilters>(ItemFiltersNotifier.new);
+
+/// Favorites are persisted in the Hive `favoritesBox`. The notifier mirrors
+/// the box so widgets re-render on toggle without re-reading Hive directly.
+class FavoritesNotifier extends Notifier<Set<int>> {
+  static const _boxName = 'favoritesBox';
+  static const _key = 'ids';
+
+  @override
+  Set<int> build() {
+    if (!Hive.isBoxOpen(_boxName)) return <int>{};
+    final box = Hive.box(_boxName);
+    return (box.get(_key, defaultValue: const <int>[]) as List).cast<int>().toSet();
+  }
+
+  void toggle(int id) {
+    final next = state.toSet();
+    if (!next.add(id)) next.remove(id);
+    state = next;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_key, next.toList());
+    }
+  }
+}
+
+final favoritesProvider =
+    NotifierProvider<FavoritesNotifier, Set<int>>(FavoritesNotifier.new);
+
+/// The item list after the user's current filters, favorites, and sort.
+final filteredItemsProvider = Provider<List<Item>>((ref) {
+  final items = ref.watch(itemsProvider).valueOrNull ?? const <Item>[];
+  final filters = ref.watch(itemFiltersProvider);
+  final favorites = ref.watch(favoritesProvider);
+
+  var results = filterItems(items, filters.search, filters.selectedCategory);
+  if (filters.minPrice != null) {
+    results = results.where((item) => (item.price ?? 0) >= filters.minPrice!).toList();
+  }
+  if (filters.maxPrice != null) {
+    results = results.where((item) => (item.price ?? 0) <= filters.maxPrice!).toList();
+  }
+  if (filters.onlyFavorites) {
+    results = results
+        .where((item) => item.id != null && favorites.contains(item.id))
+        .toList();
+  }
+  switch (filters.sortOrder) {
+    case 'priceAsc':
+      results.sort((a, b) =>
+          (a.price ?? double.infinity).compareTo(b.price ?? double.infinity));
+      break;
+    case 'priceDesc':
+      results.sort((a, b) =>
+          (b.price ?? -double.infinity).compareTo(a.price ?? -double.infinity));
+      break;
+    default:
+      results.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  }
+  return results;
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
   file_picker: ^6.1.1
   fl_chart: ^1.0.0
   google_fonts: ^6.1.0
+
+  flutter_riverpod: ^2.6.1
 dev_dependencies:
   test: ^1.25.0
   flutter_test:


### PR DESCRIPTION
## Summary

Phase 3 of the inherited-repo improvement plan: introduce state management. Picks Riverpod (\`flutter_riverpod: ^2.6.1\`, no codegen) and migrates one page as a template before tackling the rest.

**Two commits:**
1. \`add Riverpod foundation with item-exchange providers\` — adds dependency, wraps \`runApp\` in \`ProviderScope\`, adds \`lib/providers/item_providers.dart\` with itemService / items / filters / filtered / favorites providers.
2. \`migrate ItemExchangePage to ConsumerStatefulWidget\` — replaces the local \`setState/_filter\` pattern with providers, swaps the inline Hive favorites read for the new \`favoritesProvider\`.

## Backward compat

\`ItemExchangePage(service: someService)\` still works. When the optional \`service:\` is set, the page wraps its body in a nested \`ProviderScope\` that overrides \`itemServiceProvider\`, so the seven existing widget tests and the \`main_page_test\` exchange-tab case don't need any changes.

## Scope

Only ItemExchangePage is migrated. PostItemPage, ItemDetailPage, and the rest still instantiate \`ItemService\` directly — they're unaffected and will be moved over in follow-up PRs once this pattern proves out.

## Test plan

- [ ] CI: Flutter job green (no Flutter SDK locally, so this is the first verification)
- [ ] CI: server job green (untouched, expected green)
- [ ] Manual: load Exchange tab, toggle favorites, change filters/sort, confirm grid updates
- [ ] Manual: post a new item via FAB and confirm grid refreshes