### PR TITLE
Migrate ItemDetailPage to Riverpod

### DIFF
--- a/lib/pages/item_detail_page.dart
+++ b/lib/pages/item_detail_page.dart
@@ -1,43 +1,51 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
 import '../models/models.dart';
+import '../providers/item_providers.dart';
 import '../services/item_service.dart';
 import 'item_chat_page.dart';
 import 'post_item_page.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 
-class ItemDetailPage extends StatefulWidget {
+class ItemDetailPage extends ConsumerStatefulWidget {
   final Item item;
   final ItemService? service;
 
   const ItemDetailPage({super.key, required this.item, this.service});
 
   @override
-  State<ItemDetailPage> createState() => _ItemDetailPageState();
+  ConsumerState<ItemDetailPage> createState() => _ItemDetailPageState();
 }
 
-class _ItemDetailPageState extends State<ItemDetailPage> {
-  late Item _item;
-  late ItemService _service;
+class _ItemDetailPageState extends ConsumerState<ItemDetailPage> {
+  late final Item _item = widget.item;
   final _ratingCtrl = TextEditingController();
   final _reviewCtrl = TextEditingController();
 
-  @override
-  void initState() {
-    super.initState();
-    _item = widget.item;
-    _service = widget.service ?? ItemService();
+  ItemService _resolveService() {
+    final ItemService service =
+        widget.service ?? ref.read(itemServiceProvider);
+    return service;
   }
 
   Future<void> _requestItem(BuildContext context) async {
     if (_item.id == null) return;
-    final svc = _service;
     final messenger = ScaffoldMessenger.of(context);
     try {
-      await svc.requestItem(_item.id!);
+      await _resolveService().requestItem(_item.id!);
       messenger.showSnackBar(const SnackBar(content: Text('Request sent!')));
+      if (mounted) ref.invalidate(itemsProvider);
     } catch (e) {
       messenger.showSnackBar(SnackBar(content: Text('Failed: $e')));
     }
+  }
+
+  @override
+  void dispose() {
+    _ratingCtrl.dispose();
+    _reviewCtrl.dispose();
+    super.dispose();
   }
 
   @override
@@ -48,7 +56,7 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
       user = Hive.box<User>('userBox').get('currentUser');
     }
     final isOwner = user != null && user.id == _item.ownerId;
-    final favBox = Hive.box('favoritesBox');
+    final favorites = ref.watch(favoritesProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(_item.title),
@@ -57,27 +65,14 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
         elevation: 1,
         actions: [
           if (_item.id != null)
-            ValueListenableBuilder(
-              valueListenable: favBox.listenable(),
-              builder: (context, Box box, _) {
-                final ids =
-                    (box.get('ids', defaultValue: const <int>[]) as List)
-                        .cast<int>();
-                final isFav = ids.contains(_item.id);
-                return IconButton(
-                  key: const Key('toggleFavoriteDetail'),
-                  icon: Icon(isFav ? Icons.star : Icons.star_border),
-                  onPressed: () {
-                    final set = ids.toSet();
-                    if (isFav) {
-                      set.remove(_item.id);
-                    } else {
-                      set.add(_item.id as int);
-                    }
-                    box.put('ids', set.toList());
-                  },
-                );
-              },
+            IconButton(
+              key: const Key('toggleFavoriteDetail'),
+              icon: Icon(
+                favorites.contains(_item.id) ? Icons.star : Icons.star_border,
+              ),
+              onPressed: () => ref
+                  .read(favoritesProvider.notifier)
+                  .toggle(_item.id as int),
             ),
           if (isOwner) ...[
             IconButton(
@@ -87,8 +82,10 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder:
-                        (_) => PostItemPage(item: _item, service: _service),
+                    builder: (_) => PostItemPage(
+                      item: _item,
+                      service: _resolveService(),
+                    ),
                   ),
                 );
               },
@@ -100,27 +97,28 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                 if (_item.id == null) return;
                 final confirm = await showDialog<bool>(
                   context: context,
-                  builder:
-                      (ctx) => AlertDialog(
-                        title: const Text('Delete Item'),
-                        content: const Text(
-                          'Are you sure you want to delete this item?',
-                        ),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.pop(ctx, false),
-                            child: const Text('Cancel'),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.pop(ctx, true),
-                            child: const Text('Delete'),
-                          ),
-                        ],
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Delete Item'),
+                    content: const Text(
+                      'Are you sure you want to delete this item?',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, false),
+                        child: const Text('Cancel'),
                       ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx, true),
+                        child: const Text('Delete'),
+                      ),
+                    ],
+                  ),
                 );
                 if (confirm != true) return;
-                final svc = _service;
-                await svc.deleteItem(_item.id!);
+                await _resolveService().deleteItem(_item.id!);
+                if (mounted) {
+                  ref.invalidate(itemsProvider);
+                }
                 if (context.mounted) Navigator.pop(context, true);
               },
             ),
