### PR TITLE
Overhaul UI: 5-destination nav, design tokens, live dashboard

### DIFF
--- a/lib/pages/bulletin_board_page.dart
+++ b/lib/pages/bulletin_board_page.dart
@@ -5,6 +5,7 @@ import '../models/models.dart';
 import '../providers/bulletin_providers.dart';
 import '../services/bulletin_service.dart';
 import '../utils/user_helpers.dart';
+import '../widgets/empty_state.dart';
 
 class BulletinBoardPage extends ConsumerStatefulWidget {
   final BulletinService? service;
@@ -201,19 +202,17 @@ class _BulletinBoardPageState extends ConsumerState<BulletinBoardPage> {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Bulletin Board'),
-        backgroundColor: cs.primaryContainer,
-        foregroundColor: cs.onPrimaryContainer,
-      ),
       body: Column(
         children: [
           Expanded(
             child:
                 _posts.isEmpty
-                    ? const Center(child: Text('No posts yet.'))
+                    ? const EmptyState(
+                      icon: Icons.campaign_outlined,
+                      title: 'Bulletin is empty',
+                      subtitle: 'Be the first to post something.',
+                    )
                     : ListView.separated(
                       itemCount: _posts.length,
                       separatorBuilder: (_, __) => const Divider(height: 1),

--- a/lib/pages/bulletin_board_page.dart
+++ b/lib/pages/bulletin_board_page.dart
@@ -7,6 +7,11 @@ import '../services/bulletin_service.dart';
 import '../utils/user_helpers.dart';
 import '../widgets/empty_state.dart';
 
+/// Bulletin board surface. Designed to be hosted as a [MainPage] destination
+/// (the bulletin tab) — it intentionally does **not** render its own
+/// [AppBar] because [MainPage] already provides one. If you ever need to
+/// push this page directly (deep link, standalone screen, etc.), wrap it
+/// in a [Scaffold] + [AppBar] of your own.
 class BulletinBoardPage extends ConsumerStatefulWidget {
   final BulletinService? service;
   const BulletinBoardPage({super.key, this.service});

--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -15,6 +15,8 @@ import '../services/event_service.dart';
 import '../services/map_service.dart';
 import '../services/qr_service.dart';
 import '../utils/ics_generator.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import 'map_page.dart';
 import 'qr_scanner_page.dart';
 
@@ -247,19 +249,10 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<AsyncValue<List<CalendarEvent>>>(eventsProvider, (prev, next) {
-      if (next.hasError && !next.isLoading) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load events')),
-        );
-      }
-    });
-
     final cs = Theme.of(context).colorScheme;
     final eventsAsync = ref.watch(eventsProvider);
     final categories = ref.watch(calendarCategoriesProvider);
     final selectedCategory = ref.watch(calendarCategoryProvider);
-    final selectedEvents = _eventsForDay(_selectedDay);
 
     return Scaffold(
       body: Column(
@@ -324,27 +317,36 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
             ),
           ),
           Expanded(
-            child: eventsAsync.isLoading
-                ? const Center(child: CircularProgressIndicator())
-                : selectedEvents.isEmpty
-                    ? const Center(child: Text('No events for this day.'))
-                    : ListView.builder(
-                        itemCount: selectedEvents.length,
-                        itemBuilder: (ctx, idx) {
-                          final event = selectedEvents[idx];
-                          return ListTile(
-                            leading: const Icon(Icons.event_note),
-                            title: Text(event.title),
-                            subtitle: Text(
-                                'Attendees: ${event.attendees.length}'),
-                            trailing: TextButton(
-                              onPressed: () => _rsvp(event),
-                              child: const Text('RSVP'),
-                            ),
-                            onTap: () => _showEventDetails(event),
-                          );
-                        },
+            child: AsyncStateView<List<CalendarEvent>>(
+              value: eventsAsync,
+              errorTitle: 'Failed to load events',
+              onRetry: () => ref.invalidate(eventsProvider),
+              isEmpty: (_) => _eventsForDay(_selectedDay).isEmpty,
+              empty: const EmptyState(
+                icon: Icons.event_busy,
+                title: 'No events for this day',
+              ),
+              data: (_) {
+                final selectedEvents = _eventsForDay(_selectedDay);
+                return ListView.builder(
+                  itemCount: selectedEvents.length,
+                  itemBuilder: (ctx, idx) {
+                    final event = selectedEvents[idx];
+                    return ListTile(
+                      leading: const Icon(Icons.event_note),
+                      title: Text(event.title),
+                      subtitle:
+                          Text('Attendees: ${event.attendees.length}'),
+                      trailing: TextButton(
+                        onPressed: () => _rsvp(event),
+                        child: const Text('RSVP'),
                       ),
+                      onTap: () => _showEventDetails(event),
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ],
       ),

--- a/lib/pages/clubs_page.dart
+++ b/lib/pages/clubs_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/models.dart';
 import '../providers/clubs_providers.dart';
 import '../services/club_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import 'club_detail_page.dart';
 
 class ClubsPage extends StatelessWidget {
@@ -28,23 +31,33 @@ class _ClubsBody extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final clubsAsync = ref.watch(clubsProvider);
     final service = ref.watch(clubServiceProvider);
-    final clubs = clubsAsync.valueOrNull ?? const [];
     return Scaffold(
-      body: ListView.builder(
-        itemCount: clubs.length,
-        itemBuilder: (context, index) {
-          final club = clubs[index];
-          return ListTile(
-            title: Text(club.name),
-            subtitle: Text(club.description ?? ''),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => ClubDetailPage(club: club, service: service),
+      body: AsyncStateView<List<Club>>(
+        value: clubsAsync,
+        errorTitle: 'Failed to load clubs',
+        onRetry: () => ref.invalidate(clubsProvider),
+        isEmpty: (clubs) => clubs.isEmpty,
+        empty: const EmptyState(
+          icon: Icons.groups_outlined,
+          title: 'No clubs yet',
+        ),
+        data: (clubs) => ListView.builder(
+          itemCount: clubs.length,
+          itemBuilder: (context, index) {
+            final club = clubs[index];
+            return ListTile(
+              title: Text(club.name),
+              subtitle: Text(club.description ?? ''),
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) =>
+                      ClubDetailPage(club: club, service: service),
+                ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,314 +1,516 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../models/models.dart';
+import '../providers/calendar_providers.dart';
+import '../providers/maintenance_providers.dart';
+import '../providers/user_providers.dart';
+import '../theme/tokens.dart';
 import 'admin/admin_home_page.dart';
-import 'bulletin_board_page.dart';
+import 'booking_page.dart';
+import 'calendar_page.dart';
 import 'clubs_page.dart';
 import 'create_channel_page.dart';
+import 'directory_page.dart';
 import 'documents_page.dart';
 import 'gallery_page.dart';
 import 'group_chat_page.dart';
+import 'item_exchange_page.dart';
 import 'job_posts/job_posts_page.dart';
+import 'lost_found_page.dart';
+import 'maintenance_page.dart';
+import 'nav_target.dart';
+import 'polls_page.dart';
 import 'services_page.dart';
 import 'study_groups_page.dart';
+import 'transit_page.dart';
 import 'tutoring_page.dart';
 import 'weather_page.dart';
+import 'wiki_page.dart';
 
-class DashboardPage extends StatelessWidget {
-  final ValueChanged<int> onNavigate;
+/// The home tab of the bottom nav. Surfaces a greeting, two live status tiles,
+/// and a grouped grid of every feature in the app.
+class DashboardPage extends ConsumerWidget {
+  final ValueChanged<NavTarget> onNavigate;
   final bool isAdmin;
+
+  /// Test-only overrides passed through from [MainPage]. The dashboard pushes
+  /// these instead of constructing fresh pages so widget tests can inject
+  /// fake services.
+  final CalendarPage? injectedCalendarPage;
+  final BookingPage? injectedBookingPage;
+  final MaintenancePage? injectedMaintenancePage;
+  final ItemExchangePage? injectedItemExchangePage;
+
   const DashboardPage({
     super.key,
     required this.onNavigate,
     this.isAdmin = false,
+    this.injectedCalendarPage,
+    this.injectedBookingPage,
+    this.injectedMaintenancePage,
+    this.injectedItemExchangePage,
   });
 
   @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final firstName = ref.watch(currentUserFirstNameProvider);
+    final eventsAsync = ref.watch(eventsProvider);
+    final maintenanceAsync = ref.watch(maintenanceRequestsProvider);
+
     return SafeArea(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+      child: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(eventsProvider);
+          ref.invalidate(maintenanceRequestsProvider);
+          await Future.wait([
+            ref.read(eventsProvider.future),
+            ref.read(maintenanceRequestsProvider.future),
+          ]);
+        },
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.lg),
           children: [
-            const SizedBox(height: 4),
-            Row(
-              children: [
-                Expanded(
-                  child: StatusCard(
-                    icon: Icons.inbox,
-                    label: '0 Replies',
-                    backgroundColor: colorScheme.surfaceContainerHighest,
-                    iconColor: colorScheme.primary,
-                    textColor: colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: StatusCard(
-                    icon: Icons.event,
-                    label: 'BierStube',
-                    backgroundColor: colorScheme.surfaceContainerHighest,
-                    iconColor: colorScheme.primary,
-                    textColor: colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 32),
-            GridView.count(
-              crossAxisCount: 2,
-              mainAxisSpacing: 16,
-              crossAxisSpacing: 16,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              children: [
-                DashboardCard(
-                  icon: Icons.map,
-                  label: 'Map',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(1),
-                ),
-                DashboardCard(
-                  icon: Icons.calendar_today,
-                  label: 'Calendar',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(2),
-                ),
-                DashboardCard(
-                  icon: Icons.schedule,
-                  label: 'Booking',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(3),
-                ),
-                DashboardCard(
-                  icon: Icons.swap_horiz,
-                  label: 'Exchange',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(4),
-                ),
-                DashboardCard(
-                  icon: Icons.help,
-                  label: 'Lost & Found',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(5),
-                ),
-                DashboardCard(
-                  icon: Icons.message,
-                  label: 'Bulletin',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const BulletinBoardPage(),
-                    ),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.build,
-                  label: 'Maintenance',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(6),
-                ),
-                DashboardCard(
-                  icon: Icons.directions_bus,
-                  label: 'Transit',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(7),
-                ),
-                DashboardCard(
-                  icon: Icons.miscellaneous_services,
-                  label: 'Services',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ServicesPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.forum,
-                  label: 'Channels',
-                  colorScheme: colorScheme,
-                  onTap: () async {
-                    final channel = await Navigator.push<ChatChannel>(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const CreateChannelPage(),
-                      ),
-                    );
-                    if (channel != null && context.mounted) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => GroupChatPage(channel: channel),
-                        ),
-                      );
-                    }
-                  },
-                ),
-                DashboardCard(
-                  icon: Icons.group,
-                  label: 'Clubs',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ClubsPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.school,
-                  label: 'Study Groups',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const StudyGroupsPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.menu_book_outlined,
-                  label: 'Tutoring',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const TutoringPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.work,
-                  label: 'Jobs',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const JobPostsPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.description,
-                  label: 'Documents',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const DocumentsPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.photo,
-                  label: 'Gallery',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const GalleryPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.cloud,
-                  label: 'Weather',
-                  colorScheme: colorScheme,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const WeatherPage()),
-                  ),
-                ),
-                DashboardCard(
-                  icon: Icons.menu_book,
-                  label: 'Wiki',
-                  colorScheme: colorScheme,
-                  onTap: () => onNavigate(10),
-                ),
-                if (isAdmin)
-                  DashboardCard(
-                    icon: Icons.admin_panel_settings,
-                    label: 'Admin',
-                    colorScheme: colorScheme,
-                    onTap: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => const AdminHomePage()),
-                    ),
-                  ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class StatusCard extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final Color backgroundColor;
-  final Color iconColor;
-  final Color textColor;
-  const StatusCard({
-    super.key,
-    required this.icon,
-    required this.label,
-    required this.backgroundColor,
-    required this.iconColor,
-    required this.textColor,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      color: backgroundColor,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      elevation: 1,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            Icon(icon, color: iconColor),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                label,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(color: textColor),
+            _Greeting(firstName: firstName),
+            const SizedBox(height: AppSpacing.lg),
+            _StatusRow(
+              eventsAsync: eventsAsync,
+              maintenanceAsync: maintenanceAsync,
+              onTapNextEvent: () => onNavigate(NavTarget.calendar),
+              onTapMaintenance: () => _push(
+                context,
+                injectedMaintenancePage ?? const MaintenancePage(),
               ),
             ),
+            _DashboardSection(
+              title: 'Community',
+              tiles: [
+                _Tile(
+                  icon: Icons.campaign,
+                  label: 'Bulletin',
+                  onTap: () => onNavigate(NavTarget.bulletin),
+                ),
+                _Tile(
+                  icon: Icons.people,
+                  label: 'Directory',
+                  onTap: () => _push(context, const DirectoryPage()),
+                ),
+                _Tile(
+                  icon: Icons.group,
+                  label: 'Clubs',
+                  onTap: () => _push(context, const ClubsPage()),
+                ),
+                _Tile(
+                  icon: Icons.forum,
+                  label: 'Channels',
+                  onTap: () => _openCreateChannel(context),
+                ),
+                _Tile(
+                  icon: Icons.poll,
+                  label: 'Polls',
+                  onTap: () => _push(context, const PollsPage()),
+                ),
+                _Tile(
+                  icon: Icons.photo_library,
+                  label: 'Gallery',
+                  onTap: () => _push(context, const GalleryPage()),
+                ),
+              ],
+            ),
+            _DashboardSection(
+              title: 'Marketplace & Help',
+              tiles: [
+                _Tile(
+                  icon: Icons.swap_horiz,
+                  label: 'Exchange',
+                  onTap: () => _push(
+                    context,
+                    injectedItemExchangePage ?? const ItemExchangePage(),
+                  ),
+                ),
+                _Tile(
+                  icon: Icons.help_outline,
+                  label: 'Lost & Found',
+                  onTap: () => _push(context, const LostFoundPage()),
+                ),
+                _Tile(
+                  icon: Icons.work_outline,
+                  label: 'Jobs',
+                  onTap: () => _push(context, const JobPostsPage()),
+                ),
+                _Tile(
+                  icon: Icons.menu_book_outlined,
+                  label: 'Tutoring',
+                  onTap: () => _push(context, const TutoringPage()),
+                ),
+                _Tile(
+                  icon: Icons.miscellaneous_services,
+                  label: 'Services',
+                  onTap: () => _push(context, const ServicesPage()),
+                ),
+                _Tile(
+                  icon: Icons.school,
+                  label: 'Study Groups',
+                  onTap: () => _push(context, const StudyGroupsPage()),
+                ),
+              ],
+            ),
+            _DashboardSection(
+              title: 'Daily',
+              tiles: [
+                _Tile(
+                  icon: Icons.build,
+                  label: 'Maintenance',
+                  onTap: () => _push(
+                    context,
+                    injectedMaintenancePage ?? const MaintenancePage(),
+                  ),
+                ),
+                _Tile(
+                  icon: Icons.schedule,
+                  label: 'Booking',
+                  onTap: () => _push(
+                    context,
+                    injectedBookingPage ?? const BookingPage(),
+                  ),
+                ),
+                _Tile(
+                  icon: Icons.directions_bus,
+                  label: 'Transit',
+                  onTap: () => _push(context, const TransitPage()),
+                ),
+                _Tile(
+                  icon: Icons.cloud_outlined,
+                  label: 'Weather',
+                  onTap: () => _push(context, const WeatherPage()),
+                ),
+                _Tile(
+                  icon: Icons.description_outlined,
+                  label: 'Documents',
+                  onTap: () => _push(context, const DocumentsPage()),
+                ),
+                _Tile(
+                  icon: Icons.menu_book,
+                  label: 'Wiki',
+                  onTap: () => _push(context, const WikiPage()),
+                ),
+              ],
+            ),
+            if (isAdmin)
+              _DashboardSection(
+                title: 'Administration',
+                tiles: [
+                  _Tile(
+                    icon: Icons.admin_panel_settings,
+                    label: 'Admin',
+                    onTap: () => _push(context, const AdminHomePage()),
+                  ),
+                ],
+              ),
+            const SizedBox(height: AppSpacing.lg),
           ],
+        ),
+      ),
+    );
+  }
+
+  static Future<void> _push(BuildContext context, Widget page) {
+    return Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => page),
+    );
+  }
+
+  static Future<void> _openCreateChannel(BuildContext context) async {
+    final channel = await Navigator.push<ChatChannel>(
+      context,
+      MaterialPageRoute(builder: (_) => const CreateChannelPage()),
+    );
+    if (channel != null && context.mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => GroupChatPage(channel: channel)),
+      );
+    }
+  }
+}
+
+class _Greeting extends StatelessWidget {
+  final String? firstName;
+  const _Greeting({required this.firstName});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    final scheme = Theme.of(context).colorScheme;
+    final greeting = firstName == null
+        ? 'Welcome back'
+        : 'Hi, $firstName';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          greeting,
+          style: text.headlineSmall?.copyWith(color: scheme.onSurface),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          'Olydorf at a glance.',
+          style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  final AsyncValue<List<CalendarEvent>> eventsAsync;
+  final AsyncValue<List<MaintenanceRequest>> maintenanceAsync;
+  final VoidCallback onTapNextEvent;
+  final VoidCallback onTapMaintenance;
+
+  const _StatusRow({
+    required this.eventsAsync,
+    required this.maintenanceAsync,
+    required this.onTapNextEvent,
+    required this.onTapMaintenance,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _NextEventCard(
+            async: eventsAsync,
+            onTap: onTapNextEvent,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.md),
+        Expanded(
+          child: _MaintenanceCard(
+            async: maintenanceAsync,
+            onTap: onTapMaintenance,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusCardShell extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final String? subtitle;
+  final VoidCallback onTap;
+
+  const _StatusCardShell({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onTap,
+    this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, size: 20, color: scheme.primary),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: Text(
+                      label,
+                      style: text.labelLarge?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                value,
+                style: text.titleMedium?.copyWith(
+                  color: scheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  subtitle!,
+                  style: text.bodySmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class DashboardCard extends StatelessWidget {
+class _NextEventCard extends StatelessWidget {
+  final AsyncValue<List<CalendarEvent>> async;
+  final VoidCallback onTap;
+  const _NextEventCard({required this.async, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final next = async.maybeWhen(
+      data: (events) {
+        final upcoming = events.where((e) => e.date.isAfter(now)).toList()
+          ..sort((a, b) => a.date.compareTo(b.date));
+        return upcoming.isEmpty ? null : upcoming.first;
+      },
+      orElse: () => null,
+    );
+
+    final value = async.isLoading
+        ? '…'
+        : next?.title ?? 'Nothing upcoming';
+    final subtitle = next == null
+        ? null
+        : DateFormat.MMMd().add_jm().format(next.date);
+
+    return _StatusCardShell(
+      icon: Icons.event,
+      label: 'Next event',
+      value: value,
+      subtitle: subtitle,
+      onTap: onTap,
+    );
+  }
+}
+
+class _MaintenanceCard extends StatelessWidget {
+  final AsyncValue<List<MaintenanceRequest>> async;
+  final VoidCallback onTap;
+  const _MaintenanceCard({required this.async, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final openCount = async.maybeWhen(
+      data: (list) => list.where((r) => r.status != 'closed' && r.status != 'resolved').length,
+      orElse: () => null,
+    );
+
+    final value = async.isLoading
+        ? '…'
+        : openCount == null
+            ? '—'
+            : '$openCount';
+    final subtitle = openCount == null
+        ? null
+        : openCount == 1 ? 'open ticket' : 'open tickets';
+
+    return _StatusCardShell(
+      icon: Icons.build,
+      label: 'Maintenance',
+      value: value,
+      subtitle: subtitle,
+      onTap: onTap,
+    );
+  }
+}
+
+class _DashboardSection extends StatelessWidget {
+  final String title;
+  final List<_Tile> tiles;
+  const _DashboardSection({required this.title, required this.tiles});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    final scheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.xs,
+            AppSpacing.xl,
+            AppSpacing.xs,
+            AppSpacing.sm,
+          ),
+          child: Text(
+            title,
+            style: text.titleMedium?.copyWith(
+              color: scheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        GridView.count(
+          crossAxisCount: 3,
+          mainAxisSpacing: AppSpacing.md,
+          crossAxisSpacing: AppSpacing.md,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          childAspectRatio: 1,
+          children: tiles,
+        ),
+      ],
+    );
+  }
+}
+
+class _Tile extends StatelessWidget {
   final IconData icon;
   final String label;
-  final ColorScheme colorScheme;
   final VoidCallback onTap;
-  const DashboardCard({
-    super.key,
+  const _Tile({
     required this.icon,
     required this.label,
-    required this.colorScheme,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(12),
-      child: Card(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        elevation: 2,
+    final scheme = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.md),
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 24),
+          padding: const EdgeInsets.all(AppSpacing.md),
           child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(icon, size: 36, color: colorScheme.primary),
-              const SizedBox(height: 12),
+              Icon(icon, size: 32, color: scheme.primary),
+              const SizedBox(height: AppSpacing.sm),
               Text(
                 label,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: text.labelLarge?.copyWith(
+                  color: scheme.onSurface,
                 ),
               ),
             ],

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -69,9 +69,14 @@ class DashboardPage extends ConsumerWidget {
             ref.read(maintenanceRequestsProvider.future),
           ]);
         },
-        child: ListView(
+        // SingleChildScrollView (not ListView) so every section is eagerly
+        // realized — keeps widget-tests able to find off-screen tiles via
+        // find.text without needing scrollUntilVisible.
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.lg),
-          children: [
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
             _Greeting(firstName: firstName),
             const SizedBox(height: AppSpacing.lg),
             _StatusRow(
@@ -209,7 +214,8 @@ class DashboardPage extends ConsumerWidget {
                 ],
               ),
             const SizedBox(height: AppSpacing.lg),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -419,8 +419,12 @@ class _MaintenanceCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Mirror the admin page's open/closed split — see
+    // `maintenance_admin_page.dart` which only ever transitions between
+    // 'open' and 'closed'. If a new status is ever introduced, update
+    // both sites together.
     final openCount = async.maybeWhen(
-      data: (list) => list.where((r) => r.status != 'closed' && r.status != 'resolved').length,
+      data: (list) => list.where((r) => r.status != 'closed').length,
       orElse: () => null,
     );
 

--- a/lib/pages/directory_page.dart
+++ b/lib/pages/directory_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
 import '../providers/directory_providers.dart';
 import '../services/directory_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import 'user_chat_page.dart';
 
 class DirectoryPage extends StatelessWidget {
@@ -40,20 +42,7 @@ class _DirectoryBodyState extends ConsumerState<_DirectoryBody> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<AsyncValue<List<User>>>(directoryUsersProvider, (prev, next) {
-      // Only surface errors when no users are shown (matches prior behavior).
-      if (next.hasError && !next.isLoading) {
-        final fallback = (prev?.valueOrNull ?? const <User>[]);
-        if (fallback.isEmpty) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to load users')),
-          );
-        }
-      }
-    });
-
     final usersAsync = ref.watch(directoryUsersProvider);
-    final users = usersAsync.valueOrNull ?? const <User>[];
 
     return Scaffold(
       body: Padding(
@@ -75,37 +64,41 @@ class _DirectoryBodyState extends ConsumerState<_DirectoryBody> {
             ),
             const SizedBox(height: 12),
             Expanded(
-              child: usersAsync.isLoading
-                  ? const Center(child: CircularProgressIndicator())
-                  : users.isEmpty
-                      ? const Center(child: Text('No residents found.'))
-                      : ListView.builder(
-                          itemCount: users.length,
-                          itemBuilder: (context, index) {
-                            final user = users[index];
-                            return ListTile(
-                              leading: user.avatarUrl != null
-                                  ? CircleAvatar(
-                                      backgroundImage:
-                                          NetworkImage(user.avatarUrl!),
-                                    )
-                                  : const CircleAvatar(
-                                      child: Icon(Icons.person)),
-                              title: Text(user.name),
-                              subtitle: Text(user.email),
-                              onTap: () {
-                                if (user.id == null) return;
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) =>
-                                        UserChatPage(user: user),
-                                  ),
-                                );
-                              },
-                            );
-                          },
-                        ),
+              child: AsyncStateView<List<User>>(
+                value: usersAsync,
+                errorTitle: 'Failed to load users',
+                onRetry: () => ref.invalidate(directoryUsersProvider),
+                isEmpty: (users) => users.isEmpty,
+                empty: const EmptyState(
+                  icon: Icons.people_outline,
+                  title: 'No residents found',
+                ),
+                data: (users) => ListView.builder(
+                  itemCount: users.length,
+                  itemBuilder: (context, index) {
+                    final user = users[index];
+                    return ListTile(
+                      leading: user.avatarUrl != null
+                          ? CircleAvatar(
+                              backgroundImage:
+                                  NetworkImage(user.avatarUrl!),
+                            )
+                          : const CircleAvatar(child: Icon(Icons.person)),
+                      title: Text(user.name),
+                      subtitle: Text(user.email),
+                      onTap: () {
+                        if (user.id == null) return;
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => UserChatPage(user: user),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/pages/documents_page.dart
+++ b/lib/pages/documents_page.dart
@@ -7,6 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
 import '../providers/documents_providers.dart';
 import '../services/document_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 
 class DocumentsPage extends StatelessWidget {
   final DocumentService? service;
@@ -59,39 +61,39 @@ class _DocumentsBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<List<Document>>>(documentsProvider, (prev, next) {
-      if (next.hasError && !next.isLoading) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Failed to load: ${next.error}')));
-      }
-    });
     final cs = Theme.of(context).colorScheme;
     final docsAsync = ref.watch(documentsProvider);
-    final documents = docsAsync.valueOrNull ?? const <Document>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Documents'),
         backgroundColor: cs.primaryContainer,
         foregroundColor: cs.onPrimaryContainer,
       ),
-      body: docsAsync.isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : documents.isEmpty
-              ? const Center(child: Text('No documents uploaded.'))
-              : ListView.separated(
-                  itemCount: documents.length,
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemBuilder: (_, i) {
-                    final doc = documents[i];
-                    return ListTile(
-                      title: Text(doc.fileName),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.download),
-                        onPressed: () => _download(context, ref, doc),
-                      ),
-                    );
-                  },
-                ),
+      body: AsyncStateView<List<Document>>(
+        value: docsAsync,
+        errorTitle: 'Failed to load documents',
+        onRetry: () => ref.invalidate(documentsProvider),
+        isEmpty: (documents) => documents.isEmpty,
+        empty: const EmptyState(
+          icon: Icons.description_outlined,
+          title: 'No documents',
+          subtitle: 'Upload one with the button below.',
+        ),
+        data: (documents) => ListView.separated(
+          itemCount: documents.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (_, i) {
+            final doc = documents[i];
+            return ListTile(
+              title: Text(doc.fileName),
+              trailing: IconButton(
+                icon: const Icon(Icons.download),
+                onPressed: () => _download(context, ref, doc),
+              ),
+            );
+          },
+        ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _pickAndUpload(context, ref),
         child: const Icon(Icons.upload_file),

--- a/lib/pages/gallery_page.dart
+++ b/lib/pages/gallery_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
 import '../providers/gallery_providers.dart';
 import '../services/gallery_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 
 class GalleryPage extends StatelessWidget {
   final GalleryService? service;
@@ -26,68 +28,63 @@ class _GalleryBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<List<GalleryImage>>>(galleryImagesProvider,
-        (prev, next) {
-      if (next.hasError && !next.isLoading) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to load: ${next.error}')),
-        );
-      }
-    });
-
     final cs = Theme.of(context).colorScheme;
     final imagesAsync = ref.watch(galleryImagesProvider);
-    final images = imagesAsync.valueOrNull ?? const <GalleryImage>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Community Gallery'),
         backgroundColor: cs.primaryContainer,
         foregroundColor: cs.onPrimaryContainer,
       ),
-      body: imagesAsync.isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : images.isEmpty
-              ? const Center(child: Text('No images uploaded.'))
-              : GridView.builder(
-                  padding: const EdgeInsets.all(8),
-                  gridDelegate:
-                      const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                    mainAxisSpacing: 4,
-                    crossAxisSpacing: 4,
-                  ),
-                  itemCount: images.length,
-                  itemBuilder: (ctx, i) {
-                    final img = images[i];
-                    return GestureDetector(
-                      onTap: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => _FullScreenImage(url: img.url),
-                        ),
-                      ),
-                      child: Image.network(
-                        img.url,
-                        fit: BoxFit.cover,
-                        loadingBuilder: (context, child, progress) {
-                          if (progress == null) return child;
-                          return const Center(
-                            child: CircularProgressIndicator(),
-                          );
-                        },
-                        errorBuilder: (context, error, stackTrace) =>
-                            Container(
-                          color: cs.surfaceContainerHighest,
-                          alignment: Alignment.center,
-                          child: Icon(
-                            Icons.broken_image,
-                            color: cs.onSurfaceVariant,
-                          ),
-                        ),
-                      ),
-                    );
-                  },
+      body: AsyncStateView<List<GalleryImage>>(
+        value: imagesAsync,
+        errorTitle: 'Failed to load gallery',
+        onRetry: () => ref.invalidate(galleryImagesProvider),
+        isEmpty: (images) => images.isEmpty,
+        empty: const EmptyState(
+          icon: Icons.photo_library_outlined,
+          title: 'No photos yet',
+          subtitle: 'Be the first to share something from Olydorf.',
+        ),
+        data: (images) => GridView.builder(
+          padding: const EdgeInsets.all(8),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 3,
+            mainAxisSpacing: 4,
+            crossAxisSpacing: 4,
+          ),
+          itemCount: images.length,
+          itemBuilder: (ctx, i) {
+            final img = images[i];
+            return GestureDetector(
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => _FullScreenImage(url: img.url),
                 ),
+              ),
+              child: Image.network(
+                img.url,
+                fit: BoxFit.cover,
+                loadingBuilder: (context, child, progress) {
+                  if (progress == null) return child;
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                },
+                errorBuilder: (context, error, stackTrace) => Container(
+                  color: cs.surfaceContainerHighest,
+                  alignment: Alignment.center,
+                  child: Icon(
+                    Icons.broken_image,
+                    color: cs.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/item_exchange_page.dart
+++ b/lib/pages/item_exchange_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../models/models.dart';
 import '../providers/item_providers.dart';
 import '../services/item_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import '../widgets/item_card.dart';
 import 'item_detail_page.dart';
 import 'post_item_page.dart';
@@ -59,7 +62,6 @@ class _ItemExchangeBodyState extends ConsumerState<_ItemExchangeBody> {
   Widget build(BuildContext context) {
     final itemsAsync = ref.watch(itemsProvider);
     final filters = ref.watch(itemFiltersProvider);
-    final filteredItems = ref.watch(filteredItemsProvider);
     final favorites = ref.watch(favoritesProvider);
     final filtersNotifier = ref.read(itemFiltersProvider.notifier);
 
@@ -186,64 +188,74 @@ class _ItemExchangeBodyState extends ConsumerState<_ItemExchangeBody> {
             Expanded(
               child: RefreshIndicator(
                 onRefresh: () async => ref.invalidate(itemsProvider),
-                child: itemsAsync.isLoading
-                    ? const Center(child: CircularProgressIndicator())
-                    : filteredItems.isEmpty
-                        ? const Center(child: Text('No items found.'))
-                        : GridView.builder(
-                            gridDelegate:
-                                const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 2,
-                              mainAxisSpacing: 12,
-                              crossAxisSpacing: 12,
-                              childAspectRatio: 0.8,
-                            ),
-                            itemCount: filteredItems.length,
-                            itemBuilder: (ctx, idx) {
-                              final item = filteredItems[idx];
-                              final isFav =
-                                  item.id != null && favorites.contains(item.id);
-                              return Stack(
-                                children: [
-                                  InkWell(
-                                    borderRadius: BorderRadius.circular(12),
-                                    onTap: () {
-                                      Navigator.push(
-                                        context,
-                                        MaterialPageRoute(
-                                          builder: (_) =>
-                                              ItemDetailPage(item: item),
-                                        ),
-                                      );
-                                    },
-                                    child: ItemCard(
-                                      title: item.title,
-                                      averageRating: item.ratings.isNotEmpty
-                                          ? item.averageRating
-                                          : null,
-                                    ),
+                child: AsyncStateView<List<Item>>(
+                  value: itemsAsync,
+                  errorTitle: 'Could not load items',
+                  onRetry: () => ref.invalidate(itemsProvider),
+                  isEmpty: (_) => ref.read(filteredItemsProvider).isEmpty,
+                  empty: const EmptyState(
+                    icon: Icons.inventory_2_outlined,
+                    title: 'Nothing on offer',
+                    subtitle: 'Try clearing your filters or check back later.',
+                  ),
+                  data: (_) {
+                    final filteredItems = ref.watch(filteredItemsProvider);
+                    return GridView.builder(
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        mainAxisSpacing: 12,
+                        crossAxisSpacing: 12,
+                        childAspectRatio: 0.8,
+                      ),
+                      itemCount: filteredItems.length,
+                      itemBuilder: (ctx, idx) {
+                        final item = filteredItems[idx];
+                        final isFav =
+                            item.id != null && favorites.contains(item.id);
+                        return Stack(
+                          children: [
+                            InkWell(
+                              borderRadius: BorderRadius.circular(12),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) =>
+                                        ItemDetailPage(item: item),
                                   ),
-                                  if (item.id != null)
-                                    Positioned(
-                                      top: 0,
-                                      right: 0,
-                                      child: IconButton(
-                                        key: Key('toggleFavorite_${item.id}'),
-                                        icon: Icon(
-                                          isFav
-                                              ? Icons.star
-                                              : Icons.star_border,
-                                          color: Colors.amber,
-                                        ),
-                                        onPressed: () => ref
-                                            .read(favoritesProvider.notifier)
-                                            .toggle(item.id as int),
-                                      ),
-                                    ),
-                                ],
-                              );
-                            },
-                          ),
+                                );
+                              },
+                              child: ItemCard(
+                                title: item.title,
+                                averageRating: item.ratings.isNotEmpty
+                                    ? item.averageRating
+                                    : null,
+                              ),
+                            ),
+                            if (item.id != null)
+                              Positioned(
+                                top: 0,
+                                right: 0,
+                                child: IconButton(
+                                  key: Key('toggleFavorite_${item.id}'),
+                                  icon: Icon(
+                                    isFav
+                                        ? Icons.star
+                                        : Icons.star_border,
+                                    color: Colors.amber,
+                                  ),
+                                  onPressed: () => ref
+                                      .read(favoritesProvider.notifier)
+                                      .toggle(item.id as int),
+                                ),
+                              ),
+                          ],
+                        );
+                      },
+                    );
+                  },
+                ),
               ),
             ),
           ],

--- a/lib/pages/lost_found_page.dart
+++ b/lib/pages/lost_found_page.dart
@@ -8,6 +8,8 @@ import '../models/models.dart';
 import '../providers/lost_found_providers.dart';
 import '../services/lost_found_service.dart';
 import '../utils/user_helpers.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import 'lost_found_detail_page.dart';
 
 class LostFoundPage extends StatelessWidget {
@@ -79,7 +81,6 @@ class _LostFoundBodyState extends ConsumerState<_LostFoundBody> {
     final filters = ref.watch(lostFoundFiltersProvider);
     final filtersNotifier = ref.read(lostFoundFiltersProvider.notifier);
     final itemsAsync = ref.watch(lostFoundItemsProvider);
-    final items = itemsAsync.valueOrNull ?? const <LostItem>[];
     return Scaffold(
       appBar: AppBar(
         title: const Text('Lost & Found'),
@@ -151,37 +152,45 @@ class _LostFoundBodyState extends ConsumerState<_LostFoundBody> {
             ),
           ),
           Expanded(
-            child: items.isEmpty
-                ? const Center(child: Text('No posts yet.'))
-                : ListView.separated(
-                    itemCount: items.length,
-                    separatorBuilder: (_, __) => const Divider(height: 1),
-                    itemBuilder: (_, i) {
-                      final item = items[i];
-                      return ListTile(
-                        title: Text(item.title),
-                        subtitle: item.description != null
-                            ? Text(item.description!)
-                            : null,
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () async {
-                          final changed = await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => LostFoundDetailPage(
-                                item: item,
-                                service:
-                                    ref.read(lostFoundServiceProvider),
-                              ),
-                            ),
-                          );
-                          if (changed == true) {
-                            ref.invalidate(lostFoundItemsProvider);
-                          }
-                        },
+            child: AsyncStateView<List<LostItem>>(
+              value: itemsAsync,
+              errorTitle: 'Failed to load lost & found',
+              onRetry: () => ref.invalidate(lostFoundItemsProvider),
+              isEmpty: (items) => items.isEmpty,
+              empty: const EmptyState(
+                icon: Icons.help_outline,
+                title: 'Nothing reported',
+                subtitle: 'Be the first to post a lost or found item below.',
+              ),
+              data: (items) => ListView.separated(
+                itemCount: items.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (_, i) {
+                  final item = items[i];
+                  return ListTile(
+                    title: Text(item.title),
+                    subtitle: item.description != null
+                        ? Text(item.description!)
+                        : null,
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () async {
+                      final changed = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => LostFoundDetailPage(
+                            item: item,
+                            service: ref.read(lostFoundServiceProvider),
+                          ),
+                        ),
                       );
+                      if (changed == true) {
+                        ref.invalidate(lostFoundItemsProvider);
+                      }
                     },
-                  ),
+                  );
+                },
+              ),
+            ),
           ),
           Padding(
             padding: const EdgeInsets.all(8),

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -4,22 +4,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
 import '../providers/calendar_providers.dart';
 import 'booking_page.dart';
+import 'bulletin_board_page.dart';
 import 'calendar_page.dart';
 import 'dashboard_page.dart';
-import 'directory_page.dart';
 import 'item_exchange_page.dart';
-import 'lost_found_page.dart';
 import 'maintenance_page.dart';
 import 'map_page.dart';
+import 'nav_target.dart';
 import 'notifications_page.dart';
-import 'polls_page.dart';
-import 'post_item_page.dart';
 import 'profile_page.dart';
 import 'settings_page.dart';
-import 'transit_page.dart';
-import 'wiki_page.dart';
+
+export 'nav_target.dart';
 
 class MainPage extends ConsumerStatefulWidget {
+  /// Test-only injection points: provide pre-built pages whose services have
+  /// been overridden. Production callers should rely on [ProviderScope].
   final CalendarPage? calendarPage;
   final BookingPage? bookingPage;
   final MaintenancePage? maintenancePage;
@@ -41,51 +41,53 @@ class MainPage extends ConsumerStatefulWidget {
 }
 
 class _MainPageState extends ConsumerState<MainPage> {
-  int _currentIndex = 0;
+  NavTarget _current = NavTarget.home;
 
-  static const List<String> _titles = [
-    'Dashboard',
-    'Map',
-    'Calendar',
-    'Booking',
-    'Item Exchange',
-    'Lost & Found',
-    'Maintenance',
-    'Transit',
-    'Directory',
-    'Polls',
-    'Wiki',
-  ];
+  late final Map<NavTarget, Widget> _pages = {
+    NavTarget.home: DashboardPage(
+      onNavigate: _onDashboardNavigate,
+      isAdmin: widget.isAdmin,
+      injectedCalendarPage: widget.calendarPage,
+      injectedBookingPage: widget.bookingPage,
+      injectedMaintenancePage: widget.maintenancePage,
+      injectedItemExchangePage: widget.itemExchangePage,
+    ),
+    NavTarget.map: const MapPage(),
+    NavTarget.calendar:
+        widget.calendarPage ?? CalendarPage(isAdmin: widget.isAdmin),
+    NavTarget.bulletin: const BulletinBoardPage(),
+    NavTarget.profile: const ProfilePage(),
+  };
 
-  late final List<Widget> _pages;
+  String _title(NavTarget t) => switch (t) {
+        NavTarget.home => 'Dashboard',
+        NavTarget.map => 'Map',
+        NavTarget.calendar => 'Calendar',
+        NavTarget.bulletin => 'Bulletin',
+        NavTarget.profile => 'Profile',
+      };
 
-  @override
-  void initState() {
-    super.initState();
-    _pages = [
-      DashboardPage(onNavigate: _onDashboardNavigate, isAdmin: widget.isAdmin),
-      const MapPage(),
-      widget.calendarPage ?? CalendarPage(isAdmin: widget.isAdmin),
-      widget.bookingPage ?? const BookingPage(),
-      widget.itemExchangePage ?? const ItemExchangePage(),
-      const LostFoundPage(),
-      widget.maintenancePage ?? const MaintenancePage(),
-      const TransitPage(),
-      const DirectoryPage(),
-      const PollsPage(),
-      const WikiPage(),
-    ];
-  }
+  IconData _icon(NavTarget t) => switch (t) {
+        NavTarget.home => Icons.home_outlined,
+        NavTarget.map => Icons.map_outlined,
+        NavTarget.calendar => Icons.calendar_today_outlined,
+        NavTarget.bulletin => Icons.campaign_outlined,
+        NavTarget.profile => Icons.person_outline,
+      };
+
+  IconData _selectedIcon(NavTarget t) => switch (t) {
+        NavTarget.home => Icons.home,
+        NavTarget.map => Icons.map,
+        NavTarget.calendar => Icons.calendar_today,
+        NavTarget.bulletin => Icons.campaign,
+        NavTarget.profile => Icons.person,
+      };
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
-        title: Text(_titles[_currentIndex]),
-        backgroundColor: colorScheme.primaryContainer,
-        foregroundColor: colorScheme.onPrimaryContainer,
-        elevation: 2,
+        title: Text(_title(_current)),
         actions: [
           PopupMenuButton<String>(
             onSelected: (val) async {
@@ -94,134 +96,83 @@ class _MainPageState extends ConsumerState<MainPage> {
                   context,
                   MaterialPageRoute(builder: (_) => const SettingsPage()),
                 );
-              } else if (val == 'profile') {
-                await Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const ProfilePage()),
-                );
               } else if (val == 'logout' && widget.onLogout != null) {
                 widget.onLogout!();
               }
             },
             itemBuilder: (context) => [
               const PopupMenuItem(value: 'settings', child: Text('Settings')),
-              const PopupMenuItem(value: 'profile', child: Text('Profile')),
               if (widget.onLogout != null)
                 const PopupMenuItem(value: 'logout', child: Text('Logout')),
             ],
           ),
         ],
       ),
-      body: _pages[_currentIndex],
-      floatingActionButton: _fabCallback() != null
-          ? FloatingActionButton(
-              onPressed: _fabCallback(),
-              backgroundColor: colorScheme.secondary,
-              foregroundColor: colorScheme.onSecondary,
-              child: Icon(_fabIcon()),
-            )
-          : null,
+      body: _pages[_current],
+      floatingActionButton: _buildFab(),
       bottomNavigationBar: NavigationBar(
-        selectedIndex: _currentIndex,
-        onDestinationSelected: (index) => setState(() => _currentIndex = index),
-        height: 60,
-        destinations: const [
-          NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
-          NavigationDestination(icon: Icon(Icons.map), label: 'Map'),
-          NavigationDestination(
-            icon: Icon(Icons.calendar_today),
-            label: 'Calendar',
-          ),
-          NavigationDestination(icon: Icon(Icons.schedule), label: 'Booking'),
-          NavigationDestination(
-            icon: Icon(Icons.swap_horiz),
-            label: 'Exchange',
-          ),
-          NavigationDestination(icon: Icon(Icons.help), label: 'Lost'),
-          NavigationDestination(icon: Icon(Icons.build), label: 'Maintenance'),
-          NavigationDestination(
-            icon: Icon(Icons.directions_bus),
-            label: 'Transit',
-          ),
-          NavigationDestination(icon: Icon(Icons.people), label: 'Directory'),
-          NavigationDestination(icon: Icon(Icons.poll), label: 'Polls'),
-          NavigationDestination(icon: Icon(Icons.menu_book), label: 'Wiki'),
+        selectedIndex: NavTarget.values.indexOf(_current),
+        onDestinationSelected: (index) =>
+            setState(() => _current = NavTarget.values[index]),
+        destinations: [
+          for (final t in NavTarget.values)
+            NavigationDestination(
+              icon: Icon(_icon(t)),
+              selectedIcon: Icon(_selectedIcon(t)),
+              label: _title(t),
+            ),
         ],
       ),
     );
   }
 
-  IconData _fabIcon() {
-    switch (_currentIndex) {
-      case 0:
-        return Icons.notifications;
-      case 1:
-        return Icons.place;
-      case 2:
-        return Icons.event;
-      case 3:
-        return Icons.book_online;
-      case 4:
-        return Icons.add_shopping_cart;
-      default:
-        return Icons.add;
-    }
-  }
-
-  VoidCallback? _fabCallback() {
-    switch (_currentIndex) {
-      case 0:
-        return () {
-          Navigator.push(
+  Widget? _buildFab() {
+    switch (_current) {
+      case NavTarget.home:
+        return FloatingActionButton(
+          heroTag: 'homeFab',
+          onPressed: () => Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => const NotificationsPage()),
-          );
-        };
-      case 1:
-        return () {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(const SnackBar(content: Text('No map action')));
-        };
-      case 2:
+          ),
+          child: const Icon(Icons.notifications),
+        );
+      case NavTarget.calendar:
         if (!widget.isAdmin) return null;
-        return () async {
-          await showAddEventDialog(context, (
-            title,
-            date,
-            location,
-            interval,
-            until,
-            category,
-          ) async {
-            final service = ref.read(eventServiceProvider);
-            await service.createEvent(
-              CalendarEvent(
-                title: title,
-                date: date,
-                location: location,
-                repeatInterval: interval,
-                repeatUntil: until,
-                category: category,
-              ),
-            );
-          });
-        };
-      case 3:
-        return null;
-      case 4:
-        return () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => const PostItemPage()),
-          );
-        };
-      default:
+        return FloatingActionButton(
+          heroTag: 'calendarFab',
+          onPressed: () async {
+            await showAddEventDialog(context, (
+              title,
+              date,
+              location,
+              interval,
+              until,
+              category,
+            ) async {
+              final service = ref.read(eventServiceProvider);
+              await service.createEvent(
+                CalendarEvent(
+                  title: title,
+                  date: date,
+                  location: location,
+                  repeatInterval: interval,
+                  repeatUntil: until,
+                  category: category,
+                ),
+              );
+            });
+          },
+          child: const Icon(Icons.event),
+        );
+      case NavTarget.map:
+      case NavTarget.bulletin:
+      case NavTarget.profile:
         return null;
     }
   }
 
-  void _onDashboardNavigate(int index) {
-    setState(() => _currentIndex = index);
+  void _onDashboardNavigate(NavTarget target) {
+    setState(() => _current = target);
   }
 }

--- a/lib/pages/maintenance_page.dart
+++ b/lib/pages/maintenance_page.dart
@@ -8,6 +8,8 @@ import '../models/models.dart';
 import '../providers/maintenance_providers.dart';
 import '../services/maintenance_service.dart';
 import '../utils/user_helpers.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 import 'maintenance_chat_page.dart';
 
 class MaintenancePage extends StatelessWidget {
@@ -58,18 +60,6 @@ class _MaintenanceBodyState extends ConsumerState<_MaintenanceBody> {
 
   @override
   Widget build(BuildContext context) {
-    // Surface load errors via a snackbar, matching the prior behavior.
-    ref.listen<AsyncValue<List<MaintenanceRequest>>>(
-      maintenanceRequestsProvider,
-      (previous, next) {
-        if (next.hasError && !next.isLoading) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to load tickets')),
-          );
-        }
-      },
-    );
-
     return Scaffold(
       body: Column(
         children: [
@@ -168,32 +158,36 @@ class _MaintenanceBodyState extends ConsumerState<_MaintenanceBody> {
 
   Widget _buildConversations() {
     final ticketsAsync = ref.watch(maintenanceRequestsProvider);
-    if (ticketsAsync.isLoading) {
-      return const Center(child: CircularProgressIndicator());
-    }
-    final tickets = ticketsAsync.valueOrNull ?? const <MaintenanceRequest>[];
-    if (tickets.isEmpty) {
-      return const Center(child: Text('No conversations yet.'));
-    }
-    return ListView.separated(
-      itemCount: tickets.length,
-      separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (context, index) {
-        final ticket = tickets[index];
-        return ListTile(
-          title: Text(ticket.subject),
-          subtitle: Text('Status: ${ticket.status}'),
-          trailing: const Icon(Icons.chevron_right),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => MaintenanceChatPage(request: ticket),
-              ),
-            );
-          },
-        );
-      },
+    return AsyncStateView<List<MaintenanceRequest>>(
+      value: ticketsAsync,
+      errorTitle: 'Failed to load tickets',
+      onRetry: () => ref.invalidate(maintenanceRequestsProvider),
+      isEmpty: (tickets) => tickets.isEmpty,
+      empty: const EmptyState(
+        icon: Icons.handyman_outlined,
+        title: 'No open tickets',
+        subtitle: 'Submit a new request from the other tab.',
+      ),
+      data: (tickets) => ListView.separated(
+        itemCount: tickets.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final ticket = tickets[index];
+          return ListTile(
+            title: Text(ticket.subject),
+            subtitle: Text('Status: ${ticket.status}'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MaintenanceChatPage(request: ticket),
+                ),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/nav_target.dart
+++ b/lib/pages/nav_target.dart
@@ -1,0 +1,4 @@
+/// The five primary surfaces exposed in the bottom navigation. Defined here
+/// (rather than in `main_page.dart`) so that `dashboard_page.dart` can
+/// reference it without a circular import.
+enum NavTarget { home, map, calendar, bulletin, profile }

--- a/lib/pages/polls_page.dart
+++ b/lib/pages/polls_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
 import '../providers/polls_providers.dart';
 import '../services/poll_service.dart';
+import '../widgets/async_state_view.dart';
+import '../widgets/empty_state.dart';
 
 class PollsPage extends StatelessWidget {
   final PollService? service;
@@ -40,47 +42,50 @@ class _PollsBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<List<Poll>>>(pollsProvider, (prev, next) {
-      if (next.hasError && !next.isLoading) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load polls')),
-        );
-      }
-    });
-    final polls = ref.watch(pollsProvider).valueOrNull ?? const <Poll>[];
+    final pollsAsync = ref.watch(pollsProvider);
     return RefreshIndicator(
       onRefresh: () async => ref.invalidate(pollsProvider),
-      child: ListView.builder(
-        itemCount: polls.length,
-        itemBuilder: (context, index) {
-          final poll = polls[index];
-          return Card(
-            margin: const EdgeInsets.all(12),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    poll.question,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  for (var i = 0; i < poll.options.length; i++)
-                    ListTile(
-                      title: Text(
-                        '${poll.options[i]} (${poll.counts.length > i ? poll.counts[i] : 0})',
-                      ),
-                      trailing: ElevatedButton(
-                        onPressed: () => _vote(ref, context, poll, i),
-                        child: const Text('Vote'),
-                      ),
+      child: AsyncStateView<List<Poll>>(
+        value: pollsAsync,
+        errorTitle: 'Failed to load polls',
+        onRetry: () => ref.invalidate(pollsProvider),
+        isEmpty: (polls) => polls.isEmpty,
+        empty: const EmptyState(
+          icon: Icons.poll_outlined,
+          title: 'No active polls',
+        ),
+        data: (polls) => ListView.builder(
+          itemCount: polls.length,
+          itemBuilder: (context, index) {
+            final poll = polls[index];
+            return Card(
+              margin: const EdgeInsets.all(12),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      poll.question,
+                      style: Theme.of(context).textTheme.titleMedium,
                     ),
-                ],
+                    const SizedBox(height: 12),
+                    for (var i = 0; i < poll.options.length; i++)
+                      ListTile(
+                        title: Text(
+                          '${poll.options[i]} (${poll.counts.length > i ? poll.counts[i] : 0})',
+                        ),
+                        trailing: ElevatedButton(
+                          onPressed: () => _vote(ref, context, poll, i),
+                          child: const Text('Vote'),
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -147,7 +147,6 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
   Widget build(BuildContext context) {
     final avatarUrl = _avatarCtrl.text.trim();
     return Scaffold(
-      appBar: AppBar(title: const Text('Profile')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Form(

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -10,6 +10,11 @@ import '../models/models.dart';
 import '../providers/user_providers.dart';
 import '../services/user_service.dart';
 
+/// Profile surface. Designed to be hosted as a [MainPage] destination
+/// (the profile tab) — it intentionally does **not** render its own
+/// [AppBar] because [MainPage] already provides one. If you ever need to
+/// push this page directly (deep link, standalone screen, etc.), wrap it
+/// in a [Scaffold] + [AppBar] of your own.
 class ProfilePage extends ConsumerStatefulWidget {
   final UserService? service;
   const ProfilePage({super.key, this.service});

--- a/lib/providers/user_providers.dart
+++ b/lib/providers/user_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
@@ -7,13 +9,33 @@ import '../services/user_service.dart';
 final userServiceProvider = Provider<UserService>((ref) => UserService());
 
 /// The user currently signed in, or `null` if no session is active.
-/// Sourced from the Hive `userBox` populated by the login flow in
-/// `lib/main.dart`. Invalidate after login/logout for the UI to refresh.
-final currentUserProvider = Provider<User?>((ref) {
-  if (!Hive.isBoxOpen('userBox')) return null;
-  final box = Hive.box<User>('userBox');
-  return box.get('currentUser');
-});
+///
+/// Backed by the Hive `userBox` populated by the login / register / profile
+/// flows in `lib/main.dart`, `login_page.dart`, etc. Subscribes to
+/// `Box.watch(key: 'currentUser')` so the value auto-refreshes when any of
+/// those flows writes to the box — consumers (e.g. the dashboard greeting)
+/// don't need to invalidate manually.
+class CurrentUserNotifier extends Notifier<User?> {
+  StreamSubscription<BoxEvent>? _sub;
+
+  @override
+  User? build() {
+    _sub?.cancel();
+    if (!Hive.isBoxOpen('userBox')) {
+      return null;
+    }
+    final box = Hive.box<User>('userBox');
+    _sub = box.watch(key: 'currentUser').listen((event) {
+      state = event.deleted ? null : event.value as User?;
+    });
+    ref.onDispose(() => _sub?.cancel());
+    return box.get('currentUser');
+  }
+}
+
+final currentUserProvider = NotifierProvider<CurrentUserNotifier, User?>(
+  CurrentUserNotifier.new,
+);
 
 /// Short display name for greetings: the first whitespace-delimited token of
 /// the user's name, or `null` if no user is signed in.

--- a/lib/providers/user_providers.dart
+++ b/lib/providers/user_providers.dart
@@ -1,5 +1,25 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
 
+import '../models/models.dart';
 import '../services/user_service.dart';
 
 final userServiceProvider = Provider<UserService>((ref) => UserService());
+
+/// The user currently signed in, or `null` if no session is active.
+/// Sourced from the Hive `userBox` populated by the login flow in
+/// `lib/main.dart`. Invalidate after login/logout for the UI to refresh.
+final currentUserProvider = Provider<User?>((ref) {
+  if (!Hive.isBoxOpen('userBox')) return null;
+  final box = Hive.box<User>('userBox');
+  return box.get('currentUser');
+});
+
+/// Short display name for greetings: the first whitespace-delimited token of
+/// the user's name, or `null` if no user is signed in.
+final currentUserFirstNameProvider = Provider<String?>((ref) {
+  final user = ref.watch(currentUserProvider);
+  final name = user?.name.trim();
+  if (name == null || name.isEmpty) return null;
+  return name.split(RegExp(r'\s+')).first;
+});

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import 'theme/tokens.dart';
+
 /// Central location for light and dark theme configuration.
 class OlyTheme {
   OlyTheme._();
@@ -8,27 +10,197 @@ class OlyTheme {
   /// Brand color shared between light and dark schemes.
   static const Color _brandColor = Color(0xFF0066CC);
 
-  /// Light theme using Material 3.
-  static ThemeData light() {
-    final base = ThemeData.light(useMaterial3: true);
+  static ThemeData light() => _build(Brightness.light);
+  static ThemeData dark() => _build(Brightness.dark);
+
+  static ThemeData _build(Brightness brightness) {
+    final base = brightness == Brightness.light
+        ? ThemeData.light(useMaterial3: true)
+        : ThemeData.dark(useMaterial3: true);
+
+    final scheme = ColorScheme.fromSeed(
+      seedColor: _brandColor,
+      brightness: brightness,
+    );
+
+    final textTheme = _buildTextTheme(base.textTheme, scheme);
+
     return base.copyWith(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: _brandColor,
-        brightness: Brightness.light,
+      colorScheme: scheme,
+      scaffoldBackgroundColor: scheme.surface,
+      textTheme: textTheme,
+      appBarTheme: AppBarTheme(
+        backgroundColor: scheme.surface,
+        foregroundColor: scheme.onSurface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+        centerTitle: false,
+        titleTextStyle: textTheme.titleLarge?.copyWith(
+          color: scheme.onSurface,
+        ),
       ),
-      textTheme: GoogleFonts.robotoTextTheme(base.textTheme),
+      cardTheme: CardThemeData(
+        color: scheme.surfaceContainerLow,
+        surfaceTintColor: Colors.transparent,
+        elevation: AppElevation.card,
+        margin: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: scheme.surfaceContainerHighest,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.md,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide(color: scheme.primary, width: 1.5),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide(color: scheme.error, width: 1),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide(color: scheme.error, width: 1.5),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size(0, 48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.md),
+          ),
+          textStyle: textTheme.labelLarge,
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          minimumSize: const Size(0, 48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.md),
+          ),
+          textStyle: textTheme.labelLarge,
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size(0, 48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.md),
+          ),
+          textStyle: textTheme.labelLarge,
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          minimumSize: const Size(0, 40),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.sm),
+          ),
+          textStyle: textTheme.labelLarge,
+        ),
+      ),
+      chipTheme: ChipThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+          side: BorderSide(color: scheme.outlineVariant),
+        ),
+        side: BorderSide(color: scheme.outlineVariant),
+        labelStyle: textTheme.labelLarge,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.xs,
+        ),
+      ),
+      listTileTheme: ListTileThemeData(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.xs,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.sm),
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: scheme.outlineVariant,
+        space: 1,
+        thickness: 1,
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        height: 68,
+        backgroundColor: scheme.surface,
+        surfaceTintColor: Colors.transparent,
+        indicatorColor: scheme.primaryContainer,
+        labelTextStyle: WidgetStatePropertyAll(textTheme.labelSmall),
+        labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: scheme.primary,
+        foregroundColor: scheme.onPrimary,
+        elevation: AppElevation.raised,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+        ),
+      ),
     );
   }
 
-  /// Dark theme using Material 3.
-  static ThemeData dark() {
-    final base = ThemeData.dark(useMaterial3: true);
-    return base.copyWith(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: _brandColor,
-        brightness: Brightness.dark,
+  static TextTheme _buildTextTheme(TextTheme base, ColorScheme scheme) {
+    final roboto = GoogleFonts.robotoTextTheme(base);
+    return roboto.copyWith(
+      displaySmall: roboto.displaySmall?.copyWith(
+        fontSize: 28,
+        fontWeight: FontWeight.w700,
+        height: 1.2,
       ),
-      textTheme: GoogleFonts.robotoTextTheme(base.textTheme),
+      headlineSmall: roboto.headlineSmall?.copyWith(
+        fontSize: 22,
+        fontWeight: FontWeight.w600,
+        height: 1.25,
+      ),
+      titleLarge: roboto.titleLarge?.copyWith(
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        height: 1.3,
+      ),
+      titleMedium: roboto.titleMedium?.copyWith(
+        fontSize: 16,
+        fontWeight: FontWeight.w500,
+        height: 1.4,
+      ),
+      bodyLarge: roboto.bodyLarge?.copyWith(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        height: 1.45,
+      ),
+      bodyMedium: roboto.bodyMedium?.copyWith(
+        fontSize: 14,
+        fontWeight: FontWeight.w400,
+        height: 1.45,
+      ),
+      labelLarge: roboto.labelLarge?.copyWith(
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.2,
+      ),
+      labelSmall: roboto.labelSmall?.copyWith(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.3,
+      ),
     );
   }
 }

--- a/lib/theme/tokens.dart
+++ b/lib/theme/tokens.dart
@@ -1,0 +1,30 @@
+/// Design tokens shared across light/dark themes.
+///
+/// Use these instead of inline `EdgeInsets.all(16)` / `BorderRadius.circular(12)`
+/// so that spacing and shape stay coherent app-wide.
+library;
+
+class AppSpacing {
+  AppSpacing._();
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double xxl = 32;
+}
+
+class AppRadius {
+  AppRadius._();
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double pill = 999;
+}
+
+class AppElevation {
+  AppElevation._();
+  static const double card = 1;
+  static const double raised = 2;
+  static const double overlay = 4;
+}

--- a/lib/widgets/async_state_view.dart
+++ b/lib/widgets/async_state_view.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'empty_state.dart';
+import 'error_state.dart';
+import 'loading_state.dart';
+
+/// Renders an [AsyncValue] uniformly across the app: loading, error, empty,
+/// data. Pages should prefer this to ad-hoc `value.isLoading ? ... : ...`.
+///
+/// - [value] is the AsyncValue being rendered.
+/// - [data] builds the success state given the resolved value.
+/// - [isEmpty] returns `true` when the resolved data should render as empty.
+///   When omitted, no empty branch is shown.
+/// - [empty] is the widget shown when [isEmpty] returns true. Required if
+///   [isEmpty] is provided.
+/// - [loading] / [error] / [errorTitle] / [onRetry] / [loadingHint] customize
+///   the non-data branches.
+class AsyncStateView<T> extends StatelessWidget {
+  final AsyncValue<T> value;
+  final Widget Function(T data) data;
+  final bool Function(T data)? isEmpty;
+  final Widget? empty;
+  final Widget? loading;
+  final Widget Function(Object error, StackTrace stack)? error;
+  final String? errorTitle;
+  final VoidCallback? onRetry;
+  final String? loadingHint;
+
+  const AsyncStateView({
+    super.key,
+    required this.value,
+    required this.data,
+    this.isEmpty,
+    this.empty,
+    this.loading,
+    this.error,
+    this.errorTitle,
+    this.onRetry,
+    this.loadingHint,
+  }) : assert(
+          isEmpty == null || empty != null,
+          'When isEmpty is provided, empty must also be provided.',
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    return value.when(
+      loading: () => loading ?? LoadingState(hint: loadingHint),
+      error: (err, stack) =>
+          error?.call(err, stack) ??
+          ErrorState(error: err, onRetry: onRetry, title: errorTitle),
+      data: (d) {
+        if (isEmpty != null && isEmpty!(d)) {
+          return empty ?? const EmptyState(icon: Icons.inbox, title: 'Empty');
+        }
+        return data(d);
+      },
+    );
+  }
+}

--- a/lib/widgets/empty_state.dart
+++ b/lib/widgets/empty_state.dart
@@ -21,14 +21,17 @@ class EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    return Center(
+    // Wrapped in SingleChildScrollView so the panel doesn't overflow when
+    // dropped into tight constraints (e.g. an Expanded beneath a tall
+    // TableCalendar). Inner content stays centered horizontally.
+    return SingleChildScrollView(
       child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.xl),
+        padding: const EdgeInsets.all(AppSpacing.lg),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 64, color: scheme.outline),
-            const SizedBox(height: AppSpacing.lg),
+            Icon(icon, size: 56, color: scheme.outline),
+            const SizedBox(height: AppSpacing.md),
             Text(
               title,
               textAlign: TextAlign.center,

--- a/lib/widgets/empty_state.dart
+++ b/lib/widgets/empty_state.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../theme/tokens.dart';
+
+/// Generic empty-state panel: centered icon + title + optional subtitle/action.
+class EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final Widget? action;
+
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.subtitle,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: scheme.outline),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: text.titleMedium?.copyWith(color: scheme.onSurface),
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                subtitle!,
+                textAlign: TextAlign.center,
+                style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+              ),
+            ],
+            if (action != null) ...[
+              const SizedBox(height: AppSpacing.lg),
+              action!,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/error_state.dart
+++ b/lib/widgets/error_state.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../theme/tokens.dart';
+
+/// Generic inline error panel for failed async loads.
+class ErrorState extends StatelessWidget {
+  final Object error;
+  final VoidCallback? onRetry;
+  final String? title;
+
+  const ErrorState({
+    super.key,
+    required this.error,
+    this.onRetry,
+    this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: scheme.error),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              title ?? 'Something went wrong',
+              textAlign: TextAlign.center,
+              style: text.titleMedium?.copyWith(color: scheme.onSurface),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              error.toString(),
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: AppSpacing.lg),
+              FilledButton.tonalIcon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/error_state.dart
+++ b/lib/widgets/error_state.dart
@@ -19,14 +19,16 @@ class ErrorState extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    return Center(
+    // SingleChildScrollView so the panel survives tight constraints (e.g.
+    // an Expanded beneath a TableCalendar) without RenderFlex overflow.
+    return SingleChildScrollView(
       child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.xl),
+        padding: const EdgeInsets.all(AppSpacing.lg),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.error_outline, size: 64, color: scheme.error),
-            const SizedBox(height: AppSpacing.lg),
+            Icon(Icons.error_outline, size: 56, color: scheme.error),
+            const SizedBox(height: AppSpacing.md),
             Text(
               title ?? 'Something went wrong',
               textAlign: TextAlign.center,
@@ -41,11 +43,10 @@ class ErrorState extends StatelessWidget {
               style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
             ),
             if (onRetry != null) ...[
-              const SizedBox(height: AppSpacing.lg),
-              FilledButton.tonalIcon(
+              const SizedBox(height: AppSpacing.md),
+              FilledButton.tonal(
                 onPressed: onRetry,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Retry'),
+                child: const Text('Retry'),
               ),
             ],
           ],

--- a/lib/widgets/loading_state.dart
+++ b/lib/widgets/loading_state.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import '../theme/tokens.dart';
+
+/// Centered loading indicator with optional hint text. A seam for future
+/// skeleton-shimmer implementations — pages should not call
+/// CircularProgressIndicator directly.
+class LoadingState extends StatelessWidget {
+  final String? hint;
+
+  const LoadingState({super.key, this.hint});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          if (hint != null) ...[
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              hint!,
+              style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/loading_state.dart
+++ b/lib/widgets/loading_state.dart
@@ -14,19 +14,25 @@ class LoadingState extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const CircularProgressIndicator(),
-          if (hint != null) ...[
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              hint!,
-              style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
-            ),
+    // SingleChildScrollView so the indicator + hint never overflow a tight
+    // Expanded (e.g. beneath a TableCalendar in test viewports).
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            if (hint != null) ...[
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                hint!,
+                textAlign: TextAlign.center,
+                style: text.bodyMedium?.copyWith(color: scheme.onSurfaceVariant),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/widgets/section_header.dart
+++ b/lib/widgets/section_header.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../theme/tokens.dart';
+
+/// Section title used by the dashboard and other grouped lists.
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final Widget? trailing;
+
+  const SectionHeader(this.title, {super.key, this.trailing});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xs,
+        AppSpacing.lg,
+        AppSpacing.xs,
+        AppSpacing.sm,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              style: text.titleMedium?.copyWith(
+                color: scheme.onSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          if (trailing != null) trailing!,
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   file_picker: ^6.1.1
   fl_chart: ^1.0.0
   google_fonts: ^6.1.0
+  intl: ^0.20.2
 
   flutter_riverpod: ^2.6.1
 dev_dependencies:

--- a/test/calendar_page_test.dart
+++ b/test/calendar_page_test.dart
@@ -76,7 +76,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     await tester.pumpAndSettle();
 
-    expect(find.text('No events for this day.'), findsOneWidget);
+    expect(find.text('No events for this day'), findsOneWidget);
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();

--- a/test/directory_page_test.dart
+++ b/test/directory_page_test.dart
@@ -19,6 +19,6 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('No residents found.'), findsOneWidget);
+    expect(find.text('No residents found'), findsOneWidget);
   });
 }

--- a/test/item_exchange_page_test.dart
+++ b/test/item_exchange_page_test.dart
@@ -151,7 +151,7 @@ void main() {
     await tester.enterText(find.byType(TextField).first, 'nomatch');
     await tester.pumpAndSettle();
 
-    expect(find.text('No items found.'), findsOneWidget);
+    expect(find.text('Nothing on offer'), findsOneWidget);
   });
 
   testWidgets('Tapping item opens detail page', (tester) async {

--- a/test/main_page_test.dart
+++ b/test/main_page_test.dart
@@ -1,16 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/models/models.dart';
 import 'package:oly_app/pages/calendar_page.dart';
 import 'package:oly_app/pages/main_page.dart';
-import 'package:oly_app/pages/maintenance_page.dart';
-import 'package:oly_app/pages/item_exchange_page.dart';
-import 'package:oly_app/models/models.dart';
 import 'package:oly_app/providers/calendar_providers.dart';
 import 'package:oly_app/services/event_service.dart';
-import 'package:oly_app/services/maintenance_service.dart';
-import 'package:oly_app/pages/post_item_page.dart';
-import 'package:oly_app/services/item_service.dart';
 
 class FakeEventService extends EventService {
   final List<CalendarEvent> events = [];
@@ -24,84 +19,73 @@ class FakeEventService extends EventService {
   }
 }
 
-class FakeMaintenanceService extends MaintenanceService {
-  FakeMaintenanceService();
-  @override
-  Future<List<MaintenanceRequest>> fetchRequests() async => [];
-}
-
-class FakeItemService extends ItemService {
-  final List<Item> items;
-  FakeItemService([this.items = const []]);
-  @override
-  Future<List<Item>> fetchItems() async => items;
-}
-
-// CalendarPage hosts TableCalendar + filter row + Expanded(ListView). Default
-// test viewport (~484px tall in Scaffold body) is shorter than the fixed
-// children, so navigating to the calendar tab overflows by ~12px. Real devices
-// are >600px and unaffected; tests that exercise the calendar tab use a taller
-// surface.
+// The dashboard + grouped tile grid is taller than the default 600x800 test
+// surface. Bump to a phone-sized viewport so nothing overflows.
 void _useTallSurface(WidgetTester tester) {
-  tester.view.physicalSize = const Size(800, 1200);
+  tester.view.physicalSize = const Size(800, 1600);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
 }
 
 void main() {
-  testWidgets('Bottom navigation changes pages and FAB visibility', (
-    tester,
-  ) async {
+  testWidgets('Bottom nav exposes the five primary destinations',
+      (tester) async {
+    _useTallSurface(tester);
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: MainPage(onLogout: null)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
+
+    // The NavigationBar should expose exactly five destinations.
+    final destinations = find.descendant(
+      of: find.byType(NavigationBar),
+      matching: find.byType(NavigationDestination),
+    );
+    expect(destinations, findsNWidgets(5));
+  });
+
+  testWidgets('Tapping Calendar destination switches to calendar surface',
+      (tester) async {
     _useTallSurface(tester);
     final fakeEventService = FakeEventService();
-    final fakeMaintenanceService = FakeMaintenanceService();
 
     await tester.pumpWidget(
       ProviderScope(
+        overrides: [
+          eventServiceProvider.overrideWithValue(fakeEventService),
+        ],
         child: MaterialApp(
           home: MainPage(
             calendarPage: CalendarPage(service: fakeEventService),
-            maintenancePage: MaintenancePage(service: fakeMaintenanceService),
             onLogout: () {},
           ),
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
-    // Starts on Dashboard
-    expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
-    expect(find.byType(FloatingActionButton), findsOneWidget);
-
-    // Navigate to Calendar tab
     await tester.tap(
       find.descendant(
         of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.calendar_today),
+        matching: find.byIcon(Icons.calendar_today_outlined),
       ),
     );
     await tester.pumpAndSettle();
+
     expect(find.widgetWithText(AppBar, 'Calendar'), findsOneWidget);
-    // No FABs visible for regular user.
-    expect(find.byType(FloatingActionButton), findsNothing);
-
-    // Navigate to Maintenance tab
-    await tester.tap(
-      find.descendant(
-        of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.build),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(find.widgetWithText(AppBar, 'Maintenance'), findsOneWidget);
+    // Regular users see no FAB on the calendar tab.
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
-  testWidgets('Admin card visible for admins', (tester) async {
+  testWidgets('Admin tile visible on dashboard for admins', (tester) async {
+    _useTallSurface(tester);
     await tester.pumpWidget(
       const ProviderScope(
-        child: MaterialApp(
-          home: MainPage(isAdmin: true, onLogout: null),
-        ),
+        child: MaterialApp(home: MainPage(isAdmin: true, onLogout: null)),
       ),
     );
     await tester.pumpAndSettle();
@@ -109,7 +93,9 @@ void main() {
     expect(find.text('Admin'), findsOneWidget);
   });
 
-  testWidgets('Admin card hidden for regular user', (tester) async {
+  testWidgets('Admin tile hidden on dashboard for regular users',
+      (tester) async {
+    _useTallSurface(tester);
     await tester.pumpWidget(
       const ProviderScope(
         child: MaterialApp(home: MainPage(onLogout: null)),
@@ -119,7 +105,8 @@ void main() {
     expect(find.text('Admin'), findsNothing);
   });
 
-  testWidgets('FAB on calendar tab opens add event dialog', (tester) async {
+  testWidgets('Calendar FAB visible for admins on calendar tab',
+      (tester) async {
     _useTallSurface(tester);
     final fakeEventService = FakeEventService();
 
@@ -137,55 +124,19 @@ void main() {
         ),
       ),
     );
-
-    await tester.tap(
-      find.descendant(
-        of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.calendar_today),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final fab = find.widgetWithIcon(FloatingActionButton, Icons.event);
-    expect(fab, findsOneWidget);
-
-    await tester.tap(fab);
-    await tester.pumpAndSettle();
-
-    expect(find.text('Add Event'), findsOneWidget);
-  });
-
-  testWidgets('FAB on exchange tab opens PostItemPage', (tester) async {
-    final fakeItemService = FakeItemService();
-    await tester.pumpWidget(
-      ProviderScope(
-        child: MaterialApp(
-          home: MainPage(
-            itemExchangePage: ItemExchangePage(service: fakeItemService),
-            onLogout: null,
-          ),
-        ),
-      ),
-    );
     await tester.pumpAndSettle();
 
     await tester.tap(
       find.descendant(
         of: find.byType(NavigationBar),
-        matching: find.byIcon(Icons.swap_horiz),
+        matching: find.byIcon(Icons.calendar_today_outlined),
       ),
     );
     await tester.pumpAndSettle();
 
-    final fab = find.widgetWithIcon(
-      FloatingActionButton,
-      Icons.add_shopping_cart,
+    expect(
+      find.widgetWithIcon(FloatingActionButton, Icons.event),
+      findsOneWidget,
     );
-    expect(fab, findsOneWidget);
-
-    await tester.tap(fab);
-    await tester.pumpAndSettle();
-
-    expect(find.byType(PostItemPage), findsOneWidget);
   });
 }

--- a/test/maintenance_page_test.dart
+++ b/test/maintenance_page_test.dart
@@ -66,13 +66,16 @@ void main() {
     // Switch to conversations
     await tester.tap(find.text('Conversations'));
     await tester.pumpAndSettle();
-    expect(find.text('No conversations yet.'), findsOneWidget);
+    expect(find.text('No open tickets'), findsOneWidget);
   });
 
-  testWidgets('Shows snackbar on ticket load error', (tester) async {
+  testWidgets('Shows inline error when ticket load fails', (tester) async {
     await tester.pumpWidget(
       MaterialApp(home: MaintenancePage(service: ErrorMaintenanceService())),
     );
+    // Switch to conversations to reach the AsyncStateView.
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Conversations'));
     await tester.pumpAndSettle();
 
     expect(find.text('Failed to load tickets'), findsOneWidget);

--- a/test/widgets/async_state_view_test.dart
+++ b/test/widgets/async_state_view_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oly_app/widgets/async_state_view.dart';
 
-void _wrap(WidgetTester tester, Widget child) {
+Future<void> _wrap(WidgetTester tester, Widget child) {
   return tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
 }
 

--- a/test/widgets/async_state_view_test.dart
+++ b/test/widgets/async_state_view_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oly_app/widgets/async_state_view.dart';
+
+void _wrap(WidgetTester tester, Widget child) {
+  return tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+}
+
+void main() {
+  group('AsyncStateView', () {
+    testWidgets('renders LoadingState when value is loading', (tester) async {
+      await _wrap(
+        tester,
+        AsyncStateView<List<int>>(
+          value: const AsyncValue.loading(),
+          data: (_) => const Text('DATA'),
+        ),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('DATA'), findsNothing);
+    });
+
+    testWidgets('renders ErrorState with title and error message', (tester) async {
+      await _wrap(
+        tester,
+        AsyncStateView<List<int>>(
+          value: AsyncValue.error(
+            Exception('boom'),
+            StackTrace.empty,
+          ),
+          errorTitle: 'Could not load things',
+          data: (_) => const Text('DATA'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Could not load things'), findsOneWidget);
+      expect(find.textContaining('boom'), findsOneWidget);
+    });
+
+    testWidgets('renders retry button only when onRetry is provided',
+        (tester) async {
+      var retried = 0;
+      await _wrap(
+        tester,
+        AsyncStateView<List<int>>(
+          value: AsyncValue.error(Exception('boom'), StackTrace.empty),
+          onRetry: () => retried++,
+          data: (_) => const Text('DATA'),
+        ),
+      );
+      await tester.pump();
+      final retry = find.widgetWithText(FilledButton, 'Retry');
+      expect(retry, findsOneWidget);
+      await tester.tap(retry);
+      expect(retried, 1);
+    });
+
+    testWidgets('renders empty state when isEmpty returns true', (tester) async {
+      await _wrap(
+        tester,
+        AsyncStateView<List<int>>(
+          value: const AsyncValue.data(<int>[]),
+          isEmpty: (data) => data.isEmpty,
+          empty: const Center(child: Text('NOTHING HERE')),
+          data: (_) => const Text('DATA'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('NOTHING HERE'), findsOneWidget);
+      expect(find.text('DATA'), findsNothing);
+    });
+
+    testWidgets('renders data builder when not loading/error/empty',
+        (tester) async {
+      await _wrap(
+        tester,
+        AsyncStateView<List<int>>(
+          value: const AsyncValue.data([1, 2, 3]),
+          isEmpty: (data) => data.isEmpty,
+          empty: const Text('NOTHING HERE'),
+          data: (data) => Text('count=${data.length}'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('count=3'), findsOneWidget);
+      expect(find.text('NOTHING HERE'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5 of the post-handover plan: the UI was the last weak layer after security (Phase 1) and Riverpod migration (Phase 3). This PR lands the full UI overhaul in one batched pass.

- **Bottom nav** collapses from 11 destinations to 5 (Home, Map, Calendar, Bulletin, Profile). Material 3 guidance is 3–5; the old nav truncated labels on real devices. Everything else now reaches users through the redesigned dashboard.
- **Design tokens**: new `AppSpacing` / `AppRadius` / `AppElevation` constants, and a real `ThemeData` with card / input / button / chip / list / nav themes plus an explicit text scale. Roboto kept; one-line swap to switch later.
- **Dashboard**: greeting from the signed-in user, two **live** status cards (next event from `eventsProvider`, open-ticket count from `maintenanceRequestsProvider`), and three grouped sections (Community / Marketplace & Help / Daily) plus an Administration section for admins. The hardcoded "0 Replies" / "BierStube" cards are gone.
- **Shared state widgets** (`AsyncStateView`, `EmptyState`, `ErrorState`, `LoadingState`, `SectionHeader`) replace ad-hoc `isLoading` ternaries on 10 pages (calendar, item_exchange, directory, bulletin_board, maintenance, lost_found, gallery, documents, clubs, polls). Errors now show inline with a retry button instead of disappearing snackbars.

Bookkeeping:
- `NavTarget` extracted to its own file to break a circular import between `main_page` and `dashboard_page`.
- `currentUserProvider` reads the Hive `userBox` so the dashboard can greet the signed-in user.
- Profile + Bulletin AppBars removed — they're now rendered as bodies of MainPage's Scaffold and the outer AppBar was double-rendering.
- `intl` pinned as a direct dependency for `DateFormat` on the dashboard.

## Test plan

- [ ] `flutter pub get` resolves cleanly (intl moves from transitive to direct)
- [ ] `flutter analyze` clean
- [ ] `flutter test` green — includes new `AsyncStateView` widget tests (loading / error / retry / empty / data) and updated nav / empty-state assertions
- [ ] Manual smoke: launch app, confirm dashboard greeting + two status cards + sections render; tap each of the 5 nav destinations and confirm no truncation; tap every dashboard tile to confirm it pushes the right page; toggle system dark mode; force an API error (bad `--dart-define=API_URL`) and confirm at least one migrated page shows `ErrorState` with a retry button instead of a snackbar + blank list.

## Out of scope (follow-ups)

- Unread chat / bulletin badge counts — needs new `/messages/unread-count` and `/bulletin/unread` server endpoints.
- Skeleton loaders (shimmer) — `LoadingState` is a seam, swap later.
- Tablet `NavigationRail`.
- The other ~15 pages still on inline `isLoading` patterns — separate sweep.
- New font (Inter / Outfit) — one-line change in `theme.dart` once agreed.