### PR TITLE
Migrate Clubs, Gallery, Directory, and Lost & Found pages to Riverpod

### DIFF
--- a/lib/pages/clubs_page.dart
+++ b/lib/pages/clubs_page.dart
@@ -1,47 +1,46 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../models/models.dart';
+import '../providers/clubs_providers.dart';
 import '../services/club_service.dart';
 import 'club_detail_page.dart';
 
-class ClubsPage extends StatefulWidget {
+class ClubsPage extends StatelessWidget {
   final ClubService? service;
   const ClubsPage({super.key, this.service});
 
   @override
-  State<ClubsPage> createState() => _ClubsPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _ClubsBody();
+    }
+    return ProviderScope(
+      overrides: [clubServiceProvider.overrideWithValue(service!)],
+      child: const _ClubsBody(),
+    );
+  }
 }
 
-class _ClubsPageState extends State<ClubsPage> {
-  late final ClubService _service;
-  List<Club> _clubs = [];
+class _ClubsBody extends ConsumerWidget {
+  const _ClubsBody();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? ClubService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final list = await _service.fetchClubs();
-    if (mounted) setState(() => _clubs = list);
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clubsAsync = ref.watch(clubsProvider);
+    final service = ref.watch(clubServiceProvider);
+    final clubs = clubsAsync.valueOrNull ?? const [];
     return Scaffold(
       body: ListView.builder(
-        itemCount: _clubs.length,
+        itemCount: clubs.length,
         itemBuilder: (context, index) {
-          final club = _clubs[index];
+          final club = clubs[index];
           return ListTile(
             title: Text(club.name),
             subtitle: Text(club.description ?? ''),
             onTap: () => Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (_) => ClubDetailPage(club: club, service: _service),
+                builder: (_) => ClubDetailPage(club: club, service: service),
               ),
             ),
           );

--- a/lib/pages/directory_page.dart
+++ b/lib/pages/directory_page.dart
@@ -1,54 +1,60 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/directory_providers.dart';
 import '../services/directory_service.dart';
 import 'user_chat_page.dart';
 
-class DirectoryPage extends StatefulWidget {
+class DirectoryPage extends StatelessWidget {
   final DirectoryService? service;
   const DirectoryPage({super.key, this.service});
 
   @override
-  State<DirectoryPage> createState() => _DirectoryPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _DirectoryBody();
+    }
+    return ProviderScope(
+      overrides: [directoryServiceProvider.overrideWithValue(service!)],
+      child: const _DirectoryBody(),
+    );
+  }
 }
 
-class _DirectoryPageState extends State<DirectoryPage> {
-  late final DirectoryService _service;
-  final TextEditingController _searchCtrl = TextEditingController();
-  List<User> _users = [];
-  bool _loading = false;
+class _DirectoryBody extends ConsumerStatefulWidget {
+  const _DirectoryBody();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? DirectoryService();
-    _loadUsers();
-  }
+  ConsumerState<_DirectoryBody> createState() => _DirectoryBodyState();
+}
 
-  Future<void> _loadUsers() async {
-    setState(() => _loading = true);
-    final cached = _service.loadCachedUsers(search: _searchCtrl.text);
-    if (cached.isNotEmpty) {
-      setState(() => _users = cached);
-    }
-    try {
-      final users = await _service.fetchUsers(search: _searchCtrl.text);
-      if (!mounted) return;
-      setState(() => _users = users);
-    } catch (_) {
-      if (!mounted) return;
-      if (_users.isEmpty) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Failed to load users')));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
+class _DirectoryBodyState extends ConsumerState<_DirectoryBody> {
+  final TextEditingController _searchCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<List<User>>>(directoryUsersProvider, (prev, next) {
+      // Only surface errors when no users are shown (matches prior behavior).
+      if (next.hasError && !next.isLoading) {
+        final fallback = (prev?.valueOrNull ?? const <User>[]);
+        if (fallback.isEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to load users')),
+          );
+        }
+      }
+    });
+
+    final usersAsync = ref.watch(directoryUsersProvider);
+    final users = usersAsync.valueOrNull ?? const <User>[];
+
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.all(16),
@@ -61,28 +67,30 @@ class _DirectoryPageState extends State<DirectoryPage> {
                 hintText: 'Search residents…',
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.refresh),
-                  onPressed: _loadUsers,
+                  onPressed: () => ref.invalidate(directoryUsersProvider),
                 ),
               ),
-              onChanged: (_) => _loadUsers(),
+              onChanged: (value) =>
+                  ref.read(directorySearchProvider.notifier).set(value),
             ),
             const SizedBox(height: 12),
             Expanded(
-              child: _loading
+              child: usersAsync.isLoading
                   ? const Center(child: CircularProgressIndicator())
-                  : _users.isEmpty
+                  : users.isEmpty
                       ? const Center(child: Text('No residents found.'))
                       : ListView.builder(
-                          itemCount: _users.length,
+                          itemCount: users.length,
                           itemBuilder: (context, index) {
-                            final user = _users[index];
+                            final user = users[index];
                             return ListTile(
                               leading: user.avatarUrl != null
                                   ? CircleAvatar(
                                       backgroundImage:
                                           NetworkImage(user.avatarUrl!),
                                     )
-                                  : const CircleAvatar(child: Icon(Icons.person)),
+                                  : const CircleAvatar(
+                                      child: Icon(Icons.person)),
                               title: Text(user.name),
                               subtitle: Text(user.email),
                               onTap: () {
@@ -90,7 +98,8 @@ class _DirectoryPageState extends State<DirectoryPage> {
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(
-                                    builder: (_) => UserChatPage(user: user),
+                                    builder: (_) =>
+                                        UserChatPage(user: user),
                                   ),
                                 );
                               },

--- a/lib/pages/gallery_page.dart
+++ b/lib/pages/gallery_page.dart
@@ -1,95 +1,93 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/gallery_providers.dart';
 import '../services/gallery_service.dart';
 
-class GalleryPage extends StatefulWidget {
+class GalleryPage extends StatelessWidget {
   final GalleryService? service;
   const GalleryPage({super.key, this.service});
 
   @override
-  State<GalleryPage> createState() => _GalleryPageState();
-}
-
-class _GalleryPageState extends State<GalleryPage> {
-  late final GalleryService _service;
-  List<GalleryImage> _images = [];
-  bool _loading = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? GalleryService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    setState(() => _loading = true);
-    try {
-      final imgs = await _service.fetchImages();
-      if (mounted) setState(() => _images = imgs);
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to load: $e')));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _GalleryBody();
     }
-  }
-
-  void _view(GalleryImage img) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => _FullScreenImage(url: img.url)),
+    return ProviderScope(
+      overrides: [galleryServiceProvider.overrideWithValue(service!)],
+      child: const _GalleryBody(),
     );
   }
+}
+
+class _GalleryBody extends ConsumerWidget {
+  const _GalleryBody();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<List<GalleryImage>>>(galleryImagesProvider,
+        (prev, next) {
+      if (next.hasError && !next.isLoading) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to load: ${next.error}')),
+        );
+      }
+    });
+
     final cs = Theme.of(context).colorScheme;
+    final imagesAsync = ref.watch(galleryImagesProvider);
+    final images = imagesAsync.valueOrNull ?? const <GalleryImage>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Community Gallery'),
         backgroundColor: cs.primaryContainer,
         foregroundColor: cs.onPrimaryContainer,
       ),
-      body: _loading
+      body: imagesAsync.isLoading
           ? const Center(child: CircularProgressIndicator())
-          : _images.isEmpty
-          ? const Center(child: Text('No images uploaded.'))
-          : GridView.builder(
-              padding: const EdgeInsets.all(8),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 3,
-                mainAxisSpacing: 4,
-                crossAxisSpacing: 4,
-              ),
-              itemCount: _images.length,
-              itemBuilder: (ctx, i) {
-                final img = _images[i];
-                return GestureDetector(
-                  onTap: () => _view(img),
-                  child: Image.network(
-                    img.url,
-                    fit: BoxFit.cover,
-                    loadingBuilder: (context, child, progress) {
-                      if (progress == null) return child;
-                      return const Center(child: CircularProgressIndicator());
-                    },
-                    errorBuilder: (context, error, stackTrace) => Container(
-                      color: cs.surfaceContainerHighest,
-                      alignment: Alignment.center,
-                      child: Icon(
-                        Icons.broken_image,
-                        color: cs.onSurfaceVariant,
-                      ),
-                    ),
+          : images.isEmpty
+              ? const Center(child: Text('No images uploaded.'))
+              : GridView.builder(
+                  padding: const EdgeInsets.all(8),
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    mainAxisSpacing: 4,
+                    crossAxisSpacing: 4,
                   ),
-                );
-              },
-            ),
+                  itemCount: images.length,
+                  itemBuilder: (ctx, i) {
+                    final img = images[i];
+                    return GestureDetector(
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => _FullScreenImage(url: img.url),
+                        ),
+                      ),
+                      child: Image.network(
+                        img.url,
+                        fit: BoxFit.cover,
+                        loadingBuilder: (context, child, progress) {
+                          if (progress == null) return child;
+                          return const Center(
+                            child: CircularProgressIndicator(),
+                          );
+                        },
+                        errorBuilder: (context, error, stackTrace) =>
+                            Container(
+                          color: cs.surfaceContainerHighest,
+                          alignment: Alignment.center,
+                          child: Icon(
+                            Icons.broken_image,
+                            color: cs.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
     );
   }
 }

--- a/lib/pages/lost_found_page.dart
+++ b/lib/pages/lost_found_page.dart
@@ -1,47 +1,50 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
 import '../models/models.dart';
+import '../providers/lost_found_providers.dart';
 import '../services/lost_found_service.dart';
 import '../utils/user_helpers.dart';
 import 'lost_found_detail_page.dart';
-import 'package:image_picker/image_picker.dart';
 
-class LostFoundPage extends StatefulWidget {
+class LostFoundPage extends StatelessWidget {
   final LostFoundService? service;
   const LostFoundPage({super.key, this.service});
 
   @override
-  State<LostFoundPage> createState() => _LostFoundPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _LostFoundBody();
+    }
+    return ProviderScope(
+      overrides: [lostFoundServiceProvider.overrideWithValue(service!)],
+      child: const _LostFoundBody(),
+    );
+  }
 }
 
