### PR TITLE
Finish remaining page migrations to Riverpod

### DIFF
--- a/lib/pages/bulletin_board_page.dart
+++ b/lib/pages/bulletin_board_page.dart
@@ -1,22 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/bulletin_providers.dart';
 import '../services/bulletin_service.dart';
 import '../utils/user_helpers.dart';
 
-class BulletinBoardPage extends StatefulWidget {
+class BulletinBoardPage extends ConsumerStatefulWidget {
   final BulletinService? service;
   const BulletinBoardPage({super.key, this.service});
 
   @override
-  State<BulletinBoardPage> createState() => _BulletinBoardPageState();
+  ConsumerState<BulletinBoardPage> createState() => _BulletinBoardPageState();
 }
 
-class _BulletinBoardPageState extends State<BulletinBoardPage> {
-  late final BulletinService _service;
+class _BulletinBoardPageState extends ConsumerState<BulletinBoardPage> {
   final TextEditingController _textCtrl = TextEditingController();
   List<BulletinPost> _posts = [];
   final Map<int, List<BulletinComment>> _comments = {};
   final Map<int, TextEditingController> _commentCtrls = {};
+
+  BulletinService _resolveService() {
+    final BulletinService service =
+        widget.service ?? ref.read(bulletinServiceProvider);
+    return service;
+  }
 
   String _authorName(String userId) {
     final me = currentUserId();
@@ -26,29 +34,31 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? BulletinService();
-    _loadPosts();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadPosts());
   }
 
   Future<void> _loadPosts() async {
-    final posts = await _service.fetchPosts();
+    final service = _resolveService();
+    final posts = await service.fetchPosts();
     if (!mounted) return;
     final commentEntries = <int, List<BulletinComment>>{};
     for (final p in posts) {
       if (p.id != null) {
-        commentEntries[p.id!] = await _service.fetchComments(p.id!);
+        commentEntries[p.id!] = await service.fetchComments(p.id!);
       }
     }
     setState(() {
       _posts = posts;
-      _comments.addAll(commentEntries);
+      _comments
+        ..clear()
+        ..addAll(commentEntries);
     });
   }
 
   Future<void> _submit() async {
     final text = _textCtrl.text.trim();
     if (text.isEmpty) return;
-    final post = await _service.addPost(
+    final post = await _resolveService().addPost(
       BulletinPost(userId: currentUserId(), content: text),
     );
     if (!mounted) return;
@@ -64,7 +74,7 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
     if (ctrl == null) return;
     final text = ctrl.text.trim();
     if (text.isEmpty) return;
-    final comment = await _service.addComment(
+    final comment = await _resolveService().addComment(
       BulletinComment(
         postId: postId,
         userId: currentUserId(),
@@ -96,7 +106,7 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
       ),
     );
     if (result != null && result.isNotEmpty) {
-      final updated = await _service.updatePost(
+      final updated = await _resolveService().updatePost(
         BulletinPost(
           id: post.id,
           userId: post.userId,
@@ -113,7 +123,7 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
   }
 
   Future<void> _deletePost(int id) async {
-    await _service.deletePost(id);
+    await _resolveService().deletePost(id);
     if (!mounted) return;
     setState(() {
       _posts.removeWhere((p) => p.id == id);
@@ -141,6 +151,9 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
       ),
     );
     if (result != null && result.isNotEmpty) {
+      // NOTE: the previous implementation only mutated local state here;
+      // there is no BulletinService.updateComment endpoint. Preserved as-is
+      // — fixing the comment-mutation API is its own follow-up.
       setState(() {
         final list = _comments[postId];
         final idx = list?.indexWhere((c) => c.id == comment.id) ?? -1;
@@ -158,6 +171,8 @@ class _BulletinBoardPageState extends State<BulletinBoardPage> {
   }
 
   void _deleteComment(int postId, int id) {
+    // NOTE: server-side comment deletion is also missing; we only drop the
+    // local entry. Same caveat as _editComment.
     setState(() {
       _comments[postId]?.removeWhere((c) => c.id == id);
     });

--- a/lib/pages/club_detail_page.dart
+++ b/lib/pages/club_detail_page.dart
@@ -1,37 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/clubs_providers.dart';
 import '../services/club_service.dart';
-import '../services/chat_service.dart';
 import '../utils/user_helpers.dart';
-import 'group_chat_page.dart';
 import 'documents_page.dart';
+import 'group_chat_page.dart';
 
-class ClubDetailPage extends StatefulWidget {
+class ClubDetailPage extends ConsumerStatefulWidget {
   final Club club;
   final ClubService? service;
   const ClubDetailPage({super.key, required this.club, this.service});
 
   @override
-  State<ClubDetailPage> createState() => _ClubDetailPageState();
+  ConsumerState<ClubDetailPage> createState() => _ClubDetailPageState();
 }
 
-class _ClubDetailPageState extends State<ClubDetailPage> {
-  late Club _club;
-  late final ClubService _service;
-  final ChatService _chat = ChatService();
+class _ClubDetailPageState extends ConsumerState<ClubDetailPage> {
+  late Club _club = widget.club;
 
-  @override
-  void initState() {
-    super.initState();
-    _club = widget.club;
-    _service = widget.service ?? ClubService();
+  ClubService _resolveService() {
+    final ClubService service = widget.service ?? ref.read(clubServiceProvider);
+    return service;
   }
 
   Future<void> _joinAndChat() async {
     if (_club.id == null || _club.channelId == null) return;
-    final updated = await _service.joinClub(_club.id!);
-    if (mounted) setState(() => _club = updated);
+    final updated = await _resolveService().joinClub(_club.id!);
+    if (mounted) {
+      setState(() => _club = updated);
+      ref.invalidate(clubsProvider);
+    }
     if (!mounted) return;
     Navigator.push(
       context,

--- a/lib/pages/create_channel_page.dart
+++ b/lib/pages/create_channel_page.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../models/models.dart';
-import '../services/chat_service.dart';
+import '../providers/chat_providers.dart';
 
-class CreateChannelPage extends StatefulWidget {
+class CreateChannelPage extends ConsumerStatefulWidget {
   const CreateChannelPage({super.key});
 
   @override
-  State<CreateChannelPage> createState() => _CreateChannelPageState();
+  ConsumerState<CreateChannelPage> createState() => _CreateChannelPageState();
 }
 
-class _CreateChannelPageState extends State<CreateChannelPage> {
+class _CreateChannelPageState extends ConsumerState<CreateChannelPage> {
   final TextEditingController _nameCtrl = TextEditingController();
-  final ChatService _service = ChatService();
   bool _creating = false;
 
   Future<void> _create() async {
@@ -20,7 +19,7 @@ class _CreateChannelPageState extends State<CreateChannelPage> {
     if (name.isEmpty) return;
     setState(() => _creating = true);
     try {
-      final channel = await _service.createChannel(name);
+      final channel = await ref.read(chatServiceProvider).createChannel(name);
       if (!mounted) return;
       Navigator.pop(context, channel);
     } catch (e) {

--- a/lib/pages/forgot_password_page.dart
+++ b/lib/pages/forgot_password_page.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
-import '../services/auth_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/auth_providers.dart';
 import '../utils/validators.dart';
 
-class ForgotPasswordPage extends StatefulWidget {
+class ForgotPasswordPage extends ConsumerStatefulWidget {
   const ForgotPasswordPage({super.key});
 
   @override
-  State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
+  ConsumerState<ForgotPasswordPage> createState() =>
+      _ForgotPasswordPageState();
 }
 
-class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
+class _ForgotPasswordPageState extends ConsumerState<ForgotPasswordPage> {
   final _formKey = GlobalKey<FormState>();
   final _emailCtrl = TextEditingController();
   bool _loading = false;
@@ -24,7 +27,9 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _loading = true);
     try {
-      await AuthService().requestPasswordReset(_emailCtrl.text.trim());
+      await ref
+          .read(authServiceProvider)
+          .requestPasswordReset(_emailCtrl.text.trim());
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Reset email sent')),

--- a/lib/pages/group_chat_page.dart
+++ b/lib/pages/group_chat_page.dart
@@ -1,21 +1,22 @@
-import 'package:flutter/material.dart';
-
-import '../models/models.dart';
-import '../services/chat_service.dart';
-import '../utils/user_helpers.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
 
-class GroupChatPage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/models.dart';
+import '../providers/chat_providers.dart';
+import '../utils/user_helpers.dart';
+
+class GroupChatPage extends ConsumerStatefulWidget {
   final ChatChannel channel;
   const GroupChatPage({super.key, required this.channel});
 
   @override
-  State<GroupChatPage> createState() => _GroupChatPageState();
+  ConsumerState<GroupChatPage> createState() => _GroupChatPageState();
 }
 
-class _GroupChatPageState extends State<GroupChatPage> {
-  final ChatService _service = ChatService();
+class _GroupChatPageState extends ConsumerState<GroupChatPage> {
   final TextEditingController _messageCtrl = TextEditingController();
   List<Message> _messages = [];
   WebSocketChannel? _channel;
@@ -24,13 +25,15 @@ class _GroupChatPageState extends State<GroupChatPage> {
   @override
   void initState() {
     super.initState();
-    _loadMessages();
-    _connectSocket();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadMessages();
+      _connectSocket();
+    });
   }
 
   void _connectSocket() {
     if (widget.channel.id == null) return;
-    _channel = _service.connect(widget.channel.id!);
+    _channel = ref.read(chatServiceProvider).connect(widget.channel.id!);
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
       if (data['type'] == 'message') {
@@ -55,7 +58,8 @@ class _GroupChatPageState extends State<GroupChatPage> {
 
   Future<void> _loadMessages() async {
     if (widget.channel.id == null) return;
-    final msgs = await _service.fetchMessages(widget.channel.id!);
+    final service = ref.read(chatServiceProvider);
+    final msgs = await service.fetchMessages(widget.channel.id!);
     if (!mounted) return;
     setState(() => _messages = msgs);
   }
@@ -63,7 +67,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
   Future<void> _sendMessage() async {
     final text = _messageCtrl.text.trim();
     if (text.isEmpty || widget.channel.id == null) return;
-    await _service.sendMessage(widget.channel.id!, text);
+    await ref.read(chatServiceProvider).sendMessage(widget.channel.id!, text);
     _messageCtrl.clear();
   }
 

--- a/lib/pages/item_chat_page.dart
+++ b/lib/pages/item_chat_page.dart
@@ -1,40 +1,49 @@
-import 'package:flutter/material.dart';
-import '../models/models.dart';
-import '../services/item_service.dart';
-import '../utils/user_helpers.dart';
-import '../services/chat_service.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
 
-class ItemChatPage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/models.dart';
+import '../providers/chat_providers.dart';
+import '../providers/item_providers.dart';
+import '../services/item_service.dart';
+import '../utils/user_helpers.dart';
+
+class ItemChatPage extends ConsumerStatefulWidget {
   final Item item;
   final ItemService? service;
   const ItemChatPage({super.key, required this.item, this.service});
 
   @override
-  State<ItemChatPage> createState() => _ItemChatPageState();
+  ConsumerState<ItemChatPage> createState() => _ItemChatPageState();
 }
 
-class _ItemChatPageState extends State<ItemChatPage> {
-  late final ItemService _service;
+class _ItemChatPageState extends ConsumerState<ItemChatPage> {
   final TextEditingController _messageCtrl = TextEditingController();
-
   List<Message> _messages = [];
-  final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
   bool _online = false;
+
+  ItemService _resolveService() {
+    final ItemService service =
+        widget.service ?? ref.read(itemServiceProvider);
+    return service;
+  }
 
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? ItemService();
-    _loadMessages();
-    _connectSocket();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadMessages();
+      _connectSocket();
+    });
   }
 
   void _connectSocket() {
     if (widget.item.id == null) return;
-    _channel = _chat.connect(widget.item.id!.toString());
+    _channel =
+        ref.read(chatServiceProvider).connect(widget.item.id!.toString());
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
       if (data['type'] == 'message') {
@@ -54,7 +63,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
   Future<void> _loadMessages() async {
     if (widget.item.id == null) return;
     try {
-      final msgs = await _service.fetchMessages(widget.item.id!);
+      final msgs = await _resolveService().fetchMessages(widget.item.id!);
       if (!mounted) return;
       setState(() => _messages = msgs);
     } catch (_) {
@@ -71,7 +80,7 @@ class _ItemChatPageState extends State<ItemChatPage> {
       content: text,
     );
     try {
-      await _service.sendMessage(message);
+      await _resolveService().sendMessage(message);
       _messageCtrl.clear();
     } catch (_) {
       // ignore errors in example

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import '../models/models.dart';
-import '../utils/validators.dart';
+import '../providers/auth_providers.dart';
 import '../services/auth_service.dart';
+import '../utils/validators.dart';
 
 /// A simple login page with email/password and placeholder Google/Apple login buttons.
-class LoginPage extends StatefulWidget {
+class LoginPage extends ConsumerStatefulWidget {
   final VoidCallback onLoginSuccess;
   final AuthService? service;
   final GoogleSignIn? googleSignIn;
@@ -23,10 +25,10 @@ class LoginPage extends StatefulWidget {
   });
 
   @override
-  State<LoginPage> createState() => _LoginPageState();
+  ConsumerState<LoginPage> createState() => _LoginPageState();
 }
 
-class _LoginPageState extends State<LoginPage> {
+class _LoginPageState extends ConsumerState<LoginPage> {
   static const bool useMock = false; // Toggle between mock and real API
   final _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
@@ -54,7 +56,7 @@ class _LoginPageState extends State<LoginPage> {
       };
     }
 
-    final service = widget.service ?? AuthService();
+    final AuthService service = widget.service ?? ref.read(authServiceProvider);
     return service.login(email, password);
   }
 

--- a/lib/pages/lost_found_detail_page.dart
+++ b/lib/pages/lost_found_detail_page.dart
@@ -1,41 +1,50 @@
-import 'package:flutter/material.dart';
-import '../models/models.dart';
-import '../services/lost_found_service.dart';
-import '../utils/user_helpers.dart';
-import '../services/chat_service.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
 
-class LostFoundDetailPage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/models.dart';
+import '../providers/chat_providers.dart';
+import '../providers/lost_found_providers.dart';
+import '../services/lost_found_service.dart';
+import '../utils/user_helpers.dart';
+
+class LostFoundDetailPage extends ConsumerStatefulWidget {
   final LostItem item;
   final LostFoundService? service;
   const LostFoundDetailPage({super.key, required this.item, this.service});
 
   @override
-  State<LostFoundDetailPage> createState() => _LostFoundDetailPageState();
+  ConsumerState<LostFoundDetailPage> createState() =>
+      _LostFoundDetailPageState();
 }
 
-class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
-  late LostItem _item;
-  late final LostFoundService _service;
+class _LostFoundDetailPageState extends ConsumerState<LostFoundDetailPage> {
+  late LostItem _item = widget.item;
   final _messageCtrl = TextEditingController();
   List<Message> _messages = [];
-  final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
   bool _online = false;
+
+  LostFoundService _resolveService() {
+    final LostFoundService service =
+        widget.service ?? ref.read(lostFoundServiceProvider);
+    return service;
+  }
 
   @override
   void initState() {
     super.initState();
-    _item = widget.item;
-    _service = widget.service ?? LostFoundService();
-    _loadMessages();
-    _connectSocket();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadMessages();
+      _connectSocket();
+    });
   }
 
   void _connectSocket() {
     if (_item.id == null) return;
-    _channel = _chat.connect(_item.id!.toString());
+    _channel = ref.read(chatServiceProvider).connect(_item.id!.toString());
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
       if (data['type'] == 'message') {
@@ -55,7 +64,7 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
   Future<void> _loadMessages() async {
     if (_item.id == null) return;
     try {
-      final msgs = await _service.fetchMessages(_item.id!);
+      final msgs = await _resolveService().fetchMessages(_item.id!);
       if (mounted) setState(() => _messages = msgs);
     } catch (_) {}
   }
@@ -69,7 +78,7 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
       content: text,
     );
     try {
-      await _service.sendMessage(_item.id!, msg);
+      await _resolveService().sendMessage(_item.id!, msg);
       if (mounted) {
         _messageCtrl.clear();
       }
@@ -78,14 +87,20 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
 
   Future<void> _resolveItem() async {
     if (_item.id == null) return;
-    await _service.resolveItem(_item.id!);
-    if (mounted) Navigator.pop(context, true);
+    await _resolveService().resolveItem(_item.id!);
+    if (mounted) {
+      ref.invalidate(lostFoundItemsProvider);
+      Navigator.pop(context, true);
+    }
   }
 
   Future<void> _deleteItem() async {
     if (_item.id == null) return;
-    await _service.deleteItem(_item.id!);
-    if (mounted) Navigator.pop(context, true);
+    await _resolveService().deleteItem(_item.id!);
+    if (mounted) {
+      ref.invalidate(lostFoundItemsProvider);
+      Navigator.pop(context, true);
+    }
   }
 
   Future<void> _editItem() async {
@@ -121,7 +136,7 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
       ),
     );
     if (result == true && _item.id != null) {
-      final updated = await _service.updateItem(
+      final updated = await _resolveService().updateItem(
         LostItem(
           id: _item.id,
           ownerId: _item.ownerId,
@@ -135,7 +150,10 @@ class _LostFoundDetailPageState extends State<LostFoundDetailPage> {
           createdAt: _item.createdAt,
         ),
       );
-      if (mounted) setState(() => _item = updated);
+      if (mounted) {
+        setState(() => _item = updated);
+        ref.invalidate(lostFoundItemsProvider);
+      }
     }
   }
 

--- a/lib/pages/maintenance_chat_page.dart
+++ b/lib/pages/maintenance_chat_page.dart
@@ -1,38 +1,42 @@
-import 'package:flutter/material.dart';
-import '../models/models.dart';
-import '../services/maintenance_service.dart';
-import '../utils/user_helpers.dart';
-import '../services/chat_service.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
 
-class MaintenanceChatPage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/models.dart';
+import '../providers/chat_providers.dart';
+import '../providers/maintenance_providers.dart';
+import '../utils/user_helpers.dart';
+
+class MaintenanceChatPage extends ConsumerStatefulWidget {
   final MaintenanceRequest request;
   const MaintenanceChatPage({super.key, required this.request});
 
   @override
-  State<MaintenanceChatPage> createState() => _MaintenanceChatPageState();
+  ConsumerState<MaintenanceChatPage> createState() =>
+      _MaintenanceChatPageState();
 }
 
-class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
-  final MaintenanceService _service = MaintenanceService();
+class _MaintenanceChatPageState extends ConsumerState<MaintenanceChatPage> {
   final TextEditingController _messageCtrl = TextEditingController();
-
   List<Message> _messages = [];
-  final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
   bool _online = false;
 
   @override
   void initState() {
     super.initState();
-    _loadMessages();
-    _connectSocket();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadMessages();
+      _connectSocket();
+    });
   }
 
   void _connectSocket() {
     if (widget.request.id == null) return;
-    _channel = _chat.connect(widget.request.id!.toString());
+    _channel =
+        ref.read(chatServiceProvider).connect(widget.request.id!.toString());
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
       if (data['type'] == 'message') {
@@ -51,8 +55,9 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
 
   Future<void> _loadMessages() async {
     if (widget.request.id == null) return;
-    final msgs = await _service.fetchMessages(widget.request.id!);
-    setState(() => _messages = msgs);
+    final service = ref.read(maintenanceServiceProvider);
+    final msgs = await service.fetchMessages(widget.request.id!);
+    if (mounted) setState(() => _messages = msgs);
   }
 
   Future<void> _sendMessage() async {
@@ -63,7 +68,7 @@ class _MaintenanceChatPageState extends State<MaintenanceChatPage> {
       senderId: currentUserId(),
       content: text,
     );
-    await _service.sendMessage(message);
+    await ref.read(maintenanceServiceProvider).sendMessage(message);
     _messageCtrl.clear();
   }
 

--- a/lib/pages/map_page.dart
+++ b/lib/pages/map_page.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_tile_caching/flutter_map_tile_caching.dart';
-import 'package:latlong2/latlong.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
 
 import '../models/map_pin.dart';
+import '../providers/map_providers.dart';
 import '../services/map_service.dart';
 
-class MapPage extends StatefulWidget {
+class MapPage extends StatelessWidget {
   final MapService? service;
   final bool loadTiles;
   final List<LatLng>? route;
@@ -21,13 +23,31 @@ class MapPage extends StatefulWidget {
   });
 
   @override
-  State<MapPage> createState() => _MapPageState();
+  Widget build(BuildContext context) {
+    final body = _MapBody(loadTiles: loadTiles, route: route, center: center);
+    if (service == null) return body;
+    return ProviderScope(
+      overrides: [mapServiceProvider.overrideWithValue(service!)],
+      child: body,
+    );
+  }
 }
 
-class _MapPageState extends State<MapPage> {
-  late final MapService _service;
-  List<MapPin> _allPins = [];
-  List<MapPin> _visiblePins = [];
+class _MapBody extends ConsumerStatefulWidget {
+  final bool loadTiles;
+  final List<LatLng>? route;
+  final LatLng? center;
+  const _MapBody({
+    required this.loadTiles,
+    required this.route,
+    required this.center,
+  });
+
+  @override
+  ConsumerState<_MapBody> createState() => _MapBodyState();
+}
+
+class _MapBodyState extends ConsumerState<_MapBody> {
   final TextEditingController _searchCtrl = TextEditingController();
   Set<MapPinCategory> _selectedCats = {};
   List<MapPin> _selectedPins = [];
@@ -36,53 +56,39 @@ class _MapPageState extends State<MapPage> {
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? MapService();
     _selectedCats = Set.from(MapPinCategory.values);
     _route = widget.route;
-    _loadPins();
   }
 
-  Future<void> _loadPins() async {
-    final pins = await _service.fetchPins();
-    setState(() {
-      _allPins = pins;
-      _applyFilters();
-    });
-  }
-
-  void _applyFilters() {
+  List<MapPin> _filteredPins(List<MapPin> all) {
     final query = _searchCtrl.text.toLowerCase();
-    setState(() {
-      _visiblePins =
-          _allPins.where((p) {
-            final matchesText = p.title.toLowerCase().contains(query);
-            final matchesCat = _selectedCats.contains(p.category);
-            return matchesText && matchesCat;
-          }).toList();
-    });
+    return all
+        .where((p) =>
+            p.title.toLowerCase().contains(query) &&
+            _selectedCats.contains(p.category))
+        .toList();
   }
 
   Future<void> _onPinTap(MapPin pin) async {
     final result = await showModalBottomSheet<String>(
       context: context,
-      builder:
-          (ctx) => SafeArea(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ListTile(
-                  leading: const Icon(Icons.add_location),
-                  title: const Text('Add to route'),
-                  onTap: () => Navigator.pop(ctx, 'add'),
-                ),
-                ListTile(
-                  leading: const Icon(Icons.my_location),
-                  title: const Text('Route from my location'),
-                  onTap: () => Navigator.pop(ctx, 'from'),
-                ),
-              ],
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add_location),
+              title: const Text('Add to route'),
+              onTap: () => Navigator.pop(ctx, 'add'),
             ),
-          ),
+            ListTile(
+              leading: const Icon(Icons.my_location),
+              title: const Text('Route from my location'),
+              onTap: () => Navigator.pop(ctx, 'from'),
+            ),
+          ],
+        ),
+      ),
     );
 
     if (result == 'add') {
@@ -106,11 +112,12 @@ class _MapPageState extends State<MapPage> {
   }
 
   Future<void> _updateRoute() async {
+    final service = ref.read(mapServiceProvider);
     if (_selectedPins.length == 2) {
       final start = LatLng(_selectedPins[0].lat, _selectedPins[0].lon);
       final end = LatLng(_selectedPins[1].lat, _selectedPins[1].lon);
-      final r = await _service.fetchRoute(start, end);
-      setState(() => _route = r);
+      final r = await service.fetchRoute(start, end);
+      if (mounted) setState(() => _route = r);
     } else if (_selectedPins.length == 1) {
       try {
         var perm = await Geolocator.checkPermission();
@@ -119,19 +126,19 @@ class _MapPageState extends State<MapPage> {
         }
         if (perm == LocationPermission.denied ||
             perm == LocationPermission.deniedForever) {
-          setState(() => _route = null);
+          if (mounted) setState(() => _route = null);
           return;
         }
         final pos = await Geolocator.getCurrentPosition();
         final start = LatLng(pos.latitude, pos.longitude);
         final end = LatLng(_selectedPins[0].lat, _selectedPins[0].lon);
-        final r = await _service.fetchRoute(start, end);
-        setState(() => _route = r);
+        final r = await service.fetchRoute(start, end);
+        if (mounted) setState(() => _route = r);
       } catch (_) {
-        setState(() => _route = null);
+        if (mounted) setState(() => _route = null);
       }
     } else {
-      setState(() => _route = null);
+      if (mounted) setState(() => _route = null);
     }
   }
 
@@ -143,9 +150,12 @@ class _MapPageState extends State<MapPage> {
 
   @override
   Widget build(BuildContext context) {
+    final allPins =
+        ref.watch(mapPinsProvider).valueOrNull ?? const <MapPin>[];
+    final visiblePins = _filteredPins(allPins);
     return Scaffold(
       floatingActionButton: FloatingActionButton(
-        onPressed: _loadPins,
+        onPressed: () => ref.invalidate(mapPinsProvider),
         child: const Icon(Icons.refresh),
       ),
       body: Stack(
@@ -163,28 +173,27 @@ class _MapPageState extends State<MapPage> {
                   tileProvider: _safeProvider(),
                 ),
               MarkerLayer(
-                markers:
-                    _visiblePins
-                        .map(
-                          (p) => Marker(
-                            width: 40,
-                            height: 40,
-                            point: LatLng(p.lat, p.lon),
-                            child: GestureDetector(
-                              key: ValueKey(p.id),
-                              onTap: () => _onPinTap(p),
-                              child: Semantics(
-                                label: p.id,
-                                child: Icon(
-                                  Icons.location_pin,
-                                  color: _colorFor(p.category),
-                                  size: 32,
-                                ),
-                              ),
+                markers: visiblePins
+                    .map(
+                      (p) => Marker(
+                        width: 40,
+                        height: 40,
+                        point: LatLng(p.lat, p.lon),
+                        child: GestureDetector(
+                          key: ValueKey(p.id),
+                          onTap: () => _onPinTap(p),
+                          child: Semantics(
+                            label: p.id,
+                            child: Icon(
+                              Icons.location_pin,
+                              color: _colorFor(p.category),
+                              size: 32,
                             ),
                           ),
-                        )
-                        .toList(),
+                        ),
+                      ),
+                    )
+                    .toList(),
               ),
               if (_route != null)
                 PolylineLayer(
@@ -217,7 +226,7 @@ class _MapPageState extends State<MapPage> {
                         borderSide: BorderSide.none,
                       ),
                     ),
-                    onChanged: (_) => _applyFilters(),
+                    onChanged: (_) => setState(() {}),
                   ),
                   const SizedBox(height: 8),
                   SizedBox(
@@ -239,7 +248,6 @@ class _MapPageState extends State<MapPage> {
                               } else {
                                 _selectedCats.add(cat);
                               }
-                              _applyFilters();
                             });
                           },
                         );

--- a/lib/pages/post_service_listing_page.dart
+++ b/lib/pages/post_service_listing_page.dart
@@ -1,32 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/service_listings_providers.dart';
 import '../services/service_list_service.dart';
 import '../utils/user_helpers.dart';
 
-class PostServiceListingPage extends StatefulWidget {
+class PostServiceListingPage extends ConsumerStatefulWidget {
   final ServiceListing? listing;
   final ServiceListService? service;
 
   const PostServiceListingPage({super.key, this.listing, this.service});
 
   @override
-  State<PostServiceListingPage> createState() => _PostServiceListingPageState();
+  ConsumerState<PostServiceListingPage> createState() =>
+      _PostServiceListingPageState();
 }
 
-class _PostServiceListingPageState extends State<PostServiceListingPage> {
+class _PostServiceListingPageState
+    extends ConsumerState<PostServiceListingPage> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _titleCtrl;
   late final TextEditingController _descCtrl;
   late final TextEditingController _contactCtrl;
-  late final ServiceListService _service;
   bool _submitting = false;
 
   bool get _editing => widget.listing != null;
 
+  ServiceListService _resolveService() {
+    final ServiceListService service =
+        widget.service ?? ref.read(serviceListServiceProvider);
+    return service;
+  }
+
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? ServiceListService();
     final l = widget.listing;
     _titleCtrl = TextEditingController(text: l?.title ?? '');
     _descCtrl = TextEditingController(text: l?.description ?? '');
@@ -55,12 +64,14 @@ class _PostServiceListingPageState extends State<PostServiceListingPage> {
             ? null
             : _contactCtrl.text.trim(),
       );
+      final service = _resolveService();
       if (editing) {
-        await _service.updateListing(listing);
+        await service.updateListing(listing);
       } else {
-        await _service.addListing(listing);
+        await service.addListing(listing);
       }
       if (mounted) {
+        ref.invalidate(serviceListingsProvider);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(editing ? 'Listing updated!' : 'Listing posted!'),
@@ -102,8 +113,9 @@ class _PostServiceListingPageState extends State<PostServiceListingPage> {
       ),
     );
     if (confirm != true) return;
-    await _service.deleteListing(id);
+    await _resolveService().deleteListing(id);
     if (mounted) {
+      ref.invalidate(serviceListingsProvider);
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Listing deleted')));

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,24 +1,26 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:image_picker/image_picker.dart';
-import '../models/models.dart';
+
 import '../main.dart';
+import '../models/models.dart';
+import '../providers/user_providers.dart';
 import '../services/user_service.dart';
 
-class ProfilePage extends StatefulWidget {
+class ProfilePage extends ConsumerStatefulWidget {
   final UserService? service;
   const ProfilePage({super.key, this.service});
 
   @override
-  State<ProfilePage> createState() => _ProfilePageState();
+  ConsumerState<ProfilePage> createState() => _ProfilePageState();
 }
 
-class _ProfilePageState extends State<ProfilePage> {
+class _ProfilePageState extends ConsumerState<ProfilePage> {
   late final Box<User> _userBox;
   late User _user;
-  late final UserService _service;
 
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _nameCtrl;
@@ -28,10 +30,15 @@ class _ProfilePageState extends State<ProfilePage> {
   late final TextEditingController _roomCtrl;
   XFile? _avatarFile;
 
+  UserService _resolveService() {
+    final UserService service =
+        widget.service ?? ref.read(userServiceProvider);
+    return service;
+  }
+
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? UserService();
     _userBox = Hive.box<User>('userBox');
     _user = _userBox.get('currentUser')!;
     _nameCtrl = TextEditingController(text: _user.name);
@@ -62,9 +69,10 @@ class _ProfilePageState extends State<ProfilePage> {
 
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
+    final service = _resolveService();
     if (_avatarFile != null) {
       try {
-        final path = await _service.uploadAvatar(File(_avatarFile!.path));
+        final path = await service.uploadAvatar(File(_avatarFile!.path));
         _avatarCtrl.text = path;
       } catch (e) {
         if (mounted) {
@@ -87,7 +95,7 @@ class _ProfilePageState extends State<ProfilePage> {
       room: _roomCtrl.text.trim().isEmpty ? null : _roomCtrl.text.trim(),
     );
     try {
-      final user = await _service.updateProfile(updated);
+      final user = await service.updateProfile(updated);
       await _userBox.put('currentUser', user);
       if (mounted) {
         setState(() => _user = user);
@@ -124,7 +132,7 @@ class _ProfilePageState extends State<ProfilePage> {
     );
     if (confirm != true) return;
     try {
-      await _service.deleteAccount();
+      await _resolveService().deleteAccount();
       if (!mounted) return;
       await OlyApp.of(context)?.logout();
     } catch (e) {

--- a/lib/pages/qr_scanner_page.dart
+++ b/lib/pages/qr_scanner_page.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '../providers/qr_providers.dart';
 import '../services/qr_service.dart';
 
-class QrScannerPage extends StatefulWidget {
+class QrScannerPage extends ConsumerStatefulWidget {
   final QrService? service;
   const QrScannerPage({super.key, this.service});
 
   @override
-  State<QrScannerPage> createState() => _QrScannerPageState();
+  ConsumerState<QrScannerPage> createState() => _QrScannerPageState();
 }
 
-class _QrScannerPageState extends State<QrScannerPage> {
+class _QrScannerPageState extends ConsumerState<QrScannerPage> {
   bool _handled = false;
 
   Future<void> _onDetect(BarcodeCapture capture) async {
@@ -20,8 +23,9 @@ class _QrScannerPageState extends State<QrScannerPage> {
     final id = int.tryParse(code.substring(6));
     if (id == null) return;
     _handled = true;
+    final QrService service = widget.service ?? ref.read(qrServiceProvider);
     try {
-      await (widget.service ?? QrService()).checkIn(id);
+      await service.checkIn(id);
       if (mounted) Navigator.pop(context, true);
     } catch (e) {
       if (!mounted) return;

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/models.dart';
-import '../services/auth_service.dart';
+import '../providers/auth_providers.dart';
 import '../utils/validators.dart';
 
-class RegisterPage extends StatefulWidget {
+class RegisterPage extends ConsumerStatefulWidget {
   final VoidCallback? onRegistered;
   const RegisterPage({super.key, this.onRegistered});
 
   @override
-  State<RegisterPage> createState() => _RegisterPageState();
+  ConsumerState<RegisterPage> createState() => _RegisterPageState();
 }
 
-class _RegisterPageState extends State<RegisterPage> {
+class _RegisterPageState extends ConsumerState<RegisterPage> {
   final _formKey = GlobalKey<FormState>();
   final _nameCtrl = TextEditingController();
   final _emailCtrl = TextEditingController();
@@ -41,12 +42,11 @@ class _RegisterPageState extends State<RegisterPage> {
     }
     setState(() => _loading = true);
     try {
-      final service = AuthService();
-      final res = await service.register(
-        _nameCtrl.text.trim(),
-        _emailCtrl.text.trim(),
-        _passwordCtrl.text,
-      );
+      final res = await ref.read(authServiceProvider).register(
+            _nameCtrl.text.trim(),
+            _emailCtrl.text.trim(),
+            _passwordCtrl.text,
+          );
       final token = res['token'] as String;
       final userMap = res['user'] as Map<String, dynamic>;
       final user = User.fromMap(userMap);

--- a/lib/pages/reset_password_page.dart
+++ b/lib/pages/reset_password_page.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
-import '../services/auth_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/auth_providers.dart';
 import '../utils/validators.dart';
 
-class ResetPasswordPage extends StatefulWidget {
+class ResetPasswordPage extends ConsumerStatefulWidget {
   const ResetPasswordPage({super.key});
 
   @override
-  State<ResetPasswordPage> createState() => _ResetPasswordPageState();
+  ConsumerState<ResetPasswordPage> createState() => _ResetPasswordPageState();
 }
 
-class _ResetPasswordPageState extends State<ResetPasswordPage> {
+class _ResetPasswordPageState extends ConsumerState<ResetPasswordPage> {
   final _formKey = GlobalKey<FormState>();
   final _tokenCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
@@ -27,8 +29,10 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _loading = true);
     try {
-      await AuthService()
-          .confirmPasswordReset(_tokenCtrl.text.trim(), _passwordCtrl.text);
+      await ref.read(authServiceProvider).confirmPasswordReset(
+            _tokenCtrl.text.trim(),
+            _passwordCtrl.text,
+          );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Password updated')),

--- a/lib/pages/service_detail_page.dart
+++ b/lib/pages/service_detail_page.dart
@@ -1,44 +1,50 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/service_listings_providers.dart';
 import '../services/service_list_service.dart';
 import '../utils/user_helpers.dart';
 
-class ServiceDetailPage extends StatefulWidget {
+class ServiceDetailPage extends ConsumerStatefulWidget {
   final ServiceListing listing;
   final ServiceListService? service;
 
   const ServiceDetailPage({super.key, required this.listing, this.service});
 
   @override
-  State<ServiceDetailPage> createState() => _ServiceDetailPageState();
+  ConsumerState<ServiceDetailPage> createState() => _ServiceDetailPageState();
 }
 
-class _ServiceDetailPageState extends State<ServiceDetailPage> {
-  late ServiceListing _listing;
-  late ServiceListService _service;
-  List<ServiceRating> _ratings = [];
+class _ServiceDetailPageState extends ConsumerState<ServiceDetailPage> {
+  late ServiceListing _listing = widget.listing;
+  late List<ServiceRating> _ratings = widget.listing.ratings;
   final _ratingCtrl = TextEditingController();
   final _reviewCtrl = TextEditingController();
+
+  ServiceListService _resolveService() {
+    final ServiceListService service =
+        widget.service ?? ref.read(serviceListServiceProvider);
+    return service;
+  }
 
   @override
   void initState() {
     super.initState();
-    _listing = widget.listing;
-    _service = widget.service ?? ServiceListService();
-    _ratings = _listing.ratings;
-    _loadRatings();
+    // Fire the initial fresh fetch after the first frame so ref is usable.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadRatings());
   }
 
   Future<void> _loadRatings() async {
     if (_listing.id == null) return;
-    final list = await _service.fetchRatings(_listing.id!);
+    final list = await _resolveService().fetchRatings(_listing.id!);
     if (mounted) setState(() => _ratings = list);
   }
 
   Future<void> _submitRating() async {
     if (_listing.id == null) return;
     final rating = int.tryParse(_ratingCtrl.text) ?? 0;
-    await _service.submitRating(
+    await _resolveService().submitRating(
       _listing.id!,
       rating,
       review: _reviewCtrl.text,
@@ -48,7 +54,8 @@ class _ServiceDetailPageState extends State<ServiceDetailPage> {
     _reviewCtrl.clear();
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Rating submitted')));
-    _loadRatings();
+    await _loadRatings();
+    if (mounted) ref.invalidate(serviceListingsProvider);
   }
 
   @override

--- a/lib/pages/services_page.dart
+++ b/lib/pages/services_page.dart
@@ -1,51 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/service_listings_providers.dart';
 import '../services/service_list_service.dart';
 import '../utils/user_helpers.dart';
 import 'post_service_listing_page.dart';
 import 'service_detail_page.dart';
 
-class ServicesPage extends StatefulWidget {
+class ServicesPage extends StatelessWidget {
   final ServiceListService? service;
   const ServicesPage({super.key, this.service});
 
   @override
-  State<ServicesPage> createState() => _ServicesPageState();
+  Widget build(BuildContext context) {
+    if (service == null) return const _ServicesBody();
+    return ProviderScope(
+      overrides: [serviceListServiceProvider.overrideWithValue(service!)],
+      child: const _ServicesBody(),
+    );
+  }
 }
 
-class _ServicesPageState extends State<ServicesPage> {
-  late final ServiceListService _service;
-  List<ServiceListing> _listings = [];
+class _ServicesBody extends ConsumerWidget {
+  const _ServicesBody();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? ServiceListService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final listings = await _service.fetchListings();
-    if (!mounted) return;
-    setState(() => _listings = listings);
-  }
-
-  Future<void> _openForm([ServiceListing? listing]) async {
-    final created = await Navigator.push<bool>(
-      context,
-      MaterialPageRoute(
-        builder: (_) =>
-            PostServiceListingPage(listing: listing, service: _service),
-      ),
-    );
-    if (created == true) _load();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = Theme.of(context).colorScheme;
+    final listings = ref.watch(serviceListingsProvider).valueOrNull ??
+        const <ServiceListing>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Services'),
@@ -53,8 +38,8 @@ class _ServicesPageState extends State<ServicesPage> {
         foregroundColor: cs.onPrimaryContainer,
       ),
       body: RefreshIndicator(
-        onRefresh: _load,
-        child: _listings.isEmpty
+        onRefresh: () async => ref.invalidate(serviceListingsProvider),
+        child: listings.isEmpty
             ? ListView(
                 children: const [
                   SizedBox(
@@ -65,20 +50,24 @@ class _ServicesPageState extends State<ServicesPage> {
               )
             : ListView.separated(
                 padding: const EdgeInsets.all(16),
-                itemCount: _listings.length,
+                itemCount: listings.length,
                 separatorBuilder: (_, __) => const Divider(height: 1),
                 itemBuilder: (context, index) {
-                  final listing = _listings[index];
+                  final listing = listings[index];
                   return ListTile(
                     onTap: listing.userId == currentUserId()
-                        ? () => _openForm(listing)
+                        ? () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) =>
+                                    PostServiceListingPage(listing: listing),
+                              ),
+                            )
                         : () => Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (_) => ServiceDetailPage(
-                                  listing: listing,
-                                  service: _service,
-                                ),
+                                builder: (_) =>
+                                    ServiceDetailPage(listing: listing),
                               ),
                             ),
                     title: Text(listing.title),
@@ -120,7 +109,12 @@ class _ServicesPageState extends State<ServicesPage> {
               ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _openForm(),
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const PostServiceListingPage(),
+          ),
+        ),
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,34 +1,40 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
-import '../models/models.dart';
 import '../main.dart';
-import '../services/user_service.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
+import '../models/models.dart';
+import '../providers/user_providers.dart';
 import '../services/notification_service.dart';
+import '../services/user_service.dart';
 import 'emergency_contacts_page.dart';
 import 'suggestion_box_page.dart';
 
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends ConsumerStatefulWidget {
   final UserService? service;
   const SettingsPage({super.key, this.service});
 
   @override
-  State<SettingsPage> createState() => _SettingsPageState();
+  ConsumerState<SettingsPage> createState() => _SettingsPageState();
 }
 
-class _SettingsPageState extends State<SettingsPage> {
+class _SettingsPageState extends ConsumerState<SettingsPage> {
   ThemeMode _themeMode = ThemeMode.system;
   bool _listed = false;
   bool _eventNotif = true;
   bool _announcementNotif = true;
-  late final UserService _service;
   late User _user;
+
+  UserService _resolveService() {
+    final UserService service =
+        widget.service ?? ref.read(userServiceProvider);
+    return service;
+  }
 
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? UserService();
     final settingsBox = Hive.box('settingsBox');
     final stored = settingsBox.get('themeMode', defaultValue: 'system') as String;
     _themeMode = ThemeMode.values.firstWhere(
@@ -58,7 +64,7 @@ class _SettingsPageState extends State<SettingsPage> {
       room: _user.room,
     );
     try {
-      final user = await _service.updateProfile(updated);
+      final user = await _resolveService().updateProfile(updated);
       await Hive.box<User>('userBox').put('currentUser', user);
       if (mounted) setState(() => _user = user);
     } catch (e) {

--- a/lib/pages/transit_page.dart
+++ b/lib/pages/transit_page.dart
@@ -1,35 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../providers/transit_providers.dart';
 import '../services/transit_service.dart';
 
-class TransitPage extends StatefulWidget {
+class TransitPage extends StatelessWidget {
   final TransitService? service;
   const TransitPage({super.key, this.service});
 
   @override
-  State<TransitPage> createState() => _TransitPageState();
+  Widget build(BuildContext context) {
+    if (service == null) return const _TransitBody();
+    return ProviderScope(
+      overrides: [transitServiceProvider.overrideWithValue(service!)],
+      child: const _TransitBody(),
+    );
+  }
 }
 
-class _TransitPageState extends State<TransitPage> {
-  late final TransitService _service;
+class _TransitBody extends ConsumerStatefulWidget {
+  const _TransitBody();
+
+  @override
+  ConsumerState<_TransitBody> createState() => _TransitBodyState();
+}
+
+class _TransitBodyState extends ConsumerState<_TransitBody> {
   final TextEditingController _searchCtrl = TextEditingController();
   List<TransitStop> _searchResults = [];
-  List<TransitStop> _pinned = [];
   TransitStop? _selected;
   List<TransitDeparture> _departures = [];
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? TransitService();
-    _loadPinned();
-  }
-
-  Future<void> _loadPinned() async {
-    final list = await _service.loadPinnedStops();
-    if (!mounted) return;
-    setState(() => _pinned = list);
+  void dispose() {
+    _searchCtrl.dispose();
+    super.dispose();
   }
 
   Future<void> _search(String q) async {
@@ -38,7 +44,7 @@ class _TransitPageState extends State<TransitPage> {
       return;
     }
     try {
-      final results = await _service.searchStops(q);
+      final results = await ref.read(transitServiceProvider).searchStops(q);
       if (!mounted) return;
       setState(() => _searchResults = results);
     } catch (_) {
@@ -50,7 +56,8 @@ class _TransitPageState extends State<TransitPage> {
 
   Future<void> _selectStop(TransitStop stop) async {
     try {
-      final deps = await _service.fetchDepartures(stop.id);
+      final deps =
+          await ref.read(transitServiceProvider).fetchDepartures(stop.id);
       if (!mounted) return;
       setState(() {
         _selected = stop;
@@ -65,24 +72,21 @@ class _TransitPageState extends State<TransitPage> {
     }
   }
 
-  Future<void> _togglePin(TransitStop stop) async {
-    final exists = _pinned.any((p) => p.id == stop.id);
+  Future<void> _togglePin(TransitStop stop, List<TransitStop> pinned) async {
+    final exists = pinned.any((p) => p.id == stop.id);
+    final service = ref.read(transitServiceProvider);
     if (exists) {
-      await _service.unpinStop(stop.id);
+      await service.unpinStop(stop.id);
     } else {
-      await _service.pinStop(stop);
+      await service.pinStop(stop);
     }
-    await _loadPinned();
-  }
-
-  @override
-  void dispose() {
-    _searchCtrl.dispose();
-    super.dispose();
+    ref.invalidate(pinnedStopsProvider);
   }
 
   @override
   Widget build(BuildContext context) {
+    final pinned =
+        ref.watch(pinnedStopsProvider).valueOrNull ?? const <TransitStop>[];
     return Scaffold(
       body: Column(
         children: [
@@ -94,12 +98,12 @@ class _TransitPageState extends State<TransitPage> {
               onChanged: _search,
             ),
           ),
-          if (_pinned.isNotEmpty)
+          if (pinned.isNotEmpty)
             SizedBox(
               height: 40,
               child: ListView(
                 scrollDirection: Axis.horizontal,
-                children: _pinned
+                children: pinned
                     .map(
                       (s) => Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 4.0),
@@ -120,10 +124,10 @@ class _TransitPageState extends State<TransitPage> {
                       (s) => ListTile(
                         title: Text(s.name),
                         trailing: IconButton(
-                          icon: Icon(_pinned.any((p) => p.id == s.id)
+                          icon: Icon(pinned.any((p) => p.id == s.id)
                               ? Icons.star
                               : Icons.star_border),
-                          onPressed: () => _togglePin(s),
+                          onPressed: () => _togglePin(s, pinned),
                         ),
                         onTap: () => _selectStop(s),
                       ),

--- a/lib/pages/user_chat_page.dart
+++ b/lib/pages/user_chat_page.dart
@@ -1,40 +1,48 @@
-import 'package:flutter/material.dart';
-
-import '../models/models.dart';
-import '../services/directory_service.dart';
-import '../utils/user_helpers.dart';
-import '../services/chat_service.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'dart:convert';
 
-class UserChatPage extends StatefulWidget {
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../models/models.dart';
+import '../providers/chat_providers.dart';
+import '../providers/directory_providers.dart';
+import '../services/directory_service.dart';
+import '../utils/user_helpers.dart';
+
+class UserChatPage extends ConsumerStatefulWidget {
   final User user;
   final DirectoryService? service;
   const UserChatPage({super.key, required this.user, this.service});
 
   @override
-  State<UserChatPage> createState() => _UserChatPageState();
+  ConsumerState<UserChatPage> createState() => _UserChatPageState();
 }
 
-class _UserChatPageState extends State<UserChatPage> {
-  late final DirectoryService _service;
+class _UserChatPageState extends ConsumerState<UserChatPage> {
   final TextEditingController _messageCtrl = TextEditingController();
   List<Message> _messages = [];
-  final ChatService _chat = ChatService();
   WebSocketChannel? _channel;
   bool _online = false;
+
+  DirectoryService _resolveService() {
+    final DirectoryService service =
+        widget.service ?? ref.read(directoryServiceProvider);
+    return service;
+  }
 
   @override
   void initState() {
     super.initState();
-    _service = widget.service ?? DirectoryService();
-    _loadMessages();
-    _connectSocket();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadMessages();
+      _connectSocket();
+    });
   }
 
   void _connectSocket() {
     if (widget.user.id == null) return;
-    _channel = _chat.connect(widget.user.id!);
+    _channel = ref.read(chatServiceProvider).connect(widget.user.id!);
     _channel!.stream.listen((event) {
       final data = jsonDecode(event as String) as Map<String, dynamic>;
       if (data['type'] == 'message') {
@@ -53,7 +61,7 @@ class _UserChatPageState extends State<UserChatPage> {
 
   Future<void> _loadMessages() async {
     if (widget.user.id == null) return;
-    final msgs = await _service.fetchMessages(widget.user.id!);
+    final msgs = await _resolveService().fetchMessages(widget.user.id!);
     if (!mounted) return;
     setState(() => _messages = msgs);
   }
@@ -61,7 +69,7 @@ class _UserChatPageState extends State<UserChatPage> {
   Future<void> _sendMessage() async {
     final text = _messageCtrl.text.trim();
     if (text.isEmpty || widget.user.id == null) return;
-    await _service.sendMessage(widget.user.id!, text);
+    await _resolveService().sendMessage(widget.user.id!, text);
     _messageCtrl.clear();
   }
 

--- a/lib/pages/weather_page.dart
+++ b/lib/pages/weather_page.dart
@@ -1,80 +1,67 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/weather_providers.dart';
 import '../services/weather_service.dart';
 
-class WeatherPage extends StatefulWidget {
+class WeatherPage extends StatelessWidget {
   final WeatherService? service;
   const WeatherPage({super.key, this.service});
 
   @override
-  State<WeatherPage> createState() => _WeatherPageState();
+  Widget build(BuildContext context) {
+    if (service == null) return const _WeatherBody();
+    return ProviderScope(
+      overrides: [weatherServiceProvider.overrideWithValue(service!)],
+      child: const _WeatherBody(),
+    );
+  }
 }
 
-class _WeatherPageState extends State<WeatherPage> {
-  late final WeatherService _service;
-  WeatherData? _data;
-  bool _loading = true;
+class _WeatherBody extends ConsumerWidget {
+  const _WeatherBody();
 
   @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? WeatherService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    try {
-      final data = await _service.fetchWeather(48.1740, 11.5475);
-      if (!mounted) return;
-      setState(() {
-        _data = data;
-        _loading = false;
-      });
-    } catch (_) {
-      if (!mounted) return;
-      setState(() => _loading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = Theme.of(context).colorScheme;
+    final weatherAsync = ref.watch(weatherProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Weather'),
         backgroundColor: cs.primaryContainer,
         foregroundColor: cs.onPrimaryContainer,
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : _data == null
-          ? const Center(child: Text('Failed to load'))
-          : RefreshIndicator(
-              onRefresh: _load,
-              child: ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  Text(
-                    'Current: ${_data!.current.temperature.toStringAsFixed(1)}°C, '
-                    'wind ${_data!.current.windspeed.toStringAsFixed(1)} km/h',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'Next hours:',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  ..._data!.forecast.map(
-                    (f) => ListTile(
-                      leading: Text(
-                        '${f.time.hour.toString().padLeft(2, '0')}:00',
-                      ),
-                      title: Text('${f.temperature.toStringAsFixed(1)}°C'),
-                    ),
-                  ),
-                ],
+      body: weatherAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const Center(child: Text('Failed to load')),
+        data: (data) => RefreshIndicator(
+          onRefresh: () async => ref.invalidate(weatherProvider),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                'Current: ${data.current.temperature.toStringAsFixed(1)}°C, '
+                'wind ${data.current.windspeed.toStringAsFixed(1)} km/h',
+                style: Theme.of(context).textTheme.titleMedium,
               ),
-            ),
+              const SizedBox(height: 16),
+              Text(
+                'Next hours:',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              ...data.forecast.map(
+                (f) => ListTile(
+                  leading: Text(
+                    '${f.time.hour.toString().padLeft(2, '0')}:00',
+                  ),
+                  title: Text('${f.temperature.toStringAsFixed(1)}°C'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/wiki_page.dart
+++ b/lib/pages/wiki_page.dart
@@ -1,47 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../models/models.dart';
+import '../providers/wiki_providers.dart';
 import '../services/wiki_service.dart';
 import '../utils/user_helpers.dart';
 
-class WikiPage extends StatefulWidget {
+class WikiPage extends StatelessWidget {
   final WikiService? service;
   const WikiPage({super.key, this.service});
 
   @override
-  State<WikiPage> createState() => _WikiPageState();
+  Widget build(BuildContext context) {
+    if (service == null) return const _WikiBody();
+    return ProviderScope(
+      overrides: [wikiServiceProvider.overrideWithValue(service!)],
+      child: const _WikiBody(),
+    );
+  }
 }
 
-class _WikiPageState extends State<WikiPage> {
-  late final WikiService _service;
-  List<WikiArticle> _articles = [];
+class _WikiBody extends ConsumerWidget {
+  const _WikiBody();
 
   bool get _isAdmin => currentUserIsAdmin();
 
-  @override
-  void initState() {
-    super.initState();
-    _service = widget.service ?? WikiService();
-    _load();
-  }
-
-  Future<void> _load() async {
-    final articles = await _service.fetchArticles();
-    if (!mounted) return;
-    setState(() => _articles = articles);
-  }
-
-  Future<void> _viewArticle(WikiArticle article) async {
+  Future<void> _viewArticle(BuildContext context, WikiArticle article) async {
     await showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: Text(article.title),
         content: SingleChildScrollView(child: Text(article.content)),
-        actions: [TextButton(onPressed: () => Navigator.pop(context), child: const Text('Close'))],
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
       ),
     );
   }
 
-  Future<void> _addOrEdit({WikiArticle? article}) async {
+  Future<void> _addOrEdit(BuildContext context, WidgetRef ref,
+      {WikiArticle? article}) async {
     final titleCtrl = TextEditingController(text: article?.title);
     final contentCtrl = TextEditingController(text: article?.content);
     final result = await showDialog<bool>(
@@ -51,13 +52,26 @@ class _WikiPageState extends State<WikiPage> {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            TextField(controller: titleCtrl, decoration: const InputDecoration(labelText: 'Title')),
-            TextField(controller: contentCtrl, decoration: const InputDecoration(labelText: 'Content'), maxLines: 5),
+            TextField(
+              controller: titleCtrl,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            TextField(
+              controller: contentCtrl,
+              decoration: const InputDecoration(labelText: 'Content'),
+              maxLines: 5,
+            ),
           ],
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
-          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Save')),
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Save'),
+          ),
         ],
       ),
     );
@@ -65,14 +79,13 @@ class _WikiPageState extends State<WikiPage> {
     final title = titleCtrl.text.trim();
     final content = contentCtrl.text.trim();
     if (title.isEmpty || content.isEmpty) return;
+    final service = ref.read(wikiServiceProvider);
     if (article == null) {
-      final created = await _service.addArticle(
+      await service.addArticle(
         WikiArticle(title: title, content: content, authorId: currentUserId()),
       );
-      if (!mounted) return;
-      setState(() => _articles.add(created));
     } else {
-      final updated = await _service.updateArticle(
+      await service.updateArticle(
         WikiArticle(
           id: article.id,
           title: title,
@@ -81,15 +94,12 @@ class _WikiPageState extends State<WikiPage> {
           createdAt: article.createdAt,
         ),
       );
-      if (!mounted) return;
-      setState(() {
-        final idx = _articles.indexWhere((a) => a.id == updated.id);
-        if (idx != -1) _articles[idx] = updated;
-      });
     }
+    ref.invalidate(wikiArticlesProvider);
   }
 
-  Future<void> _delete(WikiArticle article) async {
+  Future<void> _delete(
+      BuildContext context, WidgetRef ref, WikiArticle article) async {
     if (article.id == null) return;
     final confirm = await showDialog<bool>(
       context: context,
@@ -111,14 +121,15 @@ class _WikiPageState extends State<WikiPage> {
       ),
     );
     if (confirm != true) return;
-    await _service.deleteArticle(article.id!);
-    if (!mounted) return;
-    setState(() => _articles.removeWhere((a) => a.id == article.id));
+    await ref.read(wikiServiceProvider).deleteArticle(article.id!);
+    ref.invalidate(wikiArticlesProvider);
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = Theme.of(context).colorScheme;
+    final articles = ref.watch(wikiArticlesProvider).valueOrNull ??
+        const <WikiArticle>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Wiki'),
@@ -127,31 +138,32 @@ class _WikiPageState extends State<WikiPage> {
       ),
       floatingActionButton: _isAdmin
           ? FloatingActionButton(
-              onPressed: () => _addOrEdit(),
+              onPressed: () => _addOrEdit(context, ref),
               child: const Icon(Icons.add),
             )
           : null,
       body: RefreshIndicator(
-        onRefresh: _load,
+        onRefresh: () async => ref.invalidate(wikiArticlesProvider),
         child: ListView.separated(
-          itemCount: _articles.length,
+          itemCount: articles.length,
           separatorBuilder: (_, __) => const Divider(height: 1),
           itemBuilder: (_, i) {
-            final article = _articles[i];
+            final article = articles[i];
             return ListTile(
               title: Text(article.title),
-              onTap: () => _viewArticle(article),
+              onTap: () => _viewArticle(context, article),
               trailing: _isAdmin
                   ? Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         IconButton(
                           icon: const Icon(Icons.edit),
-                          onPressed: () => _addOrEdit(article: article),
+                          onPressed: () =>
+                              _addOrEdit(context, ref, article: article),
                         ),
                         IconButton(
                           icon: const Icon(Icons.delete),
-                          onPressed: () => _delete(article),
+                          onPressed: () => _delete(context, ref, article),
                         ),
                       ],
                     )

--- a/lib/providers/auth_providers.dart
+++ b/lib/providers/auth_providers.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/auth_service.dart';
+
+final authServiceProvider = Provider<AuthService>((ref) => AuthService());

--- a/lib/providers/bulletin_providers.dart
+++ b/lib/providers/bulletin_providers.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/bulletin_service.dart';
+
+final bulletinServiceProvider =
+    Provider<BulletinService>((ref) => BulletinService());
+
+final bulletinPostsProvider = FutureProvider<List<BulletinPost>>(
+  (ref) async {
+    final service = ref.watch(bulletinServiceProvider);
+    return service.fetchPosts();
+  },
+  dependencies: [bulletinServiceProvider],
+);
+
+/// Comments per post. Keyed by post id; each entry is the latest fetch.
+/// Invalidate the family member to refresh comments for that post.
+final bulletinCommentsProvider =
+    FutureProvider.family<List<BulletinComment>, int>(
+  (ref, postId) async {
+    final service = ref.watch(bulletinServiceProvider);
+    return service.fetchComments(postId);
+  },
+  dependencies: [bulletinServiceProvider],
+);

--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/chat_service.dart';
+
+final chatServiceProvider = Provider<ChatService>((ref) => ChatService());

--- a/lib/providers/map_providers.dart
+++ b/lib/providers/map_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/map_pin.dart';
+import '../services/map_service.dart';
+
+final mapServiceProvider = Provider<MapService>((ref) => MapService());
+
+final mapPinsProvider = FutureProvider<List<MapPin>>(
+  (ref) async {
+    final service = ref.watch(mapServiceProvider);
+    return service.fetchPins();
+  },
+  dependencies: [mapServiceProvider],
+);

--- a/lib/providers/qr_providers.dart
+++ b/lib/providers/qr_providers.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/qr_service.dart';
+
+final qrServiceProvider = Provider<QrService>((ref) => QrService());

--- a/lib/providers/service_listings_providers.dart
+++ b/lib/providers/service_listings_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/service_list_service.dart';
+
+final serviceListServiceProvider =
+    Provider<ServiceListService>((ref) => ServiceListService());
+
+final serviceListingsProvider = FutureProvider<List<ServiceListing>>(
+  (ref) async {
+    final service = ref.watch(serviceListServiceProvider);
+    return service.fetchListings();
+  },
+  dependencies: [serviceListServiceProvider],
+);

--- a/lib/providers/transit_providers.dart
+++ b/lib/providers/transit_providers.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/transit_service.dart';
+
+final transitServiceProvider =
+    Provider<TransitService>((ref) => TransitService());
+
+/// User's pinned stops, persisted via the service. Search results and
+/// per-stop departures stay as local widget state (they change too often
+/// to benefit from caching).
+final pinnedStopsProvider = FutureProvider<List<TransitStop>>(
+  (ref) async {
+    final service = ref.watch(transitServiceProvider);
+    return service.loadPinnedStops();
+  },
+  dependencies: [transitServiceProvider],
+);

--- a/lib/providers/user_providers.dart
+++ b/lib/providers/user_providers.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/user_service.dart';
+
+final userServiceProvider = Provider<UserService>((ref) => UserService());

--- a/lib/providers/weather_providers.dart
+++ b/lib/providers/weather_providers.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/weather_service.dart';
+
+final weatherServiceProvider =
+    Provider<WeatherService>((ref) => WeatherService());
+
+/// Current weather + forecast for the dorm coordinates. Refresh by
+/// invalidating the provider.
+final weatherProvider = FutureProvider<WeatherData>(
+  (ref) async {
+    final service = ref.watch(weatherServiceProvider);
+    return service.fetchWeather(48.1740, 11.5475);
+  },
+  dependencies: [weatherServiceProvider],
+);

--- a/lib/providers/wiki_providers.dart
+++ b/lib/providers/wiki_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/models.dart';
+import '../services/wiki_service.dart';
+
+final wikiServiceProvider = Provider<WikiService>((ref) => WikiService());
+
+final wikiArticlesProvider = FutureProvider<List<WikiArticle>>(
+  (ref) async {
+    final service = ref.watch(wikiServiceProvider);
+    return service.fetchArticles();
+  },
+  dependencies: [wikiServiceProvider],
+);

--- a/test/bulletin_board_page_test.dart
+++ b/test/bulletin_board_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/pages/bulletin_board_page.dart';
 import 'package:oly_app/services/bulletin_service.dart';
@@ -70,7 +71,9 @@ void main() {
       },
     );
     await tester.pumpWidget(
-      MaterialApp(home: BulletinBoardPage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: BulletinBoardPage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
     expect(find.text('Hello'), findsOneWidget);
@@ -80,7 +83,9 @@ void main() {
   testWidgets('Submitting adds new post', (tester) async {
     final service = FakeBulletinService([], {});
     await tester.pumpWidget(
-      MaterialApp(home: BulletinBoardPage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: BulletinBoardPage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -97,7 +102,9 @@ void main() {
       {1: []},
     );
     await tester.pumpWidget(
-      MaterialApp(home: BulletinBoardPage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: BulletinBoardPage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -114,7 +121,9 @@ void main() {
       {1: []},
     );
     await tester.pumpWidget(
-      MaterialApp(home: BulletinBoardPage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: BulletinBoardPage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
 
@@ -133,7 +142,9 @@ void main() {
       {1: []},
     );
     await tester.pumpWidget(
-      MaterialApp(home: BulletinBoardPage(service: service)),
+      ProviderScope(
+        child: MaterialApp(home: BulletinBoardPage(service: service)),
+      ),
     );
     await tester.pumpAndSettle();
 

--- a/test/login_page_error_test.dart
+++ b/test/login_page_error_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:oly_app/models/models.dart';
@@ -32,8 +33,10 @@ void main() {
 
   testWidgets('shows server error on invalid credentials', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: LoginPage(onLoginSuccess: () {}, service: FakeAuthService()),
+      ProviderScope(
+        child: MaterialApp(
+          home: LoginPage(onLoginSuccess: () {}, service: FakeAuthService()),
+        ),
       ),
     );
 

--- a/test/profile_page_test.dart
+++ b/test/profile_page_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 import 'package:hive/hive.dart';
@@ -54,7 +55,9 @@ void main() {
 
         // 2) Pump ProfilePage:
         await tester.pumpWidget(
-          MaterialApp(home: ProfilePage(service: service)),
+          ProviderScope(
+            child: MaterialApp(home: ProfilePage(service: service)),
+          ),
         );
         // Give 300ms for any images/animations to complete (instead of pumpAndSettle):
         await tester.pump(const Duration(milliseconds: 300));
@@ -104,7 +107,9 @@ void main() {
 
         // 8) Re‐pump the ProfilePage and give it time to rebuild:
         await tester.pumpWidget(
-          MaterialApp(home: ProfilePage(service: service)),
+          ProviderScope(
+            child: MaterialApp(home: ProfilePage(service: service)),
+          ),
         );
         await tester.pump(const Duration(milliseconds: 300));
 


### PR DESCRIPTION
## Summary

Bigger one-shot PR per request — closes out the Phase 3 state-management migration. Twenty-two pages converted across nine commits, ten new provider files. Every page that used to instantiate a service directly now resolves it through Riverpod.

**Commits (build bottom-up):**

1. \`add providers for the remaining service-using pages\` — ten new provider files: auth, chat, qr, user, weather, wiki, transit, service-listings, map, bulletin. Each FutureProvider declares \`dependencies:\` so nested ProviderScope overrides propagate.
2. \`migrate Qr/CreateChannel/Weather pages to Riverpod\` — three trivial conversions; weather is the first wrapper-pattern user.
3. \`migrate auth pages to Riverpod\` — Login/Register/Forgot/Reset all consume \`authServiceProvider\`; \`login_page_error_test\` wraps in ProviderScope.
4. \`migrate detail pages to Riverpod\` — Club/Service/LostFoundDetail. The LostFound version pulls ChatService through \`chatServiceProvider\` for its WebSocket.
5. \`migrate chat pages to Riverpod\` — Item/Maintenance/User/GroupChat all resolve their service + chat service through Riverpod; messages list and online state stay local because they're WebSocket-driven.
6. \`migrate Wiki/Transit/Services/PostServiceListing pages to Riverpod\` — four pages, including the paired post/list flow for services.
7. \`migrate Profile and Settings pages to Riverpod\` — both consume \`userServiceProvider\`; \`profile_page_test\` wraps in ProviderScope.
8. \`migrate MapPage to Riverpod\` — wrapper pattern with \`mapPinsProvider\`; visible pins derived in build, refresh hits \`ref.invalidate\`.
9. \`migrate BulletinBoardPage to Riverpod\` — intentionally lightweight: only the service resolution moves to Riverpod. Posts/comments stay in local state because the existing edit/delete-comment paths mutate in-memory state without any \`updateComment\`/\`deleteComment\` endpoints on \`BulletinService\` — preserving that pre-existing quirk with explicit NOTE comments rather than rewriting it. Full provider migration here is a follow-up that should also add the missing service endpoints.

## Tests

Four tests touch these pages — all updated to wrap pumped widgets in \`ProviderScope\`:
- \`bulletin_board_page_test\`
- \`login_page_error_test\`
- \`profile_page_test\`
- \`map_page_test\` (no change needed — \`service:\` is always passed, so the wrapper handles the override)

No assertions changed.

## What's still using \`Service()\` directly after this

- \`main_page.dart\`'s \`_fabCallback\` for the Calendar tab (case 2) instantiates \`EventService()\` inline inside the closure. The page is not yet a ConsumerStatefulWidget; touching that would ripple into the four main_page_test cases that pump it bare. Cleaner as a follow-up.
- Tile-caching backend initialization in \`main.dart\` (FMTC) — not a service in the Riverpod sense.

That's it. Every page in \`lib/pages/\` that used to create a service per page is now wired through providers.

## Test plan

- [ ] CI: Flutter job green (28 pages of new builds, the largest changeset this session)
- [ ] CI: server job green (untouched)
- [ ] Manual: walk each tab plus the auth flow and at least one chat page; confirm lists refresh after mutations and that the wrapper override path still works