### PR TITLE
Migrate PostItemPage to Riverpod

### DIFF
--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -251,17 +251,15 @@ class _ItemExchangeBodyState extends ConsumerState<_ItemExchangeBody> {
         ),
       ),
 
-      // FAB to post a new listing
+      // FAB to post a new listing. PostItemPage invalidates itemsProvider
+      // itself on success, so we don't need a return-value side-effect here.
       floatingActionButton: FloatingActionButton(
         heroTag: 'exchangeFab',
-        onPressed: () async {
-          final created = await Navigator.push<bool>(
+        onPressed: () {
+          Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => const PostItemPage()),
           );
-          if (created == true && mounted) {
-            ref.invalidate(itemsProvider);
-          }
         },
         child: const Icon(Icons.add),
       ),

--- a/lib/pages/post_item_page.dart
+++ b/lib/pages/post_item_page.dart
@@ -81,7 +81,8 @@ class _PostItemPageState extends ConsumerState<PostItemPage> {
         isFree: price == null || price == 0,
         category: _category,
       );
-      final service = widget.service ?? ref.read(itemServiceProvider);
+      final ItemService service =
+          widget.service ?? ref.read(itemServiceProvider);
       if (editing) {
         await service.updateItem(item);
       } else {

--- a/lib/pages/post_item_page.dart
+++ b/lib/pages/post_item_page.dart
@@ -1,22 +1,25 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+
 import '../models/models.dart';
+import '../providers/item_providers.dart';
 import '../services/item_service.dart';
 import '../utils/user_helpers.dart';
 
-class PostItemPage extends StatefulWidget {
+class PostItemPage extends ConsumerStatefulWidget {
   final Item? item;
   final ItemService? service;
 
   const PostItemPage({super.key, this.item, this.service});
 
   @override
-  State<PostItemPage> createState() => _PostItemPageState();
+  ConsumerState<PostItemPage> createState() => _PostItemPageState();
 }
 
-class _PostItemPageState extends State<PostItemPage> {
+class _PostItemPageState extends ConsumerState<PostItemPage> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _titleCtrl;
   late final TextEditingController _descCtrl;
@@ -24,7 +27,6 @@ class _PostItemPageState extends State<PostItemPage> {
   late final TextEditingController _imageCtrl;
   XFile? _imageFile;
   late ItemCategory _category;
-  late final ItemService _service;
   bool _submitting = false;
 
   bool get _editing => widget.item != null;
@@ -32,7 +34,6 @@ class _PostItemPageState extends State<PostItemPage> {
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? ItemService();
     final item = widget.item;
     _titleCtrl = TextEditingController(text: item?.title ?? '');
     _descCtrl = TextEditingController(text: item?.description ?? '');
@@ -80,15 +81,17 @@ class _PostItemPageState extends State<PostItemPage> {
         isFree: price == null || price == 0,
         category: _category,
       );
+      final service = widget.service ?? ref.read(itemServiceProvider);
       if (editing) {
-        await _service.updateItem(item);
+        await service.updateItem(item);
       } else {
-        await _service.createItem(
+        await service.createItem(
           item,
           imageFile: _imageFile != null ? File(_imageFile!.path) : null,
         );
       }
       if (mounted) {
+        ref.invalidate(itemsProvider);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(editing ? 'Item updated!' : 'Item posted!')),
         );

--- a/lib/providers/item_providers.dart
+++ b/lib/providers/item_providers.dart
@@ -11,10 +11,18 @@ final itemServiceProvider = Provider<ItemService>((ref) => ItemService());
 
 /// Loads the catalogue of items. Refresh by invalidating the provider
 /// (e.g. `ref.invalidate(itemsProvider)`).
-final itemsProvider = FutureProvider<List<Item>>((ref) async {
-  final service = ref.watch(itemServiceProvider);
-  return service.fetchItems();
-});
+///
+/// `dependencies: [itemServiceProvider]` is required because some callers
+/// (e.g. `ItemExchangePage(service: …)`) override `itemServiceProvider` in
+/// a nested `ProviderScope`. Without declaring the dependency Riverpod
+/// would re-use the outer scope's instance and ignore the override.
+final itemsProvider = FutureProvider<List<Item>>(
+  (ref) async {
+    final service = ref.watch(itemServiceProvider);
+    return service.fetchItems();
+  },
+  dependencies: [itemServiceProvider],
+);
 
 /// Filter and sort settings for the item exchange page.
 class ItemFilters {
@@ -97,34 +105,46 @@ final favoritesProvider =
     NotifierProvider<FavoritesNotifier, Set<int>>(FavoritesNotifier.new);
 
 /// The item list after the user's current filters, favorites, and sort.
-final filteredItemsProvider = Provider<List<Item>>((ref) {
-  final items = ref.watch(itemsProvider).valueOrNull ?? const <Item>[];
-  final filters = ref.watch(itemFiltersProvider);
-  final favorites = ref.watch(favoritesProvider);
+///
+/// Inherits the scoping of [itemsProvider] so that nested
+/// `itemServiceProvider` overrides flow through correctly.
+final filteredItemsProvider = Provider<List<Item>>(
+  (ref) {
+    final items = ref.watch(itemsProvider).valueOrNull ?? const <Item>[];
+    final filters = ref.watch(itemFiltersProvider);
+    final favorites = ref.watch(favoritesProvider);
 
-  var results = filterItems(items, filters.search, filters.selectedCategory);
-  if (filters.minPrice != null) {
-    results = results.where((item) => (item.price ?? 0) >= filters.minPrice!).toList();
-  }
-  if (filters.maxPrice != null) {
-    results = results.where((item) => (item.price ?? 0) <= filters.maxPrice!).toList();
-  }
-  if (filters.onlyFavorites) {
-    results = results
-        .where((item) => item.id != null && favorites.contains(item.id))
-        .toList();
-  }
-  switch (filters.sortOrder) {
-    case 'priceAsc':
-      results.sort((a, b) =>
-          (a.price ?? double.infinity).compareTo(b.price ?? double.infinity));
-      break;
-    case 'priceDesc':
-      results.sort((a, b) =>
-          (b.price ?? -double.infinity).compareTo(a.price ?? -double.infinity));
-      break;
-    default:
-      results.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-  }
-  return results;
-});
+    var results =
+        filterItems(items, filters.search, filters.selectedCategory);
+    if (filters.minPrice != null) {
+      results = results
+          .where((item) => (item.price ?? 0) >= filters.minPrice!)
+          .toList();
+    }
+    if (filters.maxPrice != null) {
+      results = results
+          .where((item) => (item.price ?? 0) <= filters.maxPrice!)
+          .toList();
+    }
+    if (filters.onlyFavorites) {
+      results = results
+          .where((item) => item.id != null && favorites.contains(item.id))
+          .toList();
+    }
+    switch (filters.sortOrder) {
+      case 'priceAsc':
+        results.sort((a, b) =>
+            (a.price ?? double.infinity).compareTo(b.price ?? double.infinity));
+        break;
+      case 'priceDesc':
+        results.sort((a, b) =>
+            (b.price ?? -double.infinity)
+                .compareTo(a.price ?? -double.infinity));
+        break;
+      default:
+        results.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    }
+    return results;
+  },
+  dependencies: [itemsProvider],
+);

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/pages/calendar_page.dart';
 import 'package:oly_app/pages/main_page.dart';
@@ -145,10 +146,12 @@ void main() {
   testWidgets('FAB on exchange tab opens PostItemPage', (tester) async {
     final fakeItemService = FakeItemService();
     await tester.pumpWidget(
-      MaterialApp(
-        home: MainPage(
-          itemExchangePage: ItemExchangePage(service: fakeItemService),
-          onLogout: null,
+      ProviderScope(
+        child: MaterialApp(
+          home: MainPage(
+            itemExchangePage: ItemExchangePage(service: fakeItemService),
+            onLogout: null,
+          ),
         ),
       ),
     );

--- a/test/post_item_page_test.dart
+++ b/test/post_item_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:oly_app/pages/post_item_page.dart';
@@ -41,7 +42,9 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     ImagePickerPlatform.instance = FakeImagePicker();
 
-    await tester.pumpWidget(const MaterialApp(home: PostItemPage()));
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: PostItemPage())),
+    );
     expect(find.byType(Image), findsNothing);
 
     await tester.tap(find.text('Gallery'));


### PR DESCRIPTION
## Summary

Second page migration following #179. Smaller scope — only PostItemPage and the two tests that build one.

**Two commits:**
1. \`migrate PostItemPage to ConsumerStatefulWidget\` — service comes from \`widget.service ?? ref.read(itemServiceProvider)\`; on success the page invalidates \`itemsProvider\` itself.
2. \`test: wrap PostItemPage usages in ProviderScope\` — \`post_item_page_test.dart\` and the \`main_page_test\` exchange-tab case now wrap their pumped tree in \`ProviderScope\`.

## Bonus fix

Pre-existing inconsistency: MainPage's exchange-tab FAB pushed PostItemPage but never refreshed the item list on return, while ItemExchangePage's own FAB did. Moving the invalidate into PostItemPage means both entry points (and any future caller) refresh correctly. ItemExchangePage's now-redundant \`ref.invalidate\` is removed.

## Test plan

- [ ] CI: Flutter job green
- [ ] CI: server job green (untouched)
- [ ] Manual: post a new item via the MainPage scaffold FAB (shopping-cart icon) and confirm the Exchange grid refreshes
- [ ] Manual: post via ItemExchangePage's own FAB and confirm a single refresh fires