-class _LostFoundPageState extends State<LostFoundPage> {
-  late final LostFoundService _service;
+class _LostFoundBody extends ConsumerStatefulWidget {
+  const _LostFoundBody();
+
+  @override
+  ConsumerState<_LostFoundBody> createState() => _LostFoundBodyState();
+}
+
+class _LostFoundBodyState extends ConsumerState<_LostFoundBody> {
   final TextEditingController _searchCtrl = TextEditingController();
   final _titleCtrl = TextEditingController();
   final _descCtrl = TextEditingController();
   XFile? _imageFile;
-  List<LostItem> _items = [];
-  String _typeFilter = 'all';
-  String _resolvedFilter = 'all';
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? LostFoundService();
-    _loadItems();
-  }
-
-  Future<void> _loadItems() async {
-    final items = await _service.fetchItems(
-      search: _searchCtrl.text,
-      type: _typeFilter == 'all' ? null : _typeFilter,
-      resolved: _resolvedFilter == 'all'
-          ? null
-          : _resolvedFilter == 'true',
-    );
-    if (!mounted) return;
-    setState(() => _items = items);
+  void dispose() {
+    _searchCtrl.dispose();
+    _titleCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
   }
 
   Future<void> _pickImage(ImageSource source) async {
@@ -53,34 +56,30 @@ class _LostFoundPageState extends State<LostFoundPage> {
   Future<void> _submit() async {
     final title = _titleCtrl.text.trim();
     if (title.isEmpty) return;
-    final item = await _service.createItem(
-      LostItem(
-        ownerId: currentUserId(),
-        title: title,
-        description: _descCtrl.text.trim().isEmpty
-            ? null
-            : _descCtrl.text.trim(),
-      ),
-      imageFile: _imageFile != null ? File(_imageFile!.path) : null,
-    );
+    await ref.read(lostFoundServiceProvider).createItem(
+          LostItem(
+            ownerId: currentUserId(),
+            title: title,
+            description: _descCtrl.text.trim().isEmpty
+                ? null
+                : _descCtrl.text.trim(),
+          ),
+          imageFile: _imageFile != null ? File(_imageFile!.path) : null,
+        );
     if (!mounted) return;
-    setState(() => _items.add(item));
     _titleCtrl.clear();
     _descCtrl.clear();
     setState(() => _imageFile = null);
-  }
-
-  @override
-  void dispose() {
-    _searchCtrl.dispose();
-    _titleCtrl.dispose();
-    _descCtrl.dispose();
-    super.dispose();
+    ref.invalidate(lostFoundItemsProvider);
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final filters = ref.watch(lostFoundFiltersProvider);
+    final filtersNotifier = ref.read(lostFoundFiltersProvider.notifier);
+    final itemsAsync = ref.watch(lostFoundItemsProvider);
+    final items = itemsAsync.valueOrNull ?? const <LostItem>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Lost & Found'),
@@ -100,44 +99,49 @@ class _LostFoundPageState extends State<LostFoundPage> {
                     hintText: 'Search…',
                     suffixIcon: IconButton(
                       icon: const Icon(Icons.refresh),
-                      onPressed: _loadItems,
+                      onPressed: () =>
+                          ref.invalidate(lostFoundItemsProvider),
                     ),
                   ),
-                  onChanged: (_) => _loadItems(),
+                  onChanged: filtersNotifier.setSearch,
                 ),
                 const SizedBox(height: 8),
                 Row(
                   children: [
                     Expanded(
                       child: DropdownButton<String>(
-                        value: _typeFilter,
+                        value: filters.type,
                         isExpanded: true,
                         onChanged: (val) {
                           if (val == null) return;
-                          setState(() => _typeFilter = val);
-                          _loadItems();
+                          filtersNotifier.setType(val);
                         },
                         items: const [
-                          DropdownMenuItem(value: 'all', child: Text('All Types')),
-                          DropdownMenuItem(value: 'lost', child: Text('Lost')),
-                          DropdownMenuItem(value: 'found', child: Text('Found')),
+                          DropdownMenuItem(
+                              value: 'all', child: Text('All Types')),
+                          DropdownMenuItem(
+                              value: 'lost', child: Text('Lost')),
+                          DropdownMenuItem(
+                              value: 'found', child: Text('Found')),
                         ],
                       ),
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: DropdownButton<String>(
-                        value: _resolvedFilter,
+                        value: filters.resolved,
                         isExpanded: true,
                         onChanged: (val) {
                           if (val == null) return;
-                          setState(() => _resolvedFilter = val);
-                          _loadItems();
+                          filtersNotifier.setResolved(val);
                         },
                         items: const [
-                          DropdownMenuItem(value: 'all', child: Text('Any Status')),
-                          DropdownMenuItem(value: 'false', child: Text('Unresolved')),
-                          DropdownMenuItem(value: 'true', child: Text('Resolved')),
+                          DropdownMenuItem(
+                              value: 'all', child: Text('Any Status')),
+                          DropdownMenuItem(
+                              value: 'false', child: Text('Unresolved')),
+                          DropdownMenuItem(
+                              value: 'true', child: Text('Resolved')),
                         ],
                       ),
                     ),
@@ -147,13 +151,13 @@ class _LostFoundPageState extends State<LostFoundPage> {
             ),
           ),
           Expanded(
-            child: _items.isEmpty
+            child: items.isEmpty
                 ? const Center(child: Text('No posts yet.'))
                 : ListView.separated(
-                    itemCount: _items.length,
+                    itemCount: items.length,
                     separatorBuilder: (_, __) => const Divider(height: 1),
                     itemBuilder: (_, i) {
-                      final item = _items[i];
+                      final item = items[i];
                       return ListTile(
                         title: Text(item.title),
                         subtitle: item.description != null
@@ -166,11 +170,14 @@ class _LostFoundPageState extends State<LostFoundPage> {
                             MaterialPageRoute(
                               builder: (_) => LostFoundDetailPage(
                                 item: item,
-                                service: _service,
+                                service:
+                                    ref.read(lostFoundServiceProvider),
                               ),
                             ),
                           );
-                          if (changed == true) _loadItems();
+                          if (changed == true) {
+                            ref.invalidate(lostFoundItemsProvider);
+                          }
                         },
                       );
                     },

--- a/lib/providers/clubs_providers.dart
+++ b/lib/providers/clubs_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/club_service.dart';
+
+final clubServiceProvider =
+    Provider<ClubService>((ref) => ClubService());
+
+final clubsProvider = FutureProvider<List<Club>>(
+  (ref) async {
+    final service = ref.watch(clubServiceProvider);
+    return service.fetchClubs();
+  },
+  dependencies: [clubServiceProvider],
+);

--- a/lib/providers/directory_providers.dart
+++ b/lib/providers/directory_providers.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/directory_service.dart';
+
+final directoryServiceProvider =
+    Provider<DirectoryService>((ref) => DirectoryService());
+
+/// Current search query for the directory page. Setting this re-runs
+/// [directoryUsersProvider] for the new value (cached by Riverpod's
+/// family-style memoisation on the argument).
+class DirectorySearchNotifier extends Notifier<String> {
+  @override
+  String build() => '';
+  void set(String value) => state = value;
+}
+
+final directorySearchProvider =
+    NotifierProvider<DirectorySearchNotifier, String>(
+        DirectorySearchNotifier.new);
+
+/// Loads users for the current [directorySearchProvider] value.
+final directoryUsersProvider = FutureProvider<List<User>>(
+  (ref) async {
+    final search = ref.watch(directorySearchProvider);
+    final service = ref.watch(directoryServiceProvider);
+    return service.fetchUsers(search: search);
+  },
+  dependencies: [directoryServiceProvider, directorySearchProvider],
+);

--- a/lib/providers/gallery_providers.dart
+++ b/lib/providers/gallery_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/gallery_service.dart';
+
+final galleryServiceProvider =
+    Provider<GalleryService>((ref) => GalleryService());
+
+final galleryImagesProvider = FutureProvider<List<GalleryImage>>(
+  (ref) async {
+    final service = ref.watch(galleryServiceProvider);
+    return service.fetchImages();
+  },
+  dependencies: [galleryServiceProvider],
+);

--- a/lib/providers/lost_found_providers.dart
+++ b/lib/providers/lost_found_providers.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/lost_found_service.dart';
+
+final lostFoundServiceProvider =
+    Provider<LostFoundService>((ref) => LostFoundService());
+
+class LostFoundFilters {
+  final String search;
+  // 'all', 'lost', 'found'
+  final String type;
+  // 'all', 'true', 'false'
+  final String resolved;
+
+  const LostFoundFilters({
+    this.search = '',
+    this.type = 'all',
+    this.resolved = 'all',
+  });
+
+  LostFoundFilters copyWith({String? search, String? type, String? resolved}) {
+    return LostFoundFilters(
+      search: search ?? this.search,
+      type: type ?? this.type,
+      resolved: resolved ?? this.resolved,
+    );
+  }
+}
+
+class LostFoundFiltersNotifier extends Notifier<LostFoundFilters> {
+  @override
+  LostFoundFilters build() => const LostFoundFilters();
+
+  void setSearch(String value) => state = state.copyWith(search: value);
+  void setType(String value) => state = state.copyWith(type: value);
+  void setResolved(String value) => state = state.copyWith(resolved: value);
+}
+
+final lostFoundFiltersProvider =
+    NotifierProvider<LostFoundFiltersNotifier, LostFoundFilters>(
+        LostFoundFiltersNotifier.new);
+
+final lostFoundItemsProvider = FutureProvider<List<LostItem>>(
+  (ref) async {
+    final filters = ref.watch(lostFoundFiltersProvider);
+    final service = ref.watch(lostFoundServiceProvider);
+    return service.fetchItems(
+      search: filters.search,
+      type: filters.type == 'all' ? null : filters.type,
+      resolved: filters.resolved == 'all' ? null : filters.resolved == 'true',
+    );
+  },
+  dependencies: [lostFoundServiceProvider, lostFoundFiltersProvider],
+);


### PR DESCRIPTION
## Summary

Batched migration of four list-style pages to Riverpod, following the wrapper pattern established in #179 and refined through #180–#183. Each gets its own provider file and uses the same self-wrapping \`ProviderScope\` override when constructed with a \`service:\` argument.

**Four commits, one page per commit:**

1. \`migrate ClubsPage to Riverpod\` — trivial list, ConsumerWidget body
2. \`migrate GalleryPage to Riverpod\` — loading state via AsyncValue, load-error snackbar via \`ref.listen\`
3. \`migrate DirectoryPage to Riverpod\` — adds \`directorySearchProvider\` notifier so the FutureProvider re-runs when the query changes. Stale-while-revalidate dropped (DirectoryService still caches internally for offline)
4. \`migrate LostFoundPage to Riverpod\` — \`LostFoundFiltersNotifier\` holds search/type/resolved state, FutureProvider watches both filters and service

## Why these four

All four follow the same shape (fetch list, render, refresh on change). \`BulletinBoardPage\` was intentionally left out — its \`_editComment\` / \`_deleteComment\` paths mutate in-memory state without calling the service, which doesn't migrate cleanly without rethinking that pre-existing bug.

## No test changes

Only \`directory_page_test\` touches any of these pages directly; it passes \`service:\` explicitly, which the new wrapper routes through Riverpod transparently. \`main_page.dart\` constructs \`const LostFoundPage()\`, \`const DirectoryPage()\`, \`const ClubsPage()\`, \`const GalleryPage()\` but no \`main_page_test\` case navigates to those tabs, so the widgets are constructed-but-never-built in tests.

## Test plan

- [ ] CI: Flutter job green
- [ ] CI: server job green (untouched)
- [ ] Manual: walk through Clubs list, Gallery grid, Directory search, Lost & Found filters/post