@@ -159,14 +157,14 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                     ),
                   )
                 : Container(
-                  height: 200,
-                  color: colorScheme.surfaceContainerHighest,
-                  child: Icon(
-                    Icons.image_not_supported,
-                    size: 64,
-                    color: colorScheme.onSurfaceVariant,
+                    height: 200,
+                    color: colorScheme.surfaceContainerHighest,
+                    child: Icon(
+                      Icons.image_not_supported,
+                      size: 64,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                   ),
-                ),
 
             // Details
             Padding(
@@ -223,11 +221,10 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder:
-                                    (_) => ItemChatPage(
-                                      item: _item,
-                                      service: _service,
-                                    ),
+                                builder: (_) => ItemChatPage(
+                                  item: _item,
+                                  service: _resolveService(),
+                                ),
                               ),
                             );
                           },
@@ -269,12 +266,13 @@ class _ItemDetailPageState extends State<ItemDetailPage> {
                       onPressed: () async {
                         if (_item.id == null) return;
                         final rating = int.tryParse(_ratingCtrl.text) ?? 0;
-                        await _service.submitRating(
+                        await _resolveService().submitRating(
                           _item.id!,
                           rating,
                           review: _reviewCtrl.text,
                         );
                         if (context.mounted) {
+                          ref.invalidate(itemsProvider);
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(content: Text('Rating submitted')),
                           );

--- a/test/item_chat_test.dart
+++ b/test/item_chat_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/item_detail_page.dart';
@@ -33,7 +34,11 @@ void main() {
   testWidgets('Chat Owner opens ItemChatPage', (tester) async {
     final item = Item(id: 1, ownerId: '1', title: 'Chair');
     await tester.pumpWidget(
-      MaterialApp(home: ItemDetailPage(item: item, service: FakeItemService())),
+      ProviderScope(
+        child: MaterialApp(
+          home: ItemDetailPage(item: item, service: FakeItemService()),
+        ),
+      ),
     );
 
     await tester.tap(find.text('Chat Owner'));

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/item_exchange_page.dart';
@@ -95,7 +96,9 @@ void main() {
     await tester.runAsync(() async {
       final item = Item(id: 5, ownerId: '2', title: 'Chair');
 
-      await tester.pumpWidget(MaterialApp(home: ItemDetailPage(item: item)));
+      await tester.pumpWidget(
+        ProviderScope(child: MaterialApp(home: ItemDetailPage(item: item))),
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('toggleFavoriteDetail')));
@@ -160,7 +163,9 @@ void main() {
     final service = FakeItemService([item]);
 
     await tester.pumpWidget(
-      MaterialApp(home: ItemExchangePage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: ItemExchangePage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -217,7 +222,11 @@ void main() {
       final service = FakeItemService([item]);
 
       await tester.pumpWidget(
-        MaterialApp(home: ItemDetailPage(item: item, service: service)),
+        ProviderScope(
+          child: MaterialApp(
+            home: ItemDetailPage(item: item, service: service),
+          ),
+        ),
       );
       await tester.pumpAndSettle();
 
@@ -258,7 +267,11 @@ void main() {
       final service = FakeItemService([item]);
 
       await tester.pumpWidget(
-        MaterialApp(home: ItemDetailPage(item: item, service: service)),
+        ProviderScope(
+          child: MaterialApp(
+            home: ItemDetailPage(item: item, service: service),
+          ),
+        ),
       );
       await tester.pumpAndSettle();
 

--- a/test/item_request_test.dart
+++ b/test/item_request_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/item_detail_page.dart';
@@ -36,7 +37,9 @@ void main() {
     final service = FakeItemService();
     final item = Item(id: 1, ownerId: '1', title: 'Chair');
     await tester.pumpWidget(
-      MaterialApp(home: ItemDetailPage(item: item, service: service)),
+      ProviderScope(
+        child: MaterialApp(home: ItemDetailPage(item: item, service: service)),
+      ),
     );
 
     await tester.tap(find.text('Request'));


### PR DESCRIPTION
## Summary

Third page in the Riverpod migration, after #179 (ItemExchangePage) and #180 (PostItemPage). Closes out the item-domain pages — ItemChatPage still uses ItemService directly, but it's lower priority.

**Two commits:**
1. \`migrate ItemDetailPage to ConsumerStatefulWidget\` — favorites now flow through \`favoritesProvider\`, service resolved via \`widget.service ?? ref.read(itemServiceProvider)\` (explicit type annotation per the Dart CFE quirk), and successful mutations invalidate \`itemsProvider\`.
2. \`test: wrap ItemDetailPage usages in ProviderScope\` — four tests across three files get a bare \`ProviderScope\` wrap. No overrides needed since \`service:\` is still passed.

## Why no nested ProviderScope

Unlike ItemExchangePage, ItemDetailPage doesn't watch a scoped provider during build, so no scope-override dance is required. Pages it pushes downstream (PostItemPage, ItemChatPage) still receive an explicit \`service:\` argument so the override travels with them through Navigator.push.

## Test plan

- [ ] CI: Flutter job green
- [ ] CI: server job green (untouched)
- [ ] Manual: open an item, toggle favorite, confirm both detail page and exchange grid agree
- [ ] Manual: as owner, delete an item, confirm grid refreshes on pop