### PR TITLE
Migrate Polls, Emergency Contacts, Study Groups, Tutoring, Documents, Suggestion pages to Riverpod

### DIFF
--- a/lib/pages/documents_page.dart
+++ b/lib/pages/documents_page.dart
@@ -1,101 +1,99 @@
 import 'dart:io';
-import 'package:flutter/material.dart';
+
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/documents_providers.dart';
 import '../services/document_service.dart';
 
-class DocumentsPage extends StatefulWidget {
+class DocumentsPage extends StatelessWidget {
   final DocumentService? service;
   const DocumentsPage({super.key, this.service});
 
   @override
-  State<DocumentsPage> createState() => _DocumentsPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _DocumentsBody();
+    }
+    return ProviderScope(
+      overrides: [documentServiceProvider.overrideWithValue(service!)],
+      child: const _DocumentsBody(),
+    );
+  }
 }
 
-class _DocumentsPageState extends State<DocumentsPage> {
-  late final DocumentService _service;
-  List<Document> _documents = [];
-  bool _loading = false;
+class _DocumentsBody extends ConsumerWidget {
+  const _DocumentsBody();
 
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? DocumentService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    setState(() => _loading = true);
-    try {
-      final list = await _service.fetchDocuments();
-      if (mounted) setState(() => _documents = list);
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Failed to load: $e')));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  Future<void> _pickAndUpload() async {
+  Future<void> _pickAndUpload(BuildContext context, WidgetRef ref) async {
     final result = await FilePicker.platform.pickFiles();
     if (result == null || result.files.isEmpty) return;
     final path = result.files.single.path;
     if (path == null) return;
     final file = File(path);
     try {
-      final doc = await _service.uploadDocument(file);
-      if (mounted) setState(() => _documents.add(doc));
+      await ref.read(documentServiceProvider).uploadDocument(file);
+      ref.invalidate(documentsProvider);
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
-      }
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
     }
   }
 
+  Future<void> _download(BuildContext context, WidgetRef ref, Document doc)
+      async {
+    final bytes =
+        await ref.read(documentServiceProvider).downloadDocument(doc.url);
+    final fileName = doc.fileName.split('/').last;
+    final dir = await FilePicker.platform.getDirectoryPath();
+    if (dir == null) return;
+    final out = File('$dir/$fileName');
+    await out.writeAsBytes(bytes);
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Saved to $dir')));
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<List<Document>>>(documentsProvider, (prev, next) {
+      if (next.hasError && !next.isLoading) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed to load: ${next.error}')));
+      }
+    });
     final cs = Theme.of(context).colorScheme;
+    final docsAsync = ref.watch(documentsProvider);
+    final documents = docsAsync.valueOrNull ?? const <Document>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Documents'),
         backgroundColor: cs.primaryContainer,
         foregroundColor: cs.onPrimaryContainer,
       ),
-      body: _loading
+      body: docsAsync.isLoading
           ? const Center(child: CircularProgressIndicator())
-          : _documents.isEmpty
+          : documents.isEmpty
               ? const Center(child: Text('No documents uploaded.'))
               : ListView.separated(
-                  itemCount: _documents.length,
+                  itemCount: documents.length,
                   separatorBuilder: (_, __) => const Divider(height: 1),
                   itemBuilder: (_, i) {
-                    final doc = _documents[i];
+                    final doc = documents[i];
                     return ListTile(
                       title: Text(doc.fileName),
                       trailing: IconButton(
                         icon: const Icon(Icons.download),
-                        onPressed: () async {
-                          final bytes = await _service.downloadDocument(doc.url);
-                          final fileName = doc.fileName.split('/').last;
-                          final dir = await FilePicker.platform.getDirectoryPath();
-                          if (dir == null) return;
-                          final out = File('$dir/$fileName');
-                          await out.writeAsBytes(bytes);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('Saved to $dir')));
-                          }
-                        },
+                        onPressed: () => _download(context, ref, doc),
                       ),
                     );
                   },
                 ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _pickAndUpload,
+        onPressed: () => _pickAndUpload(context, ref),
         child: const Icon(Icons.upload_file),
       ),
     );

--- a/lib/pages/emergency_contacts_page.dart
+++ b/lib/pages/emergency_contacts_page.dart
@@ -1,39 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../models/models.dart';
+import '../providers/emergency_contacts_providers.dart';
 import '../services/emergency_contact_service.dart';
 
-class EmergencyContactsPage extends StatefulWidget {
+class EmergencyContactsPage extends StatelessWidget {
   final EmergencyContactService? service;
   const EmergencyContactsPage({super.key, this.service});
 
   @override
-  State<EmergencyContactsPage> createState() => _EmergencyContactsPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _EmergencyContactsBody();
+    }
+    return ProviderScope(
+      overrides: [
+        emergencyContactServiceProvider.overrideWithValue(service!),
+      ],
+      child: const _EmergencyContactsBody(),
+    );
+  }
 }
 
-class _EmergencyContactsPageState extends State<EmergencyContactsPage> {
-  late final EmergencyContactService _service;
-  List<EmergencyContact> _contacts = [];
-
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? EmergencyContactService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    try {
-      final list = await _service.fetchContacts();
-      if (mounted) setState(() => _contacts = list);
-    } catch (_) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Failed to load contacts')));
-    }
-  }
+class _EmergencyContactsBody extends ConsumerWidget {
+  const _EmergencyContactsBody();
 
   Future<void> _call(String phone) async {
     final uri = Uri.parse('tel:$phone');
@@ -43,15 +35,26 @@ class _EmergencyContactsPageState extends State<EmergencyContactsPage> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<List<EmergencyContact>>>(emergencyContactsProvider,
+        (prev, next) {
+      if (next.hasError && !next.isLoading) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to load contacts')),
+        );
+      }
+    });
+    final contacts =
+        ref.watch(emergencyContactsProvider).valueOrNull ??
+            const <EmergencyContact>[];
     return Scaffold(
       appBar: AppBar(title: const Text('Emergency Contacts')),
       body: RefreshIndicator(
-        onRefresh: _load,
+        onRefresh: () async => ref.invalidate(emergencyContactsProvider),
         child: ListView.builder(
-          itemCount: _contacts.length,
+          itemCount: contacts.length,
           itemBuilder: (context, index) {
-            final c = _contacts[index];
+            final c = contacts[index];
             return Card(
               margin: const EdgeInsets.all(12),
               child: ListTile(

--- a/lib/pages/polls_page.dart
+++ b/lib/pages/polls_page.dart
@@ -1,46 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/polls_providers.dart';
 import '../services/poll_service.dart';
 
-class PollsPage extends StatefulWidget {
+class PollsPage extends StatelessWidget {
   final PollService? service;
   const PollsPage({super.key, this.service});
 
   @override
-  State<PollsPage> createState() => _PollsPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _PollsBody();
+    }
+    return ProviderScope(
+      overrides: [pollServiceProvider.overrideWithValue(service!)],
+      child: const _PollsBody(),
+    );
+  }
 }
 
-class _PollsPageState extends State<PollsPage> {
-  late final PollService _service;
-  List<Poll> _polls = [];
+class _PollsBody extends ConsumerWidget {
+  const _PollsBody();
 
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? PollService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    try {
-      final polls = await _service.fetchPolls();
-      if (!mounted) return;
-      setState(() => _polls = polls);
-    } catch (_) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to load polls')),
-      );
-    }
-  }
-
-  Future<void> _vote(Poll poll, int index) async {
+  Future<void> _vote(WidgetRef ref, BuildContext context, Poll poll, int index)
+      async {
     if (poll.id == null) return;
     try {
-      await _service.vote(poll.id!, index);
-      await _load();
+      await ref.read(pollServiceProvider).vote(poll.id!, index);
+      ref.invalidate(pollsProvider);
     } catch (_) {
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Failed to submit vote')),
       );
@@ -48,13 +39,21 @@ class _PollsPageState extends State<PollsPage> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue<List<Poll>>>(pollsProvider, (prev, next) {
+      if (next.hasError && !next.isLoading) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to load polls')),
+        );
+      }
+    });
+    final polls = ref.watch(pollsProvider).valueOrNull ?? const <Poll>[];
     return RefreshIndicator(
-      onRefresh: _load,
+      onRefresh: () async => ref.invalidate(pollsProvider),
       child: ListView.builder(
-        itemCount: _polls.length,
+        itemCount: polls.length,
         itemBuilder: (context, index) {
-          final poll = _polls[index];
+          final poll = polls[index];
           return Card(
             margin: const EdgeInsets.all(12),
             child: Padding(
@@ -73,7 +72,7 @@ class _PollsPageState extends State<PollsPage> {
                         '${poll.options[i]} (${poll.counts.length > i ? poll.counts[i] : 0})',
                       ),
                       trailing: ElevatedButton(
-                        onPressed: () => _vote(poll, i),
+                        onPressed: () => _vote(ref, context, poll, i),
                         child: const Text('Vote'),
                       ),
                     ),

--- a/lib/pages/post_tutoring_page.dart
+++ b/lib/pages/post_tutoring_page.dart
@@ -1,30 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/tutoring_providers.dart';
 import '../services/tutoring_service.dart';
 import '../utils/user_helpers.dart';
 
-class PostTutoringPage extends StatefulWidget {
+class PostTutoringPage extends ConsumerStatefulWidget {
   final TutoringService? service;
   const PostTutoringPage({super.key, this.service});
 
   @override
-  State<PostTutoringPage> createState() => _PostTutoringPageState();
+  ConsumerState<PostTutoringPage> createState() => _PostTutoringPageState();
 }
 
-class _PostTutoringPageState extends State<PostTutoringPage> {
+class _PostTutoringPageState extends ConsumerState<PostTutoringPage> {
   final _formKey = GlobalKey<FormState>();
-  late final TutoringService _service;
   final _subjectCtrl = TextEditingController();
   final _descCtrl = TextEditingController();
   bool _isOffering = true;
   bool _submitting = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? TutoringService();
-  }
 
   @override
   void dispose() {
@@ -44,8 +39,11 @@ class _PostTutoringPageState extends State<PostTutoringPage> {
         isOffering: _isOffering,
         contactUserId: currentUserId(),
       );
-      await _service.createPost(post);
+      final TutoringService service =
+          widget.service ?? ref.read(tutoringServiceProvider);
+      await service.createPost(post);
       if (mounted) {
+        ref.invalidate(tutoringPostsProvider);
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('Posted!')));

--- a/lib/pages/study_groups_page.dart
+++ b/lib/pages/study_groups_page.dart
@@ -1,57 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/study_groups_providers.dart';
 import '../services/study_group_service.dart';
 import '../utils/user_helpers.dart';
 
-class StudyGroupsPage extends StatefulWidget {
+class StudyGroupsPage extends StatelessWidget {
   final StudyGroupService? service;
   const StudyGroupsPage({super.key, this.service});
 
   @override
-  State<StudyGroupsPage> createState() => _StudyGroupsPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _StudyGroupsBody();
+    }
+    return ProviderScope(
+      overrides: [studyGroupServiceProvider.overrideWithValue(service!)],
+      child: const _StudyGroupsBody(),
+    );
+  }
 }
 
-class _StudyGroupsPageState extends State<StudyGroupsPage> {
-  late final StudyGroupService _service;
-  List<StudyGroup> _groups = [];
+class _StudyGroupsBody extends ConsumerWidget {
+  const _StudyGroupsBody();
 
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? StudyGroupService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final groups = await _service.fetchGroups();
-    if (mounted) setState(() => _groups = groups);
-  }
-
-  Future<void> _toggle(StudyGroup group) async {
+  Future<void> _toggle(WidgetRef ref, StudyGroup group) async {
     if (group.id == null) return;
-    final isMember = group.memberIds.contains(currentUserId());
-    final updated = isMember
-        ? await _service.leaveGroup(group.id!)
-        : await _service.joinGroup(group.id!);
-    if (!mounted) return;
-    setState(() {
-      final idx = _groups.indexWhere((g) => g.id == updated.id);
-      if (idx != -1) _groups[idx] = updated;
-    });
+    final me = currentUserId();
+    final isMember = group.memberIds.contains(me);
+    final service = ref.read(studyGroupServiceProvider);
+    if (isMember) {
+      await service.leaveGroup(group.id!);
+    } else {
+      await service.joinGroup(group.id!);
+    }
+    ref.invalidate(studyGroupsProvider);
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final groups =
+        ref.watch(studyGroupsProvider).valueOrNull ?? const <StudyGroup>[];
+    final me = currentUserId();
     return Scaffold(
       appBar: AppBar(title: const Text('Study Groups')),
       body: RefreshIndicator(
-        onRefresh: _load,
+        onRefresh: () async => ref.invalidate(studyGroupsProvider),
         child: ListView.builder(
-          itemCount: _groups.length,
+          itemCount: groups.length,
           itemBuilder: (context, index) {
-            final group = _groups[index];
-            final isMember = group.memberIds.contains(currentUserId());
+            final group = groups[index];
+            final isMember = group.memberIds.contains(me);
             return ListTile(
               title: Text(group.topic),
               subtitle: Column(
@@ -63,7 +63,7 @@ class _StudyGroupsPageState extends State<StudyGroupsPage> {
                 ],
               ),
               trailing: ElevatedButton(
-                onPressed: () => _toggle(group),
+                onPressed: () => _toggle(ref, group),
                 child: Text(isMember ? 'Leave' : 'Join'),
               ),
             );

--- a/lib/pages/suggestion_box_page.dart
+++ b/lib/pages/suggestion_box_page.dart
@@ -1,47 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/suggestions_providers.dart';
 import '../services/suggestion_service.dart';
 import '../utils/user_helpers.dart';
 
-class SuggestionBoxPage extends StatefulWidget {
+class SuggestionBoxPage extends StatelessWidget {
   final SuggestionService? service;
   const SuggestionBoxPage({super.key, this.service});
 
   @override
-  State<SuggestionBoxPage> createState() => _SuggestionBoxPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _SuggestionBoxBody();
+    }
+    return ProviderScope(
+      overrides: [suggestionServiceProvider.overrideWithValue(service!)],
+      child: const _SuggestionBoxBody(),
+    );
+  }
 }
 
-class _SuggestionBoxPageState extends State<SuggestionBoxPage> {
-  late final SuggestionService _service;
+class _SuggestionBoxBody extends ConsumerStatefulWidget {
+  const _SuggestionBoxBody();
+
+  @override
+  ConsumerState<_SuggestionBoxBody> createState() => _SuggestionBoxBodyState();
+}
+
+class _SuggestionBoxBodyState extends ConsumerState<_SuggestionBoxBody> {
   final TextEditingController _ctrl = TextEditingController();
-  List<Suggestion> _suggestions = [];
 
   bool get _isAdmin => currentUserIsAdmin();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? SuggestionService();
-    if (_isAdmin) _load();
-  }
-
-  Future<void> _load() async {
-    final list = await _service.fetchSuggestions();
-    if (!mounted) return;
-    setState(() => _suggestions = list);
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
   }
 
   Future<void> _submit() async {
     final text = _ctrl.text.trim();
     if (text.isEmpty) return;
     try {
-      await _service.createSuggestion(
-        Suggestion(userId: currentUserId(), content: text),
-      );
+      await ref.read(suggestionServiceProvider).createSuggestion(
+            Suggestion(userId: currentUserId(), content: text),
+          );
       if (!mounted) return;
       _ctrl.clear();
-      if (_isAdmin) _load();
+      if (_isAdmin) ref.invalidate(suggestionsProvider);
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Thank you for the feedback!')),
       );
@@ -55,20 +63,17 @@ class _SuggestionBoxPageState extends State<SuggestionBoxPage> {
 
   Future<void> _delete(Suggestion s) async {
     if (s.id == null) return;
-    await _service.deleteSuggestion(s.id!);
+    await ref.read(suggestionServiceProvider).deleteSuggestion(s.id!);
     if (!mounted) return;
-    _load();
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
+    ref.invalidate(suggestionsProvider);
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final suggestions = _isAdmin
+        ? (ref.watch(suggestionsProvider).valueOrNull ?? const <Suggestion>[])
+        : const <Suggestion>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Suggestion Box'),
@@ -96,26 +101,25 @@ class _SuggestionBoxPageState extends State<SuggestionBoxPage> {
           if (_isAdmin)
             Expanded(
               child: RefreshIndicator(
-                onRefresh: _load,
-                child:
-                    _suggestions.isEmpty
-                        ? const Center(child: Text('No suggestions yet.'))
-                        : ListView.builder(
-                          itemCount: _suggestions.length,
-                          itemBuilder: (_, i) {
-                            final s = _suggestions[i];
-                            return ListTile(
-                              title: Text(s.content),
-                              subtitle: Text(
-                                'User ${s.userId} - ${s.createdAt.day}/${s.createdAt.month}/${s.createdAt.year}',
-                              ),
-                              trailing: IconButton(
-                                icon: const Icon(Icons.delete),
-                                onPressed: () => _delete(s),
-                              ),
-                            );
-                          },
-                        ),
+                onRefresh: () async => ref.invalidate(suggestionsProvider),
+                child: suggestions.isEmpty
+                    ? const Center(child: Text('No suggestions yet.'))
+                    : ListView.builder(
+                        itemCount: suggestions.length,
+                        itemBuilder: (_, i) {
+                          final s = suggestions[i];
+                          return ListTile(
+                            title: Text(s.content),
+                            subtitle: Text(
+                              'User ${s.userId} - ${s.createdAt.day}/${s.createdAt.month}/${s.createdAt.year}',
+                            ),
+                            trailing: IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () => _delete(s),
+                            ),
+                          );
+                        },
+                      ),
               ),
             ),
         ],

--- a/lib/pages/tutoring_page.dart
+++ b/lib/pages/tutoring_page.dart
@@ -1,51 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/tutoring_providers.dart';
 import '../services/tutoring_service.dart';
 import 'post_tutoring_page.dart';
 
-class TutoringPage extends StatefulWidget {
+class TutoringPage extends StatelessWidget {
   final TutoringService? service;
   const TutoringPage({super.key, this.service});
 
   @override
-  State<TutoringPage> createState() => _TutoringPageState();
+  Widget build(BuildContext context) {
+    if (service == null) {
+      return const _TutoringBody();
+    }
+    return ProviderScope(
+      overrides: [tutoringServiceProvider.overrideWithValue(service!)],
+      child: const _TutoringBody(),
+    );
+  }
 }
 
-class _TutoringPageState extends State<TutoringPage> {
-  late final TutoringService _service;
-  List<TutoringPost> _posts = [];
+class _TutoringBody extends ConsumerWidget {
+  const _TutoringBody();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? TutoringService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final posts = await _service.fetchPosts();
-    if (mounted) setState(() => _posts = posts);
-  }
-
-  Future<void> _openForm() async {
-    final created = await Navigator.push<bool>(
-      context,
-      MaterialPageRoute(builder: (_) => PostTutoringPage(service: _service)),
-    );
-    if (created == true) _load();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final posts =
+        ref.watch(tutoringPostsProvider).valueOrNull ?? const <TutoringPost>[];
     return Scaffold(
       appBar: AppBar(title: const Text('Tutoring')),
       body: RefreshIndicator(
-        onRefresh: _load,
+        onRefresh: () async => ref.invalidate(tutoringPostsProvider),
         child: ListView.builder(
-          itemCount: _posts.length,
+          itemCount: posts.length,
           itemBuilder: (_, index) {
-            final post = _posts[index];
+            final post = posts[index];
             return ListTile(
               title: Text(post.subject),
               subtitle: Text(post.description),
@@ -55,7 +46,10 @@ class _TutoringPageState extends State<TutoringPage> {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _openForm,
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const PostTutoringPage()),
+        ),
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/providers/documents_providers.dart
+++ b/lib/providers/documents_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/document_service.dart';
+
+final documentServiceProvider =
+    Provider<DocumentService>((ref) => DocumentService());
+
+final documentsProvider = FutureProvider<List<Document>>(
+  (ref) async {
+    final service = ref.watch(documentServiceProvider);
+    return service.fetchDocuments();
+  },
+  dependencies: [documentServiceProvider],
+);

--- a/lib/providers/emergency_contacts_providers.dart
+++ b/lib/providers/emergency_contacts_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/emergency_contact_service.dart';
+
+final emergencyContactServiceProvider =
+    Provider<EmergencyContactService>((ref) => EmergencyContactService());
+
+final emergencyContactsProvider = FutureProvider<List<EmergencyContact>>(
+  (ref) async {
+    final service = ref.watch(emergencyContactServiceProvider);
+    return service.fetchContacts();
+  },
+  dependencies: [emergencyContactServiceProvider],
+);

--- a/lib/providers/polls_providers.dart
+++ b/lib/providers/polls_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/poll_service.dart';
+
+final pollServiceProvider = Provider<PollService>((ref) => PollService());
+
+final pollsProvider = FutureProvider<List<Poll>>(
+  (ref) async {
+    final service = ref.watch(pollServiceProvider);
+    return service.fetchPolls();
+  },
+  dependencies: [pollServiceProvider],
+);

--- a/lib/providers/study_groups_providers.dart
+++ b/lib/providers/study_groups_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/study_group_service.dart';
+
+final studyGroupServiceProvider =
+    Provider<StudyGroupService>((ref) => StudyGroupService());
+
+final studyGroupsProvider = FutureProvider<List<StudyGroup>>(
+  (ref) async {
+    final service = ref.watch(studyGroupServiceProvider);
+    return service.fetchGroups();
+  },
+  dependencies: [studyGroupServiceProvider],
+);

--- a/lib/providers/suggestions_providers.dart
+++ b/lib/providers/suggestions_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/suggestion_service.dart';
+
+final suggestionServiceProvider =
+    Provider<SuggestionService>((ref) => SuggestionService());
+
+final suggestionsProvider = FutureProvider<List<Suggestion>>(
+  (ref) async {
+    final service = ref.watch(suggestionServiceProvider);
+    return service.fetchSuggestions();
+  },
+  dependencies: [suggestionServiceProvider],
+);

--- a/lib/providers/tutoring_providers.dart
+++ b/lib/providers/tutoring_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/tutoring_service.dart';
+
+final tutoringServiceProvider =
+    Provider<TutoringService>((ref) => TutoringService());
+
+final tutoringPostsProvider = FutureProvider<List<TutoringPost>>(
+  (ref) async {
+    final service = ref.watch(tutoringServiceProvider);
+    return service.fetchPosts();
+  },
+  dependencies: [tutoringServiceProvider],
+);


### PR DESCRIPTION
## Summary

Second batch of page migrations, larger this time per the previous feedback. Six pages from across the app, plus the paired PostTutoringPage. All follow the now-proven wrapper pattern.

**Six commits (one per page or paired entry):**

1. \`migrate PollsPage to Riverpod\` — list + vote-and-invalidate
2. \`migrate EmergencyContactsPage to Riverpod\` — list-only, no mutations
3. \`migrate StudyGroupsPage to Riverpod\` — list + join/leave actions
4. \`migrate TutoringPage and PostTutoringPage to Riverpod\` — paired, post page invalidates on success (same pattern as PostItemPage in #180)
5. \`migrate DocumentsPage to Riverpod\` — list + upload/download
6. \`migrate SuggestionBoxPage to Riverpod\` — admin-conditional list + submit/delete

## No test changes

None of these pages have widget tests. The wrapper pattern preserves the \`service:\` constructor argument so future tests can inject a fake exactly like \`ItemExchangePage\`/\`MaintenancePage\` tests do.

## Test plan

- [ ] CI: Flutter job green
- [ ] CI: server job green (untouched)
- [ ] Manual: walk each page (Polls vote, Emergency call, Study group join/leave, Tutoring post, Document upload, Suggestion submit) and confirm lists refresh after